### PR TITLE
Improve home page language localization

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,14 +26,14 @@ const Footer = () => {
       if (error) throw error;
 
       toast({
-        title: "Success!",
-        description: "You've been subscribed to our monthly tech tips.",
+        title: t.footer.toast.successTitle,
+        description: t.footer.toast.successMessage,
       });
       setEmail("");
     } catch (error: any) {
       toast({
-        title: "Error",
-        description: error.message || "Failed to subscribe. Please try again.",
+        title: t.footer.toast.errorTitle,
+        description: error.message || t.footer.toast.errorMessage,
         variant: "destructive",
       });
     } finally {
@@ -58,21 +58,21 @@ const Footer = () => {
               {t.footer.tagline}
             </p>
             <div className="flex space-x-4">
-              <a href="https://www.facebook.com/share/g/1NukWcXVpp/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary transition-colors" aria-label="Facebook">
+              <a href="https://www.facebook.com/share/g/1NukWcXVpp/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary transition-colors" aria-label={t.footer.social.facebook}>
                 <Facebook className="h-5 w-5" />
-                <span className="sr-only">Facebook</span>
+                <span className="sr-only">{t.footer.social.facebook}</span>
               </a>
-              <a href="https://www.instagram.com/schooltechhub/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary transition-colors" aria-label="Instagram">
+              <a href="https://www.instagram.com/schooltechhub/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary transition-colors" aria-label={t.footer.social.instagram}>
                 <Instagram className="h-5 w-5" />
-                <span className="sr-only">Instagram</span>
+                <span className="sr-only">{t.footer.social.instagram}</span>
               </a>
-              <a href="https://www.linkedin.com/in/donald-cjapi-b7800a383/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary transition-colors" aria-label="LinkedIn">
+              <a href="https://www.linkedin.com/in/donald-cjapi-b7800a383/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary transition-colors" aria-label={t.footer.social.linkedin}>
                 <Linkedin className="h-5 w-5" />
-                <span className="sr-only">LinkedIn</span>
+                <span className="sr-only">{t.footer.social.linkedin}</span>
               </a>
-              <a href="mailto:dcjapi@gmail.com" className="text-muted-foreground hover:text-primary transition-colors" aria-label="Email">
+              <a href="mailto:dcjapi@gmail.com" className="text-muted-foreground hover:text-primary transition-colors" aria-label={t.footer.social.email}>
                 <Mail className="h-5 w-5" />
-                <span className="sr-only">Email</span>
+                <span className="sr-only">{t.footer.social.email}</span>
               </a>
             </div>
           </div>
@@ -171,7 +171,7 @@ const Footer = () => {
                 className="text-sm"
               />
               <Button type="submit" className="w-full" disabled={isSubscribing}>
-                {isSubscribing ? "..." : t.footer.subscribe}
+                {isSubscribing ? t.footer.subscribing : t.footer.subscribe}
               </Button>
             </form>
           </div>
@@ -180,8 +180,8 @@ const Footer = () => {
         <div className="mt-12 pt-8 border-t text-center">
           <p className="text-sm text-muted-foreground mb-2">© 2024 SchoolTech Hub. {t.footer.allRights}.</p>
           <div className="text-xs text-muted-foreground space-y-1">
-            <p>Email: dcjapi@gmail.com | Phone: +84 0372725432</p>
-            <p>Available worldwide for online consultations</p>
+            <p>{t.footer.contact.emailLabel}: dcjapi@gmail.com | {t.footer.contact.phoneLabel}: +84 0372725432</p>
+            <p>{t.footer.contact.availability}</p>
           </div>
         </div>
       </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -80,6 +80,48 @@ const Index = () => {
 
     return () => observer.disconnect();
   }, [hasAnimated]);
+  const highlights = [
+    { icon: Brain, text: t.home.highlights.aiPowered, iconColor: "text-primary" },
+    { icon: Globe, text: t.home.highlights.vrClassrooms, iconColor: "text-accent" },
+    { icon: Zap, text: t.home.highlights.realTimeAnalytics, iconColor: "text-secondary" }
+  ];
+
+  const statsData = [
+    { value: `${counters.lessons.toLocaleString()}+`, label: t.home.stats.aiLessons, icon: Brain },
+    { value: `${counters.vr}+`, label: t.home.stats.vrExperiences, icon: Globe },
+    { value: `${counters.engagement}%`, label: t.home.stats.engagementRate, icon: Zap },
+    { value: "24/7", label: t.home.stats.supportAvailable, icon: Shield }
+  ];
+
+  const socialLinks = [
+    {
+      href: "https://www.facebook.com/share/g/1NukWcXVpp/",
+      label: t.home.cta.social.facebook,
+      Icon: Facebook,
+      ariaLabel: t.home.cta.social.facebook
+    },
+    {
+      href: "https://www.instagram.com/schooltechhub/",
+      label: t.home.cta.social.instagram,
+      Icon: Instagram,
+      ariaLabel: t.home.cta.social.instagram
+    },
+    {
+      href: "https://www.linkedin.com/in/donald-cjapi-b7800a383/",
+      label: t.home.cta.social.linkedin,
+      Icon: Linkedin,
+      ariaLabel: t.home.cta.social.linkedin
+    },
+    {
+      href: "mailto:dcjapi@gmail.com",
+      label: t.home.cta.social.email,
+      Icon: Mail,
+      ariaLabel: t.home.cta.social.email,
+      target: "_self",
+      rel: undefined
+    }
+  ];
+
   return (
     <div className="min-h-screen bg-background overflow-hidden">
       <SEO 
@@ -141,18 +183,12 @@ const Index = () => {
             </p>
             
             <div className="mb-12 flex flex-wrap justify-center gap-6 text-sm font-space animate-in fade-in slide-in-from-bottom-4 duration-1000 delay-300">
-              <div className="flex items-center gap-2">
-                <Brain className="h-5 w-5 text-primary animate-pulse-glow" />
-                <span className="text-foreground">AI-Powered</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Globe className="h-5 w-5 text-accent animate-pulse-glow delay-150" />
-                <span className="text-foreground">VR Classrooms</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Zap className="h-5 w-5 text-secondary animate-pulse-glow delay-300" />
-                <span className="text-foreground">Real-Time Analytics</span>
-              </div>
+              {highlights.map((highlight, index) => (
+                <div key={index} className="flex items-center gap-2">
+                  <highlight.icon className={`h-5 w-5 ${highlight.iconColor} animate-pulse-glow`} />
+                  <span className="text-foreground">{highlight.text}</span>
+                </div>
+              ))}
             </div>
             
             <div className="flex flex-col gap-4 sm:flex-row sm:justify-center animate-in fade-in slide-in-from-bottom-4 duration-1000 delay-500">
@@ -262,12 +298,7 @@ const Index = () => {
       <section className="relative py-20" ref={statsRef}>
         <div className="container">
           <div className="grid gap-8 md:grid-cols-4">
-            {[
-              { value: `${counters.lessons.toLocaleString()}+`, label: "AI-Powered Lessons", icon: Brain },
-              { value: `${counters.vr}+`, label: "VR Experiences", icon: Globe },
-              { value: `${counters.engagement}%`, label: "Engagement Rate", icon: Zap },
-              { value: "24/7", label: "Support Available", icon: Shield }
-            ].map((stat, index) => (
+            {statsData.map((stat, index) => (
               <div key={index} className="text-center group">
                 <stat.icon className="mx-auto mb-4 h-8 w-8 text-primary animate-pulse-glow" />
                 <div className="text-4xl font-orbitron font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
@@ -286,60 +317,39 @@ const Index = () => {
           <Card className="relative overflow-hidden border-primary/30 bg-gradient-to-r from-primary/10 via-accent/10 to-secondary/10 p-12 text-center">
             <div className="absolute inset-0 bg-cyber-grid bg-[size:30px_30px] opacity-10" />
             <div className="relative z-10">
-              <h2 className="text-4xl font-orbitron font-bold mb-4">Ready to Transform Your School?</h2>
+              <h2 className="text-4xl font-orbitron font-bold mb-4">{t.home.cta.title}</h2>
               <p className="text-xl text-muted-foreground font-space mb-8 max-w-2xl mx-auto">
-                Join thousands of educators who are already using our platform to create better learning experiences.
+                {t.home.cta.description}
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
                 <Link to={getLocalizedPath("/contact", language)}>
                   <Button size="lg" className="bg-gradient-to-r from-primary to-accent hover:shadow-[0_0_40px_hsl(var(--glow-primary)/0.5)]">
-                    Get Started
+                    {t.home.cta.primary}
                     <Rocket className="ml-2 h-5 w-5" />
                   </Button>
                 </Link>
                 <Link to={getLocalizedPath("/services", language)}>
                   <Button size="lg" variant="outline" className="border-primary/30 hover:border-primary hover:bg-primary/10">
-                    View Pricing
+                    {t.home.cta.secondary}
                   </Button>
                 </Link>
               </div>
-              
+
               {/* Social Media Icons */}
               <div className="flex justify-center space-x-4">
-                <a 
-                  href="https://www.facebook.com/share/g/1NukWcXVpp/" 
-                  target="_blank" 
-                  rel="noopener noreferrer" 
-                  className="text-muted-foreground hover:text-primary transition-colors" 
-                  aria-label="Facebook"
-                >
-                  <Facebook className="h-6 w-6" />
-                </a>
-                <a 
-                  href="https://www.instagram.com/schooltechhub/" 
-                  target="_blank" 
-                  rel="noopener noreferrer" 
-                  className="text-muted-foreground hover:text-primary transition-colors" 
-                  aria-label="Instagram"
-                >
-                  <Instagram className="h-6 w-6" />
-                </a>
-                <a 
-                  href="https://www.linkedin.com/in/donald-cjapi-b7800a383/" 
-                  target="_blank" 
-                  rel="noopener noreferrer" 
-                  className="text-muted-foreground hover:text-primary transition-colors" 
-                  aria-label="LinkedIn"
-                >
-                  <Linkedin className="h-6 w-6" />
-                </a>
-                <a 
-                  href="mailto:dcjapi@gmail.com" 
-                  className="text-muted-foreground hover:text-primary transition-colors" 
-                  aria-label="Email"
-                >
-                  <Mail className="h-6 w-6" />
-                </a>
+                {socialLinks.map(({ href, label, Icon, ariaLabel, target, rel }, index) => (
+                  <a
+                    key={index}
+                    href={href}
+                    target={target ?? "_blank"}
+                    rel={rel ?? (target === "_self" ? undefined : "noopener noreferrer")}
+                    className="text-muted-foreground hover:text-primary transition-colors"
+                    aria-label={ariaLabel}
+                  >
+                    <Icon className="h-6 w-6" />
+                    <span className="sr-only">{label}</span>
+                  </a>
+                ))}
               </div>
             </div>
           </Card>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -156,6 +156,24 @@ export const en = {
     newsletterText: "Subscribe to get the latest updates",
     emailPlaceholder: "Your email",
     subscribe: "Subscribe",
+    subscribing: "Subscribing...",
+    toast: {
+      successTitle: "Success!",
+      successMessage: "You've been subscribed to our monthly tech tips.",
+      errorTitle: "Error",
+      errorMessage: "Failed to subscribe. Please try again."
+    },
+    social: {
+      facebook: "Facebook",
+      instagram: "Instagram",
+      linkedin: "LinkedIn",
+      email: "Email"
+    },
+    contact: {
+      emailLabel: "Email",
+      phoneLabel: "Phone",
+      availability: "Available worldwide for online consultations"
+    },
     allRights: "All rights reserved",
     privacy: "Privacy Policy",
     terms: "Terms of Service"
@@ -226,6 +244,31 @@ export const en = {
     viewAll: "View All",
     classSchedule: "Class Schedule",
     notes: "Notes & Observations"
+  },
+  home: {
+    highlights: {
+      aiPowered: "AI-Powered",
+      vrClassrooms: "VR Classrooms",
+      realTimeAnalytics: "Real-Time Analytics"
+    },
+    stats: {
+      aiLessons: "AI-Powered Lessons",
+      vrExperiences: "VR Experiences",
+      engagementRate: "Engagement Rate",
+      supportAvailable: "Support Available"
+    },
+    cta: {
+      title: "Ready to Transform Your School?",
+      description: "Join thousands of educators who are already using our platform to create better learning experiences.",
+      primary: "Get Started",
+      secondary: "View Pricing",
+      social: {
+        facebook: "Facebook",
+        instagram: "Instagram",
+        linkedin: "LinkedIn",
+        email: "Email"
+      }
+    }
   },
   common: {
     loading: "Loading...",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -156,6 +156,24 @@ export const sq = {
     newsletterText: "Abonohuni për të marrë përditësimet më të fundit",
     emailPlaceholder: "Emaili juaj",
     subscribe: "Abonohu",
+    subscribing: "Duke u abonuar...",
+    toast: {
+      successTitle: "Sukses!",
+      successMessage: "Ju u abonuat në këshillat tona mujore të teknologjisë.",
+      errorTitle: "Gabim",
+      errorMessage: "Abonimi dështoi. Ju lutemi provoni përsëri."
+    },
+    social: {
+      facebook: "Facebook",
+      instagram: "Instagram",
+      linkedin: "LinkedIn",
+      email: "Email"
+    },
+    contact: {
+      emailLabel: "Email",
+      phoneLabel: "Telefoni",
+      availability: "Në dispozicion globalisht për konsultime online"
+    },
     allRights: "Të gjitha të drejtat e rezervuara",
     privacy: "Politika e Privatësisë",
     terms: "Kushtet e Shërbimit"
@@ -226,6 +244,31 @@ export const sq = {
     viewAll: "Shiko të Gjitha",
     classSchedule: "Orari i Klasave",
     notes: "Shënime dhe Vëzhgime"
+  },
+  home: {
+    highlights: {
+      aiPowered: "Me fuqi AI",
+      vrClassrooms: "Klasa VR",
+      realTimeAnalytics: "Analitikë në kohë reale"
+    },
+    stats: {
+      aiLessons: "Mësime me fuqi AI",
+      vrExperiences: "Përvoja VR",
+      engagementRate: "Norma e angazhimit",
+      supportAvailable: "Mbështetje në dispozicion"
+    },
+    cta: {
+      title: "Gati të transformoni shkollën tuaj?",
+      description: "Bashkohuni me mijëra edukatorë që tashmë përdorin platformën tonë për të krijuar përvoja më të mira të të mësuarit.",
+      primary: "Fillo Tani",
+      secondary: "Shiko Çmimet",
+      social: {
+        facebook: "Facebook",
+        instagram: "Instagram",
+        linkedin: "LinkedIn",
+        email: "Email"
+      }
+    }
   },
   common: {
     loading: "Duke ngarkuar...",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -156,6 +156,24 @@ export const vi = {
     newsletterText: "Đăng ký để nhận các cập nhật mới nhất",
     emailPlaceholder: "Email của bạn",
     subscribe: "Đăng ký",
+    subscribing: "Đang đăng ký...",
+    toast: {
+      successTitle: "Thành công!",
+      successMessage: "Bạn đã đăng ký nhận mẹo công nghệ hàng tháng của chúng tôi.",
+      errorTitle: "Lỗi",
+      errorMessage: "Không thể đăng ký. Vui lòng thử lại."
+    },
+    social: {
+      facebook: "Facebook",
+      instagram: "Instagram",
+      linkedin: "LinkedIn",
+      email: "Email"
+    },
+    contact: {
+      emailLabel: "Email",
+      phoneLabel: "Điện thoại",
+      availability: "Hỗ trợ trực tuyến trên toàn thế giới"
+    },
     allRights: "Tất cả các quyền được bảo lưu",
     privacy: "Chính sách bảo mật",
     terms: "Điều khoản dịch vụ"
@@ -226,6 +244,31 @@ export const vi = {
     viewAll: "Xem tất cả",
     classSchedule: "Lịch học",
     notes: "Ghi chú & Quan sát"
+  },
+  home: {
+    highlights: {
+      aiPowered: "Ứng dụng AI",
+      vrClassrooms: "Lớp học VR",
+      realTimeAnalytics: "Phân tích thời gian thực"
+    },
+    stats: {
+      aiLessons: "Bài học ứng dụng AI",
+      vrExperiences: "Trải nghiệm VR",
+      engagementRate: "Tỷ lệ tương tác",
+      supportAvailable: "Hỗ trợ sẵn sàng"
+    },
+    cta: {
+      title: "Sẵn sàng chuyển đổi trường học của bạn?",
+      description: "Tham gia cùng hàng nghìn nhà giáo dục đã sử dụng nền tảng của chúng tôi để tạo ra trải nghiệm học tập tốt hơn.",
+      primary: "Bắt đầu",
+      secondary: "Xem bảng giá",
+      social: {
+        facebook: "Facebook",
+        instagram: "Instagram",
+        linkedin: "LinkedIn",
+        email: "Email"
+      }
+    }
   },
   common: {
     loading: "Đang tải...",


### PR DESCRIPTION
## Summary
- use structured translation data for home page highlights, stat labels, and call-to-action content
- add localized CTA, highlight, and footer subscription strings across English, Albanian, and Vietnamese dictionaries
- switch the global footer to the shared translations for toast messaging, social labels, and contact details

## Testing
- npm run lint *(fails: repository already contains numerous @typescript-eslint/no-explicit-any and related warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ce67f4ab348331899a50dc74669e91