### PR TITLE
Ensure localized routing for internal navigation

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,12 +6,13 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
 const Footer = () => {
   const { toast } = useToast();
   const [email, setEmail] = useState("");
   const [isSubscribing, setIsSubscribing] = useState(false);
-  const { t } = useLanguage();
+  const { t, language } = useLanguage();
 
   const handleSubscribe = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -81,22 +82,34 @@ const Footer = () => {
             <h3 className="font-semibold mb-4">{t.footer.quickLinks}</h3>
             <ul className="space-y-2">
               <li>
-                <Link to="/edutech" className="text-sm text-muted-foreground hover:text-primary transition-colors">
+                <Link
+                  to={getLocalizedPath("/edutech", language)}
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                >
                   {t.nav.edutech}
                 </Link>
               </li>
               <li>
-                <Link to="/diary" className="text-sm text-muted-foreground hover:text-primary transition-colors">
+                <Link
+                  to={getLocalizedPath("/teacher-diary", language)}
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                >
                   {t.nav.teacherDiary}
                 </Link>
               </li>
               <li>
-                <Link to="/blog" className="text-sm text-muted-foreground hover:text-primary transition-colors">
+                <Link
+                  to={getLocalizedPath("/blog", language)}
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                >
                   {t.nav.blog}
                 </Link>
               </li>
               <li>
-                <Link to="/faq" className="text-sm text-muted-foreground hover:text-primary transition-colors">
+                <Link
+                  to={getLocalizedPath("/faq", language)}
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                >
                   {t.nav.faq}
                 </Link>
               </li>
@@ -108,22 +121,34 @@ const Footer = () => {
             <h3 className="font-semibold mb-4">{t.nav.services}</h3>
             <ul className="space-y-2">
               <li>
-                <Link to="/services" className="text-sm text-muted-foreground hover:text-primary transition-colors">
+                <Link
+                  to={getLocalizedPath("/services", language)}
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                >
                   {t.services.lms.title}
                 </Link>
               </li>
               <li>
-                <Link to="/services" className="text-sm text-muted-foreground hover:text-primary transition-colors">
+                <Link
+                  to={getLocalizedPath("/services", language)}
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                >
                   {t.services.virtual.title}
                 </Link>
               </li>
               <li>
-                <Link to="/services" className="text-sm text-muted-foreground hover:text-primary transition-colors">
+                <Link
+                  to={getLocalizedPath("/services", language)}
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                >
                   {t.services.assessment.title}
                 </Link>
               </li>
               <li>
-                <Link to="/contact" className="text-sm text-muted-foreground hover:text-primary transition-colors">
+                <Link
+                  to={getLocalizedPath("/contact", language)}
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                >
                   {t.nav.contact}
                 </Link>
               </li>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -59,7 +59,7 @@ const Navigation = () => {
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();
-    navigate("/");
+    navigate(getLocalizedNavPath("/"));
   };
 
   return (

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -6,8 +6,11 @@ import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { Link } from "react-router-dom";
 import { SEO } from "@/components/SEO";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
 const About = () => {
+  const { language } = useLanguage();
   const mission = [
     {
       icon: Target,
@@ -175,10 +178,10 @@ const About = () => {
                 Join thousands of teachers who've discovered that technology doesn't have to be overwhelming.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <Link to="/services">
+                <Link to={getLocalizedPath("/services", language)}>
                   <Button size="lg">Book a Consultation</Button>
                 </Link>
-                <Link to="/tools">
+                <Link to={getLocalizedPath("/tools", language)}>
                   <Button size="lg" variant="outline">
                     <BookOpen className="mr-2 h-5 w-5" />
                     Browse Free Resources

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -10,6 +10,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useToast } from "@/hooks/use-toast";
 import { SEO } from "@/components/SEO";
 import { Chrome } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
 const Auth = () => {
   const navigate = useNavigate();
@@ -20,23 +22,25 @@ const Auth = () => {
   const [fullName, setFullName] = useState("");
   const [role, setRole] = useState("Teacher");
 
+  const { language } = useLanguage();
+
   useEffect(() => {
     // Set up auth state listener FIRST to handle redirects/code exchange
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
       if (session) {
-        navigate("/");
+        navigate(getLocalizedPath("/", language));
       }
     });
 
     // Then check for existing session (also triggers code exchange on redirect)
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session) {
-        navigate("/");
+        navigate(getLocalizedPath("/", language));
       }
     });
 
     return () => subscription.unsubscribe();
-  }, [navigate]);
+  }, [navigate, language]);
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -234,7 +238,7 @@ const Auth = () => {
           </Button>
           
           <div className="mt-4 text-center text-sm">
-            <Link to="/" className="text-primary hover:underline">
+            <Link to={getLocalizedPath("/", language)} className="text-primary hover:underline">
               Back to Home
             </Link>
           </div>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -361,7 +361,10 @@ const Blog = () => {
                         <div className="absolute bottom-0 p-6">
                           <Badge className="mb-2">{featuredPost.filter_type || "Featured"}</Badge>
                           <h2 className="text-2xl font-bold mb-2">
-                            <Link to={`/blog/${featuredPost.slug}`} className="hover:text-primary">
+                            <Link
+                              to={getLocalizedPath(`/blog/${featuredPost.slug}`, language)}
+                              className="hover:text-primary"
+                            >
                               {featuredPost.title}
                             </Link>
                           </h2>

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -102,7 +102,7 @@ export default function BlogPost() {
         description: "Please log in to comment",
         variant: "destructive"
       });
-      navigate("/auth");
+      navigate(getLocalizedPath("/auth", language));
       return;
     }
 
@@ -139,7 +139,7 @@ export default function BlogPost() {
         description: "Please log in to reply",
         variant: "destructive"
       });
-      navigate("/auth");
+      navigate(getLocalizedPath("/auth", language));
       return;
     }
 
