### PR TITLE
Fix language provider routing context usage

### DIFF
--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -25,7 +25,6 @@ const Events = () => {
     stage: searchParams.getAll("stage") || [],
     subject: searchParams.getAll("subject") || []
   });
-  const { language } = useLanguage();
 
   const eventTypes = [
     { value: "all", label: "All Events" },

--- a/src/pages/TeacherDiary.tsx
+++ b/src/pages/TeacherDiary.tsx
@@ -23,7 +23,6 @@ const TeacherDiary = () => {
     stage: searchParams.getAll("stage") || [],
     subject: searchParams.getAll("subject") || []
   });
-  const { language } = useLanguage();
 
   const categories = [
     { value: "all", label: "All" },


### PR DESCRIPTION
## Summary
- derive the active language from the current pathname instead of using useParams outside of route context
- keep the language state in sync with navigation changes and skip redundant updates
- guard language changes before rebuilding the localized path when navigating

## Testing
- npm run build
- npm run lint *(fails: existing lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4f380cf48331bd4c1b83e686b0a5