### PR TITLE
Update sitemap to reflect actual localized routes

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,80 +3,239 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
         http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-  
+
+  <!-- Core English pages -->
   <url>
     <loc>https://schooltechub.com/</loc>
-    <lastmod>2025-09-11</lastmod>
+    <lastmod>2025-09-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
-  
+
   <url>
-    <loc>https://schooltechub.com/tools</loc>
-    <lastmod>2025-09-11</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
+    <loc>https://schooltechub.com/about</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
-  <url>
-    <loc>https://schooltechub.com/learn</loc>
-    <lastmod>2025-09-11</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
+
   <url>
     <loc>https://schooltechub.com/services</loc>
-    <lastmod>2025-09-11</lastmod>
+    <lastmod>2025-09-20</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.8</priority>
   </url>
+
   <url>
     <loc>https://schooltechub.com/blog</loc>
-    <lastmod>2025-09-11</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
-    <url>
+
+  <url>
     <loc>https://schooltechub.com/events</loc>
-    <lastmod>2025-09-11</lastmod>
+    <lastmod>2025-09-20</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://schooltechub.com/case-studies</loc>
-    <lastmod>2025-09-11</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-    <url>
-    <loc>https://schooltechub.com/about</loc>
-    <lastmod>2025-09-11</lastmod>
-    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+
   <url>
-    <loc>https://schooltechub.com/contact</loc>
-    <lastmod>2025-09-11</lastmod>
-    <changefreq>monthly</changefreq>
+    <loc>https://schooltechub.com/edutech</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
+
   <url>
-    <loc>https://schooltechub.com/faq</loc>
-    <lastmod>2025-09-11</lastmod>
+    <loc>https://schooltechub.com/teacher-diary</loc>
+    <lastmod>2025-09-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <url>
-    <loc>https://schooltechub.com/blog/5-quick-wins-ai-teachers</loc>
-    <lastmod>2025-09-11</lastmod>
+    <loc>https://schooltechub.com/contact</loc>
+    <lastmod>2025-09-20</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.5</priority>
   </url>
+
   <url>
-    <loc>https://schooltechub.com/case-studies/lincoln-elementary-transformation</loc>
-    <lastmod>2025-09-11</lastmod>
+    <loc>https://schooltechub.com/faq</loc>
+    <lastmod>2025-09-20</lastmod>
     <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/auth</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/sitemap</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <!-- Albanian localized pages -->
