### PR TITLE
Restrict newsletter subscriber select access

### DIFF
--- a/supabase/migrations/20250923120000_secure_newsletter_select_policy.sql
+++ b/supabase/migrations/20250923120000_secure_newsletter_select_policy.sql
@@ -1,0 +1,23 @@
+-- Secure SELECT access for newsletter subscribers
+-- Drops any existing SELECT policies and replaces them with a service-role only policy
+
+DO $$
+DECLARE
+  _policy record;
+BEGIN
+  FOR _policy IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'newsletter_subscribers'
+      AND cmd = 'SELECT'
+  LOOP
+    EXECUTE format('DROP POLICY %I ON public.newsletter_subscribers', _policy.policyname);
+  END LOOP;
+END
+$$;
+
+CREATE POLICY "Service role can read newsletter subscribers"
+ON public.newsletter_subscribers
+FOR SELECT
+USING (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- drop any existing SELECT policies on public.newsletter_subscribers via a dynamic DO block
- add a new SELECT policy allowing reads only when auth.role() returns service_role, preserving public insert access

## Testing
- not run (supabase CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce6009e4448331b1ee9284742b2684