### PR TITLE
Fix duplicate useLanguage declarations causing Vite build failure

### DIFF
--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -25,7 +25,6 @@ const Events = () => {
     stage: searchParams.getAll("stage") || [],
     subject: searchParams.getAll("subject") || []
   });
-  const { language } = useLanguage();
 
   const eventTypes = [
     { value: "all", label: "All Events" },

--- a/src/pages/TeacherDiary.tsx
+++ b/src/pages/TeacherDiary.tsx
@@ -23,7 +23,6 @@ const TeacherDiary = () => {
     stage: searchParams.getAll("stage") || [],
     subject: searchParams.getAll("subject") || []
   });
-  const { language } = useLanguage();
 
   const categories = [
     { value: "all", label: "All" },


### PR DESCRIPTION
## Summary
- remove duplicate `useLanguage` destructuring declarations in Events and TeacherDiary pages
- resolve Vite compile error preventing the app from starting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce4f380cf48331bd4c1b83e686b0a5