### PR TITLE
Adjust blog post query for localized pages

### DIFF
--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -36,18 +36,24 @@ export default function BlogPost() {
 
   // Fetch blog post
   const { data: post, isLoading } = useQuery({
-    queryKey: ["blog-post", slug],
+    queryKey: ["blog-post", slug, language],
+    enabled: !!slug,
     queryFn: async () => {
+      if (!slug) return null;
+
       const { data, error } = await supabase
         .from("content_master")
         .select("*")
         .eq("slug", slug)
-        .eq("page", "research_blog")
-        .eq("is_published", true)
-        .single();
+        .in("page", ["research_blog", "edutech", "teacher_diary"])
+        .eq("language", language)
+        .eq("is_published", true);
 
-      if (error) throw error;
-      return data;
+      if (error) {
+        throw error;
+      }
+
+      return data?.[0] ?? null;
     }
   });
 


### PR DESCRIPTION
## Summary
- update the blog post detail query to accept all blog page types and honor the current language filter
- guard the query with the slug-aware key/enabled flag and return null when no record is found so the not-found state still renders cleanly

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce558a54f08331a4ddf52321736925