### PR TITLE
Remove page-level navigation and footer wrappers

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -2,8 +2,6 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Award, Users, BookOpen, Target, Heart, Lightbulb } from "lucide-react";
-import Navigation from "@/components/Navigation";
-import Footer from "@/components/Footer";
 import { Link } from "react-router-dom";
 import { SEO } from "@/components/SEO";
 
@@ -35,13 +33,12 @@ const About = () => {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <SEO 
+      <SEO
         title="About Us"
         description="Learn about SchoolTech Hub's mission to make educational technology accessible. 7+ years experience, 100+ schools helped, certified educators supporting your tech journey."
         keywords="about SchoolTech Hub, educational technology company, EdTech consultants, teacher training experts, classroom technology specialists"
         canonicalUrl="https://schooltechhub.com/about"
       />
-      <Navigation />
 
       {/* Hero Section */}
       <section className="py-16 px-4 bg-gradient-to-b from-primary/5 to-background">
@@ -279,8 +276,6 @@ const About = () => {
           </div>
         </div>
       </section>
-
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -9,8 +9,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Mail, Phone, MapPin, Send, CalendarIcon, MessageSquare } from "lucide-react";
-import Navigation from "@/components/Navigation";
-import Footer from "@/components/Footer";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { SEO } from "@/components/SEO";
@@ -88,8 +86,6 @@ const Contact = () => {
         keywords="book consultation, EdTech support, contact education consultant, schedule training, teacher coaching booking"
         canonicalUrl="https://schooltechhub.com/contact"
       />
-      <Navigation />
-
       {/* Header */}
       <section className="py-16 px-4 bg-gradient-to-b from-primary/5 to-background">
         <div className="container mx-auto text-center">
@@ -336,7 +332,6 @@ const Contact = () => {
         </div>
       </section>
 
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Edutech.tsx
+++ b/src/pages/Edutech.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import Navigation from "@/components/Navigation";
-import Footer from "@/components/Footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -143,8 +141,6 @@ const Edutech = () => {
         description="Learn classroom technology the practical way: tutorials, teaching techniques, activities, and AI lesson planning. Filter by grade, subject, and time to implement."
         canonicalUrl="https://schooltechhub.com/edutech"
       />
-      <Navigation />
-      
       <main className="flex-1">
         <div className="container py-12">
           <div className="mb-8">
@@ -361,7 +357,6 @@ const Edutech = () => {
         </div>
       </main>
 
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import Navigation from "@/components/Navigation";
-import Footer from "@/components/Footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -143,8 +141,7 @@ const Events = () => {
         description="Join live EdTech webinars, workshops, and meetups. Browse upcoming and past events, and watch recordings to level up your classroom technology skills."
         canonicalUrl="https://schooltechhub.com/events"
       />
-      <Navigation />
-      
+
       <main className="flex-1">
         <div className="container py-12">
           <div className="mb-8">
@@ -365,8 +362,6 @@ const Events = () => {
           </div>
         </div>
       </main>
-
-      <Footer />
     </div>
   );
 };

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useState } from "react";
-import Navigation from "@/components/Navigation";
-import Footer from "@/components/Footer";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { supabase } from "@/integrations/supabase/client";
@@ -74,8 +72,6 @@ const FAQ = () => {
           }}
         />
       )}
-      <Navigation />
-      
       <main className="flex-1">
         <div className="container py-12">
           <div className="max-w-4xl mx-auto">
@@ -141,7 +137,6 @@ const FAQ = () => {
         </div>
       </main>
 
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useState, useRef } from "react";
-import Navigation from "@/components/Navigation";
-import Footer from "@/components/Footer";
 import MouseGlowEffect from "@/components/MouseGlowEffect";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -91,8 +89,6 @@ const Index = () => {
       />
       <StructuredData type="Organization" data={{}} />
       <MouseGlowEffect />
-      <Navigation />
-      
       {/* Cyber Grid Background */}
       <div className="fixed inset-0 bg-cyber-grid bg-[size:50px_50px] opacity-20" />
       
@@ -349,7 +345,6 @@ const Index = () => {
         </div>
       </section>
 
-      <Footer />
     </div>
   );
 };

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,8 +1,6 @@
 import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
 import { SEO } from "@/components/SEO";
