### PR TITLE
Add localized detail pages for events and diary entries

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -7,10 +7,12 @@ import Services from '@/pages/Services';
 import Blog from '@/pages/Blog';
 import BlogPost from '@/pages/BlogPost';
 import Events from '@/pages/Events';
+import EventDetail from '@/pages/EventDetail';
 import Contact from '@/pages/Contact';
 import FAQ from '@/pages/FAQ';
 import Edutech from '@/pages/Edutech';
 import TeacherDiary from '@/pages/TeacherDiary';
+import TeacherDiaryEntry from '@/pages/TeacherDiaryEntry';
 import Auth from '@/pages/Auth';
 import NotFound from '@/pages/NotFound';
 import Sitemap from '@/pages/Sitemap';
@@ -45,10 +47,12 @@ export const LocalizedRoutes = () => {
       <Route path="/blog" element={<RouteWrapper><Blog /></RouteWrapper>} />
       <Route path="/blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
       <Route path="/events" element={<RouteWrapper><Events /></RouteWrapper>} />
+      <Route path="/events/:slug" element={<RouteWrapper><EventDetail /></RouteWrapper>} />
       <Route path="/contact" element={<RouteWrapper><Contact /></RouteWrapper>} />
       <Route path="/faq" element={<RouteWrapper><FAQ /></RouteWrapper>} />
       <Route path="/edutech" element={<RouteWrapper><Edutech /></RouteWrapper>} />
       <Route path="/teacher-diary" element={<RouteWrapper><TeacherDiary /></RouteWrapper>} />
+      <Route path="/teacher-diary/:slug" element={<RouteWrapper><TeacherDiaryEntry /></RouteWrapper>} />
       <Route path="/auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
       <Route path="/sitemap" element={<RouteWrapper><Sitemap /></RouteWrapper>} />
       
@@ -60,10 +64,12 @@ export const LocalizedRoutes = () => {
         <Route path="blog" element={<RouteWrapper><Blog /></RouteWrapper>} />
         <Route path="blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
         <Route path="events" element={<RouteWrapper><Events /></RouteWrapper>} />
+        <Route path="events/:slug" element={<RouteWrapper><EventDetail /></RouteWrapper>} />
         <Route path="contact" element={<RouteWrapper><Contact /></RouteWrapper>} />
         <Route path="faq" element={<RouteWrapper><FAQ /></RouteWrapper>} />
         <Route path="edutech" element={<RouteWrapper><Edutech /></RouteWrapper>} />
         <Route path="teacher-diary" element={<RouteWrapper><TeacherDiary /></RouteWrapper>} />
+        <Route path="teacher-diary/:slug" element={<RouteWrapper><TeacherDiaryEntry /></RouteWrapper>} />
         <Route path="auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
         <Route path="sitemap" element={<RouteWrapper><Sitemap /></RouteWrapper>} />
       </Route>

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -1,0 +1,289 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { SEO } from "@/components/SEO";
+import RichContent from "@/components/RichContent";
+import {
+  ArrowLeft,
+  Calendar,
+  Clock,
+  MapPin,
+  Users,
+  Award,
+  Video,
+  Globe,
+  Timer,
+  Languages,
+} from "lucide-react";
+import { format } from "date-fns";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+import type { Database } from "@/integrations/supabase/types";
+
+type Event = Database["public"]["Tables"]["content_master"]["Row"];
+
+const formatDate = (dateString: string | null) => {
+  if (!dateString) return null;
+  try {
+    return format(new Date(dateString), "MMM d, yyyy");
+  } catch (error) {
+    console.error("Error formatting date", error);
+    return null;
+  }
+};
+
+const formatTime = (dateString: string | null) => {
+  if (!dateString) return null;
+  try {
+    return format(new Date(dateString), "h:mm a");
+  } catch (error) {
+    console.error("Error formatting time", error);
+    return null;
+  }
+};
+
+const EventDetail = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+  const { language } = useLanguage();
+
+  const {
+    data: event,
+    isLoading,
+    error,
+  } = useQuery<Event | null>({
+    queryKey: ["event-detail", slug],
+    enabled: Boolean(slug),
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("content_master")
+        .select("*")
+        .eq("slug", slug)
+        .eq("page", "events")
+        .eq("is_published", true)
+        .maybeSingle();
+
+      if (error) throw error;
+      return data as Event | null;
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="container mx-auto px-4 py-8 max-w-4xl">
+          <div className="space-y-4 animate-pulse">
+            <div className="h-8 w-1/3 bg-muted rounded" />
+            <div className="h-64 w-full bg-muted rounded" />
+            <div className="h-4 w-full bg-muted rounded" />
+            <div className="h-4 w-3/4 bg-muted rounded" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !event) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <Card className="p-8 text-center">
+          <CardHeader className="space-y-4">
+            <CardTitle className="text-2xl">Event Not Found</CardTitle>
+            <p className="text-muted-foreground">
+              The event you're looking for couldn't be found.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={() => navigate(getLocalizedPath("/events", language))}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Events
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const isPastEvent = event.start_datetime ? new Date(event.start_datetime) < new Date() : false;
+  const eventDate = formatDate(event.start_datetime);
+  const eventTime = formatTime(event.start_datetime);
+  const endTime = formatTime(event.end_datetime);
+
+  return (
+    <>
+      <SEO
+        title={event.meta_title || event.title}
+        description={event.meta_description || event.excerpt}
+        image={event.featured_image || undefined}
+        keywords={event.keywords?.join(", ")}
+      />
+
+      <article className="min-h-screen bg-background">
+        <div className="container mx-auto px-4 py-8 max-w-6xl">
+          <Button
+            variant="ghost"
+            onClick={() => navigate(getLocalizedPath("/events", language))}
+            className="mb-6"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Events
+          </Button>
+
+          <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
+            <div>
+              <div className="flex flex-wrap gap-2 mb-4">
+                {event.event_type && <Badge variant={isPastEvent ? "secondary" : "default"}>{event.event_type}</Badge>}
+                {event.event_mode && <Badge variant="outline">{event.event_mode}</Badge>}
+                {event.event_price_type && (
+                  <Badge variant={event.event_price_type === "Free" ? "secondary" : "outline"}>
+                    {event.event_price_type}
+                    {event.price && event.event_price_type === "Paid" && ` $${event.price}`}
+                  </Badge>
+                )}
+                {event.event_certificate_pd && (
+                  <Badge className="bg-purple-100 text-purple-800">
+                    <Award className="h-3 w-3 mr-1" />
+                    PD Certificate
+                  </Badge>
+                )}
+                {isPastEvent && event.recording_url && (
+                  <Badge className="bg-green-100 text-green-800">
+                    <Video className="h-3 w-3 mr-1" />
+                    Recording Available
+                  </Badge>
+                )}
+              </div>
+
+              <h1 className="text-4xl font-bold mb-4">{event.title}</h1>
+
+              {event.subtitle && (
+                <p className="text-lg text-muted-foreground mb-6">{event.subtitle}</p>
+              )}
+
+              <div className="grid gap-4 sm:grid-cols-2 mb-8 text-sm text-muted-foreground">
+                {eventDate && (
+                  <div className="flex items-center gap-2">
+                    <Calendar className="h-4 w-4" />
+                    <span>{eventDate}</span>
+                  </div>
+                )}
+                {(eventTime || endTime) && (
+                  <div className="flex items-center gap-2">
+                    <Clock className="h-4 w-4" />
+                    <span>
+                      {eventTime}
+                      {endTime && ` - ${endTime}`}
+                      {event.event_timezone ? ` ${event.event_timezone}` : ""}
+                    </span>
+                  </div>
+                )}
+                {event.venue && (
+                  <div className="flex items-center gap-2">
+                    <MapPin className="h-4 w-4" />
+                    <span>{event.venue}</span>
+                  </div>
+                )}
+                {event.event_language && (
+                  <div className="flex items-center gap-2">
+                    <Languages className="h-4 w-4" />
+                    <span>{event.event_language}</span>
+                  </div>
+                )}
+                {event.event_host && (
+                  <div className="flex items-center gap-2">
+                    <Globe className="h-4 w-4" />
+                    <span>{event.event_host}</span>
+                  </div>
+                )}
+                {event.event_duration && (
+                  <div className="flex items-center gap-2">
+                    <Timer className="h-4 w-4" />
+                    <span>{event.event_duration}</span>
+                  </div>
+                )}
+                {event.event_capacity && (
+                  <div className="flex items-center gap-2">
+                    <Users className="h-4 w-4" />
+                    <span>
+                      Capacity: {event.event_capacity}
+                      {typeof event.event_registered === "number" &&
+                        ` • Registered: ${event.event_registered}`}
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              {event.featured_image && (
+                <div className="mb-8 overflow-hidden rounded-lg">
+                  <img
+                    src={event.featured_image}
+                    alt={event.title}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+              )}
+
+              <RichContent content={event.content} />
+            </div>
+
+            <aside className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Event Actions</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {!isPastEvent && event.registration_url && (
+                    <Button asChild className="w-full">
+                      <a href={event.registration_url} target="_blank" rel="noopener noreferrer">
+                        Register Now
+                      </a>
+                    </Button>
+                  )}
+                  {isPastEvent && event.recording_url && (
+                    <Button asChild variant="secondary" className="w-full">
+                      <a href={event.recording_url} target="_blank" rel="noopener noreferrer">
+                        Watch Recording
+                      </a>
+                    </Button>
+                  )}
+                  {event.registration_url && isPastEvent && !event.recording_url && (
+                    <p className="text-sm text-muted-foreground">
+                      This event has passed. Registration is now closed.
+                    </p>
+                  )}
+                  {event.registration_url && !isPastEvent && (
+                    <p className="text-xs text-muted-foreground">
+                      You will be redirected to an external registration page.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+
+              {(event.stage || event.subject || (event.tags && event.tags.length > 0)) && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Audience & Topics</CardTitle>
+                  </CardHeader>
+                  <CardContent className="flex flex-wrap gap-2">
+                    {event.stage && <Badge variant="outline">{event.stage}</Badge>}
+                    {event.subject && <Badge variant="outline">{event.subject}</Badge>}
+                    {event.tags?.map((tag) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </CardContent>
+                </Card>
+              )}
+            </aside>
+          </div>
+        </div>
+      </article>
+    </>
+  );
+};
+
+export default EventDetail;

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -11,8 +11,11 @@ import { Search, Calendar, Clock, MapPin, Users, Video, Award, CalendarClock } f
 import { supabase } from "@/integrations/supabase/client";
 import { SEO } from "@/components/SEO";
 import { format, differenceInMilliseconds } from "date-fns";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
 const Events = () => {
+  const { language } = useLanguage();
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchTerm, setSearchTerm] = useState(searchParams.get("search") || "");
   const [selectedType, setSelectedType] = useState(searchParams.get("type") || "all");
@@ -298,7 +301,10 @@ const Events = () => {
                           </div>
                           
                           <h3 className="text-xl font-semibold mb-2">
-                            <Link to={`/events/${event.slug}`} className="hover:text-primary">
+                            <Link
+                              to={getLocalizedPath(`/events/${event.slug}`, language)}
+                              className="hover:text-primary"
+                            >
                               {event.title}
                             </Link>
                           </h3>
@@ -352,7 +358,7 @@ const Events = () => {
                               </Button>
                             )}
                             <Button variant="outline" asChild>
-                              <Link to={`/events/${event.slug}`}>View Details</Link>
+                              <Link to={getLocalizedPath(`/events/${event.slug}`, language)}>View Details</Link>
                             </Button>
                           </div>
                         </CardContent>

--- a/src/pages/TeacherDiary.tsx
+++ b/src/pages/TeacherDiary.tsx
@@ -10,8 +10,11 @@ import { Search, Calendar, PenLine, HelpCircle, Lightbulb, MessageSquare } from 
 import { supabase } from "@/integrations/supabase/client";
 import { SEO } from "@/components/SEO";
 import { format } from "date-fns";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
 const TeacherDiary = () => {
+  const { language } = useLanguage();
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchTerm, setSearchTerm] = useState(searchParams.get("search") || "");
   const [selectedCategory, setSelectedCategory] = useState(searchParams.get("category") || "all");
@@ -256,7 +259,10 @@ const TeacherDiary = () => {
                         </div>
                         
                         <h3 className="text-xl font-semibold mb-2">
-                          <Link to={`/diary/${entry.slug}`} className="hover:text-primary">
+                          <Link
+                            to={getLocalizedPath(`/teacher-diary/${entry.slug}`, language)}
+                            className="hover:text-primary"
+                          >
                             {entry.title}
                           </Link>
                         </h3>

--- a/src/pages/TeacherDiaryEntry.tsx
+++ b/src/pages/TeacherDiaryEntry.tsx
@@ -1,0 +1,187 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { SEO } from "@/components/SEO";
+import RichContent from "@/components/RichContent";
+import { ArrowLeft, Calendar, PenLine, HelpCircle, Lightbulb, MessageSquare } from "lucide-react";
+import { format } from "date-fns";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+import type { Database } from "@/integrations/supabase/types";
+
+type DiaryEntry = Database["public"]["Tables"]["content_master"]["Row"];
+
+const diaryTypeIcons = {
+  question: <HelpCircle className="h-4 w-4" />,
+  challenge: <MessageSquare className="h-4 w-4" />,
+  reflection: <Lightbulb className="h-4 w-4" />,
+};
+
+const diaryTypeLabels: Record<string, string> = {
+  question: "Question",
+  challenge: "Challenge",
+  reflection: "Reflection",
+};
+
+const moodClasses: Record<string, string> = {
+  optimistic: "bg-green-100 text-green-800",
+  neutral: "bg-gray-100 text-gray-800",
+  frustrated: "bg-red-100 text-red-800",
+  excited: "bg-yellow-100 text-yellow-800",
+  thoughtful: "bg-blue-100 text-blue-800",
+};
+
+const TeacherDiaryEntry = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+  const { language } = useLanguage();
+
+  const {
+    data: entry,
+    isLoading,
+    error,
+  } = useQuery<DiaryEntry | null>({
+    queryKey: ["teacher-diary-entry", slug],
+    enabled: Boolean(slug),
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("content_master")
+        .select("*")
+        .eq("slug", slug)
+        .eq("page", "teacher_diary")
+        .eq("is_published", true)
+        .maybeSingle();
+
+      if (error) throw error;
+      return data as DiaryEntry | null;
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="container mx-auto px-4 py-8 max-w-3xl">
+          <div className="space-y-4 animate-pulse">
+            <div className="h-8 w-1/3 bg-muted rounded" />
+            <div className="h-4 w-full bg-muted rounded" />
+            <div className="h-4 w-3/4 bg-muted rounded" />
+            <div className="h-48 w-full bg-muted rounded" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !entry) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <Card className="p-8 text-center">
+          <CardHeader className="space-y-4">
+            <CardTitle className="text-2xl">Diary Entry Not Found</CardTitle>
+            <p className="text-muted-foreground">
+              The diary entry you're looking for couldn't be found.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={() => navigate(getLocalizedPath("/teacher-diary", language))}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Teacher Diary
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <SEO
+        title={entry.meta_title || entry.title}
+        description={entry.meta_description || entry.excerpt}
+        image={entry.featured_image || undefined}
+        keywords={entry.keywords?.join(", ")}
+      />
+
+      <article className="min-h-screen bg-background">
+        <div className="container mx-auto px-4 py-8 max-w-4xl">
+          <Button
+            variant="ghost"
+            onClick={() => navigate(getLocalizedPath("/teacher-diary", language))}
+            className="mb-6"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Teacher Diary
+          </Button>
+
+          <header className="mb-8">
+            <div className="flex flex-wrap items-center gap-2 mb-4">
+              {entry.diary_type && (
+                <Badge variant="secondary" className="flex items-center gap-1 capitalize">
+                  {diaryTypeIcons[entry.diary_type as keyof typeof diaryTypeIcons]}
+                  {diaryTypeLabels[entry.diary_type] || entry.diary_type}
+                </Badge>
+              )}
+              {entry.mood && (
+                <Badge className={moodClasses[entry.mood] || "bg-gray-100 text-gray-800"}>
+                  {entry.mood}
+                </Badge>
+              )}
+              {entry.category && <Badge variant="outline">{entry.category}</Badge>}
+              {entry.subcategory && <Badge variant="outline">{entry.subcategory}</Badge>}
+            </div>
+
+            <h1 className="text-4xl font-bold mb-3 flex items-center gap-3">
+              <PenLine className="h-8 w-8 text-primary" />
+              {entry.title}
+            </h1>
+
+            {entry.subtitle && (
+              <p className="text-lg text-muted-foreground mb-4">{entry.subtitle}</p>
+            )}
+
+            {entry.published_at && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Calendar className="h-4 w-4" />
+                <span>{format(new Date(entry.published_at), "MMM d, yyyy")}</span>
+              </div>
+            )}
+          </header>
+
+          {entry.featured_image && (
+            <div className="mb-8 overflow-hidden rounded-lg">
+              <img
+                src={entry.featured_image}
+                alt={entry.title}
+                className="w-full h-full object-cover"
+              />
+            </div>
+          )}
+
+          <RichContent content={entry.content} />
+
+          {(entry.stage || entry.subject || (entry.tags && entry.tags.length > 0)) && (
+            <Card className="mt-10">
+              <CardHeader>
+                <CardTitle>Classroom Context</CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                {entry.stage && <Badge variant="outline">{entry.stage}</Badge>}
+                {entry.subject && <Badge variant="outline">{entry.subject}</Badge>}
+                {entry.tags?.map((tag) => (
+                  <Badge key={tag} variant="secondary">
+                    {tag}
+                  </Badge>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </article>
+    </>
+  );
+};
+
+export default TeacherDiaryEntry;


### PR DESCRIPTION
## Summary
- add localized routes for event and teacher diary detail pages
- implement new detail pages that query Supabase by slug and render full content
- update event and teacher diary listings to generate localized links for the new routes

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4baccb408331a4e91f1d3cd4b96f