### PR TITLE
Improve tab list responsiveness

### DIFF
--- a/src/pages/Edutech.tsx
+++ b/src/pages/Edutech.tsx
@@ -167,7 +167,7 @@ const Edutech = () => {
           </div>
 
           <Tabs value={selectedCategory} onValueChange={setSelectedCategory} className="mb-8">
-            <TabsList className="grid w-full grid-cols-5">
+            <TabsList className="grid w-full grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
               {categories.map((cat) => (
                 <TabsTrigger key={cat.value} value={cat.value}>
                   {cat.label}

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -171,7 +171,7 @@ const Events = () => {
           </div>
 
           <Tabs value={selectedType} onValueChange={setSelectedType} className="mb-8">
-            <TabsList className="grid w-full grid-cols-6">
+            <TabsList className="grid w-full grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
               {eventTypes.map((type) => (
                 <TabsTrigger key={type.value} value={type.value}>
                   {type.label}

--- a/src/pages/TeacherDiary.tsx
+++ b/src/pages/TeacherDiary.tsx
@@ -152,7 +152,7 @@ const TeacherDiary = () => {
           </div>
 
           <Tabs value={selectedCategory} onValueChange={setSelectedCategory} className="mb-8">
-            <TabsList className="grid w-full grid-cols-5">
+            <TabsList className="grid w-full grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
               {categories.map((cat) => (
                 <TabsTrigger key={cat.value} value={cat.value}>
                   {cat.label}


### PR DESCRIPTION
## Summary
- make the Edutech category tabs responsive with smaller breakpoints
- apply the same responsive grid layout to the Teacher Diary tabs
- adjust the Events page tabs to keep event types legible on small screens

## Testing
- `npm run lint` *(fails: pre-existing lint errors around explicit any types)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9607a320833192fb2c23cafdc21a