-import Navigation from "@/components/Navigation";
-import Footer from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { Home, ArrowLeft } from "lucide-react";
 
@@ -20,8 +18,6 @@ const NotFound = () => {
         description="The page you're looking for doesn't exist. Return to SchoolTech Hub homepage to explore our educational technology resources."
         canonicalUrl="https://schooltechub.com/404"
       />
-      <Navigation />
-      
       <div className="flex-1 flex items-center justify-center px-4">
         <div className="text-center max-w-md">
           <h1 className="text-6xl font-bold text-primary mb-4">404</h1>
@@ -44,7 +40,6 @@ const NotFound = () => {
         </div>
       </div>
       
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -4,8 +4,6 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CheckCircle, Clock, Users, Target, Calendar, Shield, GraduationCap, ArrowRight, FileText } from "lucide-react";
-import Navigation from "@/components/Navigation";
-import Footer from "@/components/Footer";
 import { Link } from "react-router-dom";
 import { SEO } from "@/components/SEO";
 import { StructuredData } from "@/components/StructuredData";
@@ -91,14 +89,14 @@ const Services = () => {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <SEO 
+      <SEO
         title="Services & Pricing"
         description="Professional EdTech consulting services. 1:1 coaching ($30), whole-school PD programs ($60), and custom dashboard setup. Transform your classroom with expert guidance."
         keywords="EdTech consulting, teacher coaching, professional development, school technology training, educational dashboard, classroom technology support"
         canonicalUrl="https://schooltechhub.com/services"
       />
-      <StructuredData 
-        type="Service" 
+      <StructuredData
+        type="Service"
         data={{
           serviceType: "Educational Technology Consulting",
           services: services.map(s => ({
@@ -111,9 +109,8 @@ const Services = () => {
               "priceCurrency": "USD"
             }
           }))
-        }} 
+        }}
       />
-      <Navigation />
 
       {/* Header */}
       <section className="py-16 px-4 bg-gradient-to-b from-primary/5 to-background">
@@ -300,8 +297,6 @@ const Services = () => {
           </div>
         </div>
       </section>
-
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -1,7 +1,5 @@
 import { useEffect } from "react";
 import { Link } from "react-router-dom";
-import Navigation from "@/components/Navigation";
-import Footer from "@/components/Footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SEO } from "@/components/SEO";
 import { useQuery } from "@tanstack/react-query";
@@ -88,8 +86,6 @@ const Sitemap = () => {
         description="Navigate through all pages and resources available on School Tech Hub"
         keywords="sitemap, navigation, school tech hub pages"
       />
-      <Navigation />
-      
       <main className="flex-1">
         <div className="container py-12">
           <h1 className="text-4xl font-bold mb-2">Sitemap</h1>
@@ -142,7 +138,6 @@ const Sitemap = () => {
         </div>
       </main>
 
-      <Footer />
     </div>
   );
 };

--- a/src/pages/TeacherDiary.tsx
+++ b/src/pages/TeacherDiary.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import Navigation from "@/components/Navigation";
-import Footer from "@/components/Footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -124,8 +122,7 @@ const TeacherDiary = () => {
         description="Real teacher reflections, challenges, and insights from the classroom. Learn what works, what doesn't, and practical tips for your teaching journey."
         canonicalUrl="https://schooltechhub.com/diary"
       />
-      <Navigation />
-      
+
       <main className="flex-1">
         <div className="container py-12">
           <div className="mb-8">
@@ -294,8 +291,6 @@ const TeacherDiary = () => {
           </div>
         </div>
       </main>
-
-      <Footer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove the duplicated Navigation/Footer imports from Events and Teacher Diary, leaving only their core page content
- clean the remaining site pages that still rendered Navigation/Footer directly so shared layout comes solely from RouteWrapper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce4ba6926c833199597433ebbe44d3