@@ -191,7 +191,7 @@ export default function BlogPost() {
         <Card className="p-8 text-center">
           <h1 className="text-2xl font-bold mb-4">Blog Post Not Found</h1>
           <p className="text-muted-foreground mb-6">The blog post you're looking for doesn't exist.</p>
-          <Button onClick={() => navigate("/blog")}>
+          <Button onClick={() => navigate(getLocalizedPath("/blog", language))}>
             <ArrowLeft className="mr-2 h-4 w-4" />
             Back to Blog
           </Button>
@@ -403,7 +403,7 @@ export default function BlogPost() {
                 <p className="text-muted-foreground mb-4">
                   Please log in to leave a comment
                 </p>
-                <Button onClick={() => navigate("/auth")}>
+                <Button onClick={() => navigate(getLocalizedPath("/auth", language))}>
                   Log In to Comment
                 </Button>
               </Card>

--- a/src/pages/Edutech.tsx
+++ b/src/pages/Edutech.tsx
@@ -10,6 +10,8 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Search, Clock, Zap, Cpu, BookOpen, Activity } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { SEO } from "@/components/SEO";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
 const Edutech = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -25,6 +27,7 @@ const Edutech = () => {
     subject: searchParams.getAll("subject") || [],
     instructionType: searchParams.getAll("instructionType") || []
   });
