### PR TITLE
Restrict profile select policy

### DIFF
--- a/supabase/migrations/20250916005000_update_profile_policy.sql
+++ b/supabase/migrations/20250916005000_update_profile_policy.sql
@@ -1,0 +1,6 @@
+-- Restrict profile visibility to owner or service role
+DROP POLICY "Public profiles are viewable by everyone" ON public.profiles;
+
+CREATE POLICY "Users can view their own profile"
+  ON public.profiles FOR SELECT
+  USING (auth.uid() = id OR auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- add a migration that replaces the open profiles select policy with one scoped to the authenticated user or service role

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce60047ec48331a76820820399575f