### PR TITLE
Fix footer links blocked by homepage background overlay

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -91,7 +91,7 @@ const Index = () => {
       <StructuredData type="Organization" data={{}} />
       <MouseGlowEffect />
       {/* Cyber Grid Background */}
-      <div className="fixed inset-0 bg-cyber-grid bg-[size:50px_50px] opacity-20" />
+      <div className="pointer-events-none fixed inset-0 bg-cyber-grid bg-[size:50px_50px] opacity-20" />
       
       {/* Hero Section */}
       <section className="relative min-h-screen flex items-center justify-center overflow-hidden">


### PR DESCRIPTION
## Summary
- disable pointer events on the homepage's fixed cyber grid background layer so that it no longer intercepts clicks meant for the footer links

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce68ca3cb48331b250ff358630a91b