+  const { language } = useLanguage();
 
   const categories = [
     { value: "all", label: "All" },
@@ -312,7 +315,10 @@ const Edutech = () => {
                         </div>
                         
                         <h3 className="text-lg font-semibold mb-2">
-                          <Link to={`/edutech/${item.slug}`} className="hover:text-primary">
+                          <Link
+                            to={getLocalizedPath(`/edutech/${item.slug}`, language)}
+                            className="hover:text-primary"
+                          >
                             {item.title}
                           </Link>
                         </h3>

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -11,6 +11,8 @@ import { Search, Calendar, Clock, MapPin, Users, Video, Award, CalendarClock } f
 import { supabase } from "@/integrations/supabase/client";
 import { SEO } from "@/components/SEO";
 import { format, differenceInMilliseconds } from "date-fns";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
 const Events = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -24,6 +26,7 @@ const Events = () => {
     stage: searchParams.getAll("stage") || [],
     subject: searchParams.getAll("subject") || []
   });
+  const { language } = useLanguage();
 
   const eventTypes = [
     { value: "all", label: "All Events" },
@@ -298,7 +301,10 @@ const Events = () => {
                           </div>
                           
                           <h3 className="text-xl font-semibold mb-2">
-                            <Link to={`/events/${event.slug}`} className="hover:text-primary">
+                            <Link
+                              to={getLocalizedPath(`/events/${event.slug}`, language)}
+                              className="hover:text-primary"
+                            >
                               {event.title}
                             </Link>
                           </h3>
@@ -352,7 +358,7 @@ const Events = () => {
                               </Button>
                             )}
                             <Button variant="outline" asChild>
-                              <Link to={`/events/${event.slug}`}>View Details</Link>
+                              <Link to={getLocalizedPath(`/events/${event.slug}`, language)}>View Details</Link>
                             </Button>
                           </div>
                         </CardContent>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom";
 import { SEO } from "@/components/SEO";
 import { StructuredData } from "@/components/StructuredData";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 import { 
   Cpu, 
   Brain, 
@@ -41,7 +42,7 @@ const Index = () => {
   const [counters, setCounters] = useState({ lessons: 0, vr: 0, engagement: 0 });
   const statsRef = useRef<HTMLDivElement>(null);
   const [hasAnimated, setHasAnimated] = useState(false);
-  const { t } = useLanguage();
+  const { t, language } = useLanguage();
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -159,9 +160,9 @@ const Index = () => {
             </div>
             
             <div className="flex flex-col gap-4 sm:flex-row sm:justify-center animate-in fade-in slide-in-from-bottom-4 duration-1000 delay-500">
-              <Link to="/contact">
-                <Button 
-                  size="lg" 
+              <Link to={getLocalizedPath("/contact", language)}>
+                <Button
+                  size="lg"
                   className="group relative overflow-hidden bg-gradient-to-r from-primary to-accent text-primary-foreground hover:shadow-[0_0_40px_hsl(var(--glow-primary)/0.5)] transition-all duration-300"
                 >
                   <span className="relative z-10 flex items-center gap-2">
@@ -171,9 +172,9 @@ const Index = () => {
                   <div className="absolute inset-0 bg-gradient-to-r from-accent to-primary opacity-0 group-hover:opacity-100 transition-opacity" />
                 </Button>
               </Link>
-              <Link to="/edutech">
-                <Button 
-                  size="lg" 
+              <Link to={getLocalizedPath("/edutech", language)}>
+                <Button
+                  size="lg"
                   variant="outline"
                   className="border-primary/30 bg-background/50 backdrop-blur-sm hover:bg-primary/10 hover:border-primary hover:shadow-[0_0_30px_hsl(var(--glow-primary)/0.3)] transition-all duration-300"
                 >
@@ -239,8 +240,8 @@ const Index = () => {
                 color: "secondary"
               }
             ].map((feature, index) => (
-              <Link to="/edutech" key={index} className="block">
-                <Card 
+              <Link to={getLocalizedPath("/edutech", language)} key={index} className="block">
+                <Card
                   className="group relative overflow-hidden border-border/50 bg-card/50 backdrop-blur-sm hover:border-primary/50 transition-all duration-300 hover:shadow-[0_0_30px_hsl(var(--glow-primary)/0.2)] cursor-pointer h-full"
                 >
                   <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
@@ -294,13 +295,13 @@ const Index = () => {
                 Join thousands of educators who are already using our platform to create better learning experiences.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
-                <Link to="/contact">
+                <Link to={getLocalizedPath("/contact", language)}>
                   <Button size="lg" className="bg-gradient-to-r from-primary to-accent hover:shadow-[0_0_40px_hsl(var(--glow-primary)/0.5)]">
                     Get Started
                     <Rocket className="ml-2 h-5 w-5" />
                   </Button>
                 </Link>
-                <Link to="/services">
+                <Link to={getLocalizedPath("/services", language)}>
                   <Button size="lg" variant="outline" className="border-primary/30 hover:border-primary hover:bg-primary/10">
                     View Pricing
                   </Button>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -5,9 +5,12 @@ import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { Home, ArrowLeft } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
 const NotFound = () => {
   const location = useLocation();
+  const { language } = useLanguage();
 
   useEffect(() => {
     console.error("404 Error: User attempted to access non-existent route:", location.pathname);
@@ -30,7 +33,7 @@ const NotFound = () => {
             Oops! The page you're looking for doesn't exist. It might have been moved or deleted.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link to="/">
+            <Link to={getLocalizedPath("/", language)}>
               <Button>
                 <Home className="mr-2 h-4 w-4" />
                 Go to Homepage

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -9,10 +9,13 @@ import Footer from "@/components/Footer";
 import { Link } from "react-router-dom";
 import { SEO } from "@/components/SEO";
 import { StructuredData } from "@/components/StructuredData";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 // Import removed - useContent hook no longer exists
 
 const Services = () => {
-  
+  const { language } = useLanguage();
+
   const services = [
     {
       id: "consultation",
@@ -164,7 +167,7 @@ const Services = () => {
                   </p>
                 </div>
 
-                <Link to="/contact">
+                <Link to={getLocalizedPath("/contact", language)}>
                   <Button className="w-full">Book Now</Button>
                 </Link>
               </Card>
@@ -288,7 +291,7 @@ const Services = () => {
           </div>
           
           <div className="text-center mt-12">
-            <Link to="/contact">
+            <Link to={getLocalizedPath("/contact", language)}>
               <Button size="lg" className="shadow-large">
                 Book Your Session Today
                 <Calendar className="ml-2 h-5 w-5" />

--- a/src/pages/TeacherDiary.tsx
+++ b/src/pages/TeacherDiary.tsx
@@ -10,6 +10,8 @@ import { Search, Calendar, PenLine, HelpCircle, Lightbulb, MessageSquare } from 
 import { supabase } from "@/integrations/supabase/client";
 import { SEO } from "@/components/SEO";
 import { format } from "date-fns";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
 const TeacherDiary = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -22,6 +24,7 @@ const TeacherDiary = () => {
     stage: searchParams.getAll("stage") || [],
     subject: searchParams.getAll("subject") || []
   });
+  const { language } = useLanguage();
 
   const categories = [
     { value: "all", label: "All" },
@@ -122,7 +125,7 @@ const TeacherDiary = () => {
       <SEO
         title="Teacher Diary: Reflections & Classroom Insights"
         description="Real teacher reflections, challenges, and insights from the classroom. Learn what works, what doesn't, and practical tips for your teaching journey."
-        canonicalUrl="https://schooltechhub.com/diary"
+        canonicalUrl="https://schooltechhub.com/teacher-diary"
       />
       <Navigation />
       
@@ -256,7 +259,10 @@ const TeacherDiary = () => {
                         </div>
                         
                         <h3 className="text-xl font-semibold mb-2">
-                          <Link to={`/diary/${entry.slug}`} className="hover:text-primary">
+                          <Link
+                            to={getLocalizedPath(`/teacher-diary/${entry.slug}`, language)}
+                            className="hover:text-primary"
+                          >
                             {entry.title}
                           </Link>
                         </h3>


### PR DESCRIPTION
## Summary
- wrap internal `Link` components across marketing pages with `getLocalizedPath` so locale prefixes persist when navigating
- update footer quick links and teacher diary canonical/link targets to the localized `/teacher-diary` route
- localize authenticated redirects and sign-out handling to preserve the active language selection

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce4ba4764c83319584767cdd9ba75c