+  <url>
+    <loc>https://schooltechub.com/sq</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
-  
+
+  <url>
+    <loc>https://schooltechub.com/sq/about</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/sq/services</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/sq/blog</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/sq/events</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/sq/edutech</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/sq/teacher-diary</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/sq/contact</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/sq/faq</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/sq/auth</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/sq/sitemap</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <!-- Vietnamese localized pages -->
+  <url>
+    <loc>https://schooltechub.com/vi</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/vi/about</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/vi/services</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/vi/blog</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/vi/events</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/vi/edutech</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/vi/teacher-diary</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/vi/contact</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/vi/faq</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/vi/auth</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://schooltechub.com/vi/sitemap</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
 </urlset>

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -1,87 +1,154 @@
-import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SEO } from "@/components/SEO";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+import { format } from "date-fns";
+
+type RouteLink = {
+  title: string;
+  url: string;
+};
+
+type DynamicLink = RouteLink & {
+  updatedAt?: string | null;
+  language?: string | null;
+};
+
+const supportedLanguages = [
+  { code: "en", label: "English" },
+  { code: "sq", label: "Albanian" },
+  { code: "vi", label: "Vietnamese" },
+] as const;
+
+const englishRoutes: RouteLink[] = [
+  { title: "Home", url: "/" },
+  { title: "About", url: "/about" },
+  { title: "Services", url: "/services" },
+  { title: "Blog", url: "/blog" },
+  { title: "Events", url: "/events" },
+  { title: "Edutech Hub", url: "/edutech" },
+  { title: "Teacher Diary", url: "/teacher-diary" },
+  { title: "Contact", url: "/contact" },
+  { title: "FAQ", url: "/faq" },
+  { title: "Auth Portal", url: "/auth" },
+  { title: "Sitemap", url: "/sitemap" },
+];
+
+const languageLabels = supportedLanguages.reduce<Record<string, string>>((acc, lang) => {
+  acc[lang.code] = lang.label;
+  return acc;
+}, {});
+
+const formatUpdatedAt = (value?: string | null) => {
+  if (!value) return null;
+  try {
+    return format(new Date(value), "MMM d, yyyy");
+  } catch (error) {
+    console.error("Error formatting date", error);
+    return null;
+  }
+};
 
 const Sitemap = () => {
-  // Fetch blog posts for sitemap
-  const { data: blogPosts } = useQuery({
+  const { data: blogPosts = [] } = useQuery({
     queryKey: ["sitemap-blog-posts"],
     queryFn: async () => {
       const { data, error } = await supabase
         .from("content_master")
-        .select("slug, title, updated_at")
+        .select("slug, title, updated_at, published_at, language")
         .eq("page", "research_blog")
         .eq("is_published", true)
         .order("published_at", { ascending: false });
-      
+
       if (error) throw error;
-      return data;
+      return data ?? [];
     }
   });
 
-  const sitemapSections = [
-    {
-      title: "Main Pages",
-      links: [
-        { title: "Home", url: "/" },
-        { title: "About", url: "/about" },
-        { title: "Contact", url: "/contact" },
-        { title: "FAQ", url: "/faq" },
-      ]
-    },
-    {
-      title: "Tools Hub",
-      links: [
-        { title: "Tools Directory", url: "/tools" },
-        { title: "Templates", url: "/tools/templates" },
-      ]
-    },
-    {
-      title: "Learn Hub",
-      links: [
-        { title: "Learn Overview", url: "/learn" },
-        { title: "Tutorials", url: "/learn/tutorials" },
-        { title: "Teaching Techniques", url: "/learn/teaching-techniques" },
-        { title: "Activities", url: "/learn/activities" },
-        { title: "Lesson Plans", url: "/learn/lesson-plans" },
-        { title: "Teacher Tips", url: "/learn/teacher-tips" },
-      ]
-    },
-    {
-      title: "Blog Hub",
-      links: [
-        { title: "Blog Posts", url: "/blog" },
-        { title: "Case Studies", url: "/blog/case-studies" },
-        { title: "Research", url: "/blog/research" },
-        { title: "Research Questions", url: "/blog/research-questions" },
-      ]
-    },
-    {
-      title: "Events Hub",
-      links: [
-        { title: "All Events", url: "/events" },
-        { title: "Workshops", url: "/events/workshops" },
-        { title: "Webinars", url: "/events/webinars" },
-        { title: "Meetups", url: "/events/meetups" },
-      ]
-    },
-    {
-      title: "Services",
-      links: [
-        { title: "All Services", url: "/services" },
-        { title: "AI Tools Training", url: "/services/ai-tools-training" },
-        { title: "Dashboard Setup", url: "/services/dashboard-setup" },
-        { title: "Custom Workshops", url: "/services/custom-workshops" },
-      ]
+  const { data: events = [] } = useQuery({
+    queryKey: ["sitemap-events"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("content_master")
+        .select("slug, title, updated_at, start_datetime, language")
+        .eq("page", "events")
+        .eq("is_published", true)
+        .order("start_datetime", { ascending: false });
+
+      if (error) throw error;
+      return data ?? [];
     }
+  });
+
+  const { data: diaryEntries = [] } = useQuery({
+    queryKey: ["sitemap-teacher-diary"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("content_master")
+        .select("slug, title, updated_at, published_at, language")
+        .eq("page", "teacher_diary")
+        .eq("is_published", true)
+        .order("published_at", { ascending: false });
+
+      if (error) throw error;
+      return data ?? [];
+    }
+  });
+
+  const staticSections = [
+    {
+      title: "English Pages",
+      links: englishRoutes
+    },
+    ...supportedLanguages
+      .filter((lang) => lang.code !== "en")
+      .map((lang) => ({
+        title: `${lang.label} Pages`,
+        links: englishRoutes.map((route) => ({
+          title: route.title,
+          url: route.url === "/" ? `/${lang.code}` : `/${lang.code}${route.url}`
+        }))
+      }))
   ];
+
+  const dynamicSections: { title: string; links: DynamicLink[] }[] = [
+    {
+      title: "Blog Posts",
+      links: blogPosts.map((post) => ({
+        title: post.title || post.slug,
+        url: getLocalizedPath(`/blog/${post.slug}`, post.language || "en"),
+        updatedAt: formatUpdatedAt(post.updated_at ?? post.published_at ?? undefined),
+        language: post.language || "en"
+      }))
+    },
+    {
+      title: "Events",
+      links: events.map((event) => ({
+        title: event.title || event.slug,
+        url: getLocalizedPath(`/events/${event.slug}`, event.language || "en"),
+        updatedAt: formatUpdatedAt(event.updated_at ?? event.start_datetime ?? undefined),
+        language: event.language || "en"
+      }))
+    },
+    {
+      title: "Teacher Diary Entries",
+      links: diaryEntries.map((entry) => ({
+        title: entry.title || entry.slug,
+        url: getLocalizedPath(`/teacher-diary/${entry.slug}`, entry.language || "en"),
+        updatedAt: formatUpdatedAt(entry.updated_at ?? entry.published_at ?? undefined),
+        language: entry.language || "en"
+      }))
+    }
+  ].map((section) => ({
+    ...section,
+    links: section.links.filter((link) => Boolean(link?.url && link?.title))
+  })).filter((section) => section.links.length > 0);
 
   return (
     <div className="min-h-screen flex flex-col">
-      <SEO 
+      <SEO
         title="Sitemap - School Tech Hub"
         description="Navigate through all pages and resources available on School Tech Hub"
         keywords="sitemap, navigation, school tech hub pages"
@@ -94,7 +161,7 @@ const Sitemap = () => {
           </p>
 
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {sitemapSections.map((section) => (
+            {staticSections.map((section) => (
               <Card key={section.title}>
                 <CardHeader>
                   <CardTitle>{section.title}</CardTitle>
@@ -103,7 +170,7 @@ const Sitemap = () => {
                   <ul className="space-y-2">
                     {section.links.map((link) => (
                       <li key={link.url}>
-                        <Link 
+                        <Link
                           to={link.url}
                           className="text-primary hover:underline"
                         >
@@ -117,6 +184,45 @@ const Sitemap = () => {
             ))}
           </div>
 
+          {dynamicSections.length > 0 && (
+            <div className="mt-10 space-y-6">
+              <h2 className="text-2xl font-semibold">Fresh content</h2>
+              <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {dynamicSections.map((section) => (
+                  <Card key={section.title}>
+                    <CardHeader>
+                      <CardTitle>{section.title}</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <ul className="space-y-3">
+                        {section.links.map((link) => (
+                          <li key={link.url}>
+                            <Link
+                              to={link.url}
+                              className="text-primary hover:underline"
+                            >
+                              {link.title}
+                            </Link>
+                            <div className="text-xs text-muted-foreground mt-1 flex flex-wrap gap-2">
+                              {link.language && (
+                                <span className="uppercase">
+                                  {languageLabels[link.language] || link.language.toUpperCase()}
+                                </span>
+                              )}
+                              {link.updatedAt && (
+                                <span>Updated {link.updatedAt}</span>
+                              )}
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          )}
+
           <Card className="mt-8">
             <CardHeader>
               <CardTitle>XML Sitemap</CardTitle>
@@ -125,8 +231,8 @@ const Sitemap = () => {
               <p className="text-muted-foreground mb-4">
                 For search engines and automated tools, access our XML sitemap:
               </p>
-              <a 
-                href="/sitemap.xml" 
+              <a
+                href="/sitemap.xml"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-primary hover:underline"


### PR DESCRIPTION
## Summary
- replace the static XML sitemap entries with the real routes defined in LocalizedRoutes, including the localized (sq/vi) paths, and refresh the `<lastmod>` values
- rebuild the React sitemap page to mirror the same vetted routes and surface live content (blog posts, events, teacher diary entries) from Supabase with language badges and updated timestamps

## Testing
- `npm run lint` *(fails: repository has pre-existing lint issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce64b5cca883319edea7442e98a4f8