### PR TITLE
Localize About page content

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -8,49 +8,36 @@ import { useLanguage } from "@/contexts/LanguageContext";
 import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
 const About = () => {
-  const { language } = useLanguage();
-  const mission = [
-    {
-      icon: Target,
-      title: "Practical First",
-      description: "Every strategy must work in real classrooms, not just in theory.",
-    },
-    {
-      icon: Heart,
-      title: "Teacher-Centered",
-      description: "We understand the daily challenges and time constraints you face.",
-    },
-    {
-      icon: Lightbulb,
-      title: "Continuous Learning",
-      description: "Technology evolves, and so do our methods and recommendations.",
-    },
-  ];
+  const { language, t } = useLanguage();
 
-  const stats = [
-    { number: "7+", label: "Years Experience" },
-    { number: "100+", label: "Schools Helped" },
-    { number: "1,000+", label: "Teachers Supported" },
-    { number: "50+", label: "Tools Tested" },
-  ];
+  const missionIcons = [Target, Heart, Lightbulb];
+  const mission = (t.about.values.items ?? []).map((item, index) => ({
+    ...item,
+    icon: missionIcons[index] ?? Target,
+  }));
+  const stats = t.about.stats.items ?? [];
+  const storyParagraphs = t.about.story.paragraphs ?? [];
+  const certifications = t.about.credentials.certifications.items ?? [];
+  const featured = t.about.credentials.featured.items ?? [];
+  const expertise = t.about.expertise.items ?? [];
+  const testimonials = t.about.testimonials.items ?? [];
+  const faqs = t.about.faq.items ?? [];
 
   return (
     <div className="min-h-screen flex flex-col">
       <SEO
-        title="About Us"
-        description="Learn about SchoolTech Hub's mission to make educational technology accessible. 7+ years experience, 100+ schools helped, certified educators supporting your tech journey."
-        keywords="about SchoolTech Hub, educational technology company, EdTech consultants, teacher training experts, classroom technology specialists"
-        canonicalUrl="https://schooltechhub.com/about"
+        title={t.about.seo.title}
+        description={t.about.seo.description}
+        keywords={t.about.seo.keywords}
+        canonicalUrl={t.about.seo.canonical}
       />
 
       {/* Hero Section */}
       <section className="py-16 px-4 bg-gradient-to-b from-primary/5 to-background">
         <div className="container mx-auto">
           <div className="max-w-3xl mx-auto text-center">
-            <h1 className="text-4xl md:text-5xl font-bold mb-6">About SchoolTech Hub</h1>
-            <p className="text-xl text-muted-foreground">
-              Making educational technology accessible and practical for every teacher
-            </p>
+            <h1 className="text-4xl md:text-5xl font-bold mb-6">{t.about.hero.title}</h1>
+            <p className="text-xl text-muted-foreground">{t.about.hero.subtitle}</p>
           </div>
         </div>
       </section>
@@ -60,27 +47,31 @@ const About = () => {
         <div className="container mx-auto">
           <div className="max-w-3xl mx-auto">
             <Card className="p-8 bg-gradient-to-br from-card to-primary/5">
-              <h2 className="text-2xl font-bold mb-6">Our Story</h2>
+              <h2 className="text-2xl font-bold mb-6">{t.about.story.title}</h2>
               <div className="space-y-4 text-muted-foreground">
-                <p>SchoolTech Hub was founded by educators who saw the gap between amazing technology and overwhelmed teachers. We bridge that gap with practical, proven solutions.</p>
+                {storyParagraphs.map((paragraph, index) => (
+                  <p key={index}>{paragraph}</p>
+                ))}
               </div>
               <div className="mt-6 pt-6 border-t">
-                <h3 className="text-xl font-bold mb-4">CEO Message</h3>
+                <h3 className="text-xl font-bold mb-4">{t.about.story.ceo.title}</h3>
                 <div className="flex flex-col md:flex-row gap-6 items-start">
-                  <img 
-                    src="/lovable-uploads/96483919-4154-4163-b949-8ebebd6fb820.png" 
-                    alt="Donald Cjapi - CEO message" 
+                  <img
+                    src="/lovable-uploads/96483919-4154-4163-b949-8ebebd6fb820.png"
+                    alt="Donald Cjapi - CEO message"
                     className="w-48 h-48 rounded-lg object-cover shadow-lg md:w-64 md:h-64"
                   />
                   <div className="flex-1">
-                    <p className="text-muted-foreground leading-relaxed">Technology should empower teachers, not overwhelm them. Our mission is to make every educator confident with the tools that can transform their classrooms.</p>
-                    <p className="font-semibold mt-4">- Donald Cjapi, CEO & Founder</p>
+                    <p className="text-muted-foreground leading-relaxed">{t.about.story.ceo.message}</p>
+                    {t.about.story.ceo.signature && (
+                      <p className="font-semibold mt-4">{t.about.story.ceo.signature}</p>
+                    )}
                   </div>
                 </div>
               </div>
               <div className="mt-6 pt-6 border-t">
-                <h3 className="text-xl font-bold mb-4">Our Mission</h3>
-                <p className="text-muted-foreground">To democratize educational technology by providing accessible, affordable, and actionable support to educators worldwide.</p>
+                <h3 className="text-xl font-bold mb-4">{t.about.story.mission.title}</h3>
+                <p className="text-muted-foreground">{t.about.story.mission.description}</p>
               </div>
             </Card>
           </div>
@@ -90,7 +81,7 @@ const About = () => {
       {/* Mission Section */}
       <section className="py-16 px-4 bg-muted/30">
         <div className="container mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-12">Our Values</h2>
+          <h2 className="text-3xl font-bold text-center mb-12">{t.about.values.title}</h2>
           <div className="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">
             {mission.map((item, index) => (
               <Card key={index} className="p-6 text-center">
@@ -124,44 +115,40 @@ const About = () => {
         <div className="container mx-auto">
           <div className="max-w-3xl mx-auto">
             <Card className="p-8">
-              <h2 className="text-2xl font-bold mb-6">Credentials & Partnerships</h2>
-              
+              <h2 className="text-2xl font-bold mb-6">{t.about.credentials.title}</h2>
+
               <div className="space-y-6">
                 <div>
-                  <h3 className="font-semibold mb-3">Certifications</h3>
+                  <h3 className="font-semibold mb-3">{t.about.credentials.certifications.title}</h3>
                   <div className="flex flex-wrap gap-2">
-                    <Badge variant="secondary">Google Certified Educator Level 2</Badge>
-                    <Badge variant="secondary">Microsoft Innovative Educator</Badge>
-                    <Badge variant="secondary">Apple Teacher</Badge>
-                    <Badge variant="secondary">ISTE Certified Educator</Badge>
-                    <Badge variant="secondary">Common Sense Digital Citizenship</Badge>
+                    {certifications.map((certification, index) => (
+                      <Badge key={index} variant="secondary">
+                        {certification}
+                      </Badge>
+                    ))}
                   </div>
                 </div>
 
                 <div>
-                  <h3 className="font-semibold mb-3">Featured In</h3>
+                  <h3 className="font-semibold mb-3">{t.about.credentials.featured.title}</h3>
                   <div className="flex flex-wrap gap-4 opacity-60">
-                    <div className="w-32 h-12 bg-muted rounded flex items-center justify-center text-xs">
-                      EdTech Magazine
-                    </div>
-                    <div className="w-32 h-12 bg-muted rounded flex items-center justify-center text-xs">
-                      Teaching Channel
-                    </div>
-                    <div className="w-32 h-12 bg-muted rounded flex items-center justify-center text-xs">
-                      ASCD
-                    </div>
+                    {featured.map((item, index) => (
+                      <div
+                        key={index}
+                        className="w-32 h-12 bg-muted rounded flex items-center justify-center text-xs"
+                      >
+                        {item}
+                      </div>
+                    ))}
                   </div>
                 </div>
 
                 <div>
-                  <h3 className="font-semibold mb-3">School Partnerships</h3>
-                  <p className="text-muted-foreground mb-4">
-                    We're proud to work with schools nationwide to pilot new approaches and gather real-world feedback. 
-                    Our partner schools help us ensure every strategy is classroom-tested and teacher-approved.
-                  </p>
+                  <h3 className="font-semibold mb-3">{t.about.credentials.partnerships.title}</h3>
+                  <p className="text-muted-foreground mb-4">{t.about.credentials.partnerships.description}</p>
                   <Button variant="outline">
                     <Users className="mr-2 h-4 w-4" />
-                    Partner With Us
+                    {t.about.credentials.partnerships.cta}
                   </Button>
                 </div>
               </div>
@@ -170,18 +157,16 @@ const About = () => {
             {/* CTA */}
             <Card className="mt-8 p-8 text-center bg-gradient-to-r from-primary/10 to-secondary/10">
               <Award className="h-12 w-12 text-primary mx-auto mb-4" />
-              <h3 className="text-2xl font-bold mb-4">Ready to Transform Your Teaching?</h3>
-              <p className="text-muted-foreground mb-6">
-                Join thousands of teachers who've discovered that technology doesn't have to be overwhelming.
-              </p>
+              <h3 className="text-2xl font-bold mb-4">{t.about.cta.title}</h3>
+              <p className="text-muted-foreground mb-6">{t.about.cta.description}</p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <Link to={getLocalizedPath("/services", language)}>
-                  <Button size="lg">Book a Consultation</Button>
+                  <Button size="lg">{t.about.cta.primary}</Button>
                 </Link>
                 <Link to={getLocalizedPath("/tools", language)}>
                   <Button size="lg" variant="outline">
                     <BookOpen className="mr-2 h-5 w-5" />
-                    Browse Free Resources
+                    {t.about.cta.secondary}
                   </Button>
                 </Link>
               </div>
@@ -193,32 +178,14 @@ const About = () => {
       {/* Certifications Section */}
       <section className="py-16 px-4 bg-muted/30">
         <div className="container mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-12">Certifications & Expertise</h2>
+          <h2 className="text-3xl font-bold text-center mb-12">{t.about.expertise.title}</h2>
           <div className="grid md:grid-cols-3 lg:grid-cols-6 gap-6">
-            <Card className="p-6 text-center">
-              <Award className="h-8 w-8 text-primary mx-auto mb-3" />
-              <h3 className="font-semibold text-sm">ClassDojo Mentorship</h3>
-            </Card>
-            <Card className="p-6 text-center">
-              <Award className="h-8 w-8 text-primary mx-auto mb-3" />
-              <h3 className="font-semibold text-sm">Wordwall Certified</h3>
-            </Card>
-            <Card className="p-6 text-center">
-              <Award className="h-8 w-8 text-primary mx-auto mb-3" />
-              <h3 className="font-semibold text-sm">Canvas Certification</h3>
-            </Card>
-            <Card className="p-6 text-center">
-              <Award className="h-8 w-8 text-primary mx-auto mb-3" />
-              <h3 className="font-semibold text-sm">Microsoft Educator</h3>
-            </Card>
-            <Card className="p-6 text-center">
-              <Award className="h-8 w-8 text-primary mx-auto mb-3" />
-              <h3 className="font-semibold text-sm">AI Education</h3>
-            </Card>
-            <Card className="p-6 text-center">
-              <Award className="h-8 w-8 text-primary mx-auto mb-3" />
-              <h3 className="font-semibold text-sm">Leadership Management</h3>
-            </Card>
+            {expertise.map((item, index) => (
+              <Card key={index} className="p-6 text-center">
+                <Award className="h-8 w-8 text-primary mx-auto mb-3" />
+                <h3 className="font-semibold text-sm">{item}</h3>
+              </Card>
+            ))}
           </div>
         </div>
       </section>
@@ -226,29 +193,15 @@ const About = () => {
       {/* Testimonials Section */}
       <section className="py-16 px-4">
         <div className="container mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-12">What Teachers Say</h2>
+          <h2 className="text-3xl font-bold text-center mb-12">{t.about.testimonials.title}</h2>
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <Card className="p-6">
-              <p className="text-muted-foreground mb-4 italic">
-                "The AI tools training transformed how I create lesson plans. I'm saving hours every week!"
-              </p>
-              <p className="font-semibold">Sarah M.</p>
-              <p className="text-sm text-muted-foreground">5th Grade Teacher</p>
-            </Card>
-            <Card className="p-6">
-              <p className="text-muted-foreground mb-4 italic">
-                "Finally, someone who understands classroom reality and doesn't just push the latest tech trends."
-              </p>
-              <p className="font-semibold">Mike T.</p>
-              <p className="text-sm text-muted-foreground">High School Science</p>
-            </Card>
-            <Card className="p-6">
-              <p className="text-muted-foreground mb-4 italic">
-                "The dashboard setup service revolutionized our school's data management. Highly recommend!"
-              </p>
-              <p className="font-semibold">Principal Johnson</p>
-              <p className="text-sm text-muted-foreground">Elementary School</p>
-            </Card>
+            {testimonials.map((testimonial, index) => (
+              <Card key={index} className="p-6">
+                <p className="text-muted-foreground mb-4 italic">“{testimonial.quote}”</p>
+                <p className="font-semibold">{testimonial.name}</p>
+                <p className="text-sm text-muted-foreground">{testimonial.role}</p>
+              </Card>
+            ))}
           </div>
         </div>
       </section>
@@ -256,26 +209,14 @@ const About = () => {
       {/* FAQ Section */}
       <section className="py-16 px-4 bg-muted/30" id="faq">
         <div className="container mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-12">Frequently Asked Questions</h2>
+          <h2 className="text-3xl font-bold text-center mb-12">{t.about.faq.title}</h2>
           <div className="max-w-3xl mx-auto space-y-4">
-            <Card className="p-6">
-              <h3 className="font-semibold mb-2">How do you stay current with EdTech?</h3>
-              <p className="text-muted-foreground">
-                We continuously test new tools, attend conferences, and collaborate with teachers worldwide to ensure our recommendations are cutting-edge yet practical.
-              </p>
-            </Card>
-            <Card className="p-6">
-              <h3 className="font-semibold mb-2">Do you work with schools outside Vietnam?</h3>
-              <p className="text-muted-foreground">
-                Yes! While based in Vietnam, we offer online consulting and training services globally, with experience across multiple education systems.
-              </p>
-            </Card>
-            <Card className="p-6">
-              <h3 className="font-semibold mb-2">What makes your approach different?</h3>
-              <p className="text-muted-foreground">
-                We focus on practical, immediately implementable solutions that work within real classroom constraints, not theoretical best practices.
-              </p>
-            </Card>
+            {faqs.map((faq, index) => (
+              <Card key={index} className="p-6">
+                <h3 className="font-semibold mb-2">{faq.question}</h3>
+                <p className="text-muted-foreground">{faq.answer}</p>
+              </Card>
+            ))}
           </div>
         </div>
       </section>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -50,25 +50,140 @@ export const en = {
     }
   },
   about: {
-    title: "About Us",
-    subtitle: "Leading the Digital Transformation in Education",
-    mission: "Our Mission",
-    missionText: "To revolutionize education through innovative technology solutions that empower educators, engage students, and transform learning outcomes.",
-    vision: "Our Vision",
-    visionText: "To become the global leader in educational technology, creating a world where every student has access to personalized, engaging, and effective learning experiences.",
-    values: "Our Values",
-    innovation: "Innovation",
-    innovationText: "Constantly pushing boundaries with cutting-edge solutions",
-    excellence: "Excellence",
-    excellenceText: "Delivering exceptional quality in everything we do",
-    integrity: "Integrity",
-    integrityText: "Building trust through transparency and ethical practices",
-    collaboration: "Collaboration",
-    collaborationText: "Working together to achieve extraordinary results",
-    teamTitle: "Meet Our Leadership Team",
-    ceo: "Chief Executive Officer",
-    cto: "Chief Technology Officer",
-    coo: "Chief Operating Officer"
+    seo: {
+      title: "About Us | SchoolTech Hub",
+      description:
+        "Learn about SchoolTech Hub's mission to make educational technology accessible. 7+ years experience, 100+ schools helped, certified educators supporting your tech journey.",
+      keywords:
+        "about SchoolTech Hub, educational technology company, EdTech consultants, teacher training experts, classroom technology specialists",
+      canonical: "https://schooltechhub.com/about"
+    },
+    hero: {
+      title: "About SchoolTech Hub",
+      subtitle: "Making educational technology accessible and practical for every teacher"
+    },
+    story: {
+      title: "Our Story",
+      paragraphs: [
+        "SchoolTech Hub was founded by educators who saw the gap between amazing technology and overwhelmed teachers. We bridge that gap with practical, proven solutions."
+      ],
+      ceo: {
+        title: "CEO Message",
+        message:
+          "Technology should empower teachers, not overwhelm them. Our mission is to make every educator confident with the tools that can transform their classrooms.",
+        signature: "- Donald Cjapi, CEO & Founder"
+      },
+      mission: {
+        title: "Our Mission",
+        description:
+          "To democratize educational technology by providing accessible, affordable, and actionable support to educators worldwide."
+      }
+    },
+    values: {
+      title: "Our Values",
+      items: [
+        {
+          title: "Practical First",
+          description: "Every strategy must work in real classrooms, not just in theory."
+        },
+        {
+          title: "Teacher-Centered",
+          description: "We understand the daily challenges and time constraints you face."
+        },
+        {
+          title: "Continuous Learning",
+          description: "Technology evolves, and so do our methods and recommendations."
+        }
+      ]
+    },
+    stats: {
+      items: [
+        { number: "7+", label: "Years Experience" },
+        { number: "100+", label: "Schools Helped" },
+        { number: "1,000+", label: "Teachers Supported" },
+        { number: "50+", label: "Tools Tested" }
+      ]
+    },
+    credentials: {
+      title: "Credentials & Partnerships",
+      certifications: {
+        title: "Certifications",
+        items: [
+          "Google Certified Educator Level 2",
+          "Microsoft Innovative Educator",
+          "Apple Teacher",
+          "ISTE Certified Educator",
+          "Common Sense Digital Citizenship"
+        ]
+      },
+      featured: {
+        title: "Featured In",
+        items: ["EdTech Magazine", "Teaching Channel", "ASCD"]
+      },
+      partnerships: {
+        title: "School Partnerships",
+        description:
+          "We're proud to work with schools nationwide to pilot new approaches and gather real-world feedback. Our partner schools help us ensure every strategy is classroom-tested and teacher-approved.",
+        cta: "Partner With Us"
+      }
+    },
+    cta: {
+      title: "Ready to Transform Your Teaching?",
+      description: "Join thousands of teachers who've discovered that technology doesn't have to be overwhelming.",
+      primary: "Book a Consultation",
+      secondary: "Browse Free Resources"
+    },
+    expertise: {
+      title: "Certifications & Expertise",
+      items: [
+        "ClassDojo Mentorship",
+        "Wordwall Certified",
+        "Canvas Certification",
+        "Microsoft Educator",
+        "AI Education",
+        "Leadership Management"
+      ]
+    },
+    testimonials: {
+      title: "What Teachers Say",
+      items: [
+        {
+          quote: "The AI tools training transformed how I create lesson plans. I'm saving hours every week!",
+          name: "Sarah M.",
+          role: "5th Grade Teacher"
+        },
+        {
+          quote: "Finally, someone who understands classroom reality and doesn't just push the latest tech trends.",
+          name: "Mike T.",
+          role: "High School Science"
+        },
+        {
+          quote: "The dashboard setup service revolutionized our school's data management. Highly recommend!",
+          name: "Principal Johnson",
+          role: "Elementary School"
+        }
+      ]
+    },
+    faq: {
+      title: "Frequently Asked Questions",
+      items: [
+        {
+          question: "How do you stay current with EdTech?",
+          answer:
+            "We continuously test new tools, attend conferences, and collaborate with teachers worldwide to ensure our recommendations are cutting-edge yet practical."
+        },
+        {
+          question: "Do you work with schools outside Vietnam?",
+          answer:
+            "Yes! While based in Vietnam, we offer online consulting and training services globally, with experience across multiple education systems."
+        },
+        {
+          question: "What makes your approach different?",
+          answer:
+            "We focus on practical, immediately implementable solutions that work within real classroom constraints, not theoretical best practices."
+        }
+      ]
+    }
   },
   services: {
     title: "Our Services",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -50,25 +50,144 @@ export const sq = {
     }
   },
   about: {
-    title: "Rreth Nesh",
-    subtitle: "Udhëheqës në Transformimin Dixhital në Arsim",
-    mission: "Misioni Ynë",
-    missionText: "Të revolucionarizojmë arsimin përmes zgjidhjeve inovative teknologjike që fuqizojnë edukatorët, angazhojnë studentët dhe transformojnë rezultatet e të mësuarit.",
-    vision: "Vizioni Ynë",
-    visionText: "Të bëhemi lider global në teknologjinë arsimore, duke krijuar një botë ku çdo student ka qasje në përvoja të personalizuara, angazhuese dhe efektive të të mësuarit.",
-    values: "Vlerat Tona",
-    innovation: "Inovacion",
-    innovationText: "Vazhdimisht duke shtyrë kufijtë me zgjidhje të avancuara",
-    excellence: "Përsosmëri",
-    excellenceText: "Duke ofruar cilësi të jashtëzakonshme në gjithçka që bëjmë",
-    integrity: "Integritet",
-    integrityText: "Ndërtimi i besimit përmes transparencës dhe praktikave etike",
-    collaboration: "Bashkëpunim",
-    collaborationText: "Duke punuar së bashku për të arritur rezultate të jashtëzakonshme",
-    teamTitle: "Takoni Ekipin Tonë Drejtues",
-    ceo: "Drejtor Ekzekutiv",
-    cto: "Drejtor i Teknologjisë",
-    coo: "Drejtor Operacional"
+    seo: {
+      title: "Rreth Nesh | SchoolTech Hub",
+      description:
+        "Njihuni me misionin e SchoolTech Hub për ta bërë teknologjinë arsimore të qasshme. 7+ vite përvojë, 100+ shkolla të ndihmuara, edukatorë të certifikuar që mbështesin udhëtimin tuaj teknologjik.",
+      keywords:
+        "rreth SchoolTech Hub, kompani teknologjie arsimore, konsulentë EdTech, ekspertë trajnimi mësuesish, specialistë të teknologjisë në klasë",
+      canonical: "https://schooltechhub.com/about"
+    },
+    hero: {
+      title: "Rreth SchoolTech Hub",
+      subtitle: "E bëjmë teknologjinë arsimore të qasshme dhe praktike për çdo mësues"
+    },
+    story: {
+      title: "Historia jonë",
+      paragraphs: [
+        "SchoolTech Hub u themelua nga edukatorë që panë hendekun mes teknologjisë së shkëlqyer dhe mësuesve të mbingarkuar. Ne e tejkalojmë atë hendek me zgjidhje praktike dhe të provuara."
+      ],
+      ceo: {
+        title: "Mesazhi i CEO-së",
+        message:
+          "Teknologjia duhet t'i fuqizojë mësuesit, jo t'i lodhë ata. Misioni ynë është ta bëjmë çdo edukator të ndihet i sigurt me mjetet që mund të transformojnë klasat e tyre.",
+        signature: "- Donald Cjapi, CEO & Themelues"
+      },
+      mission: {
+        title: "Misioni Ynë",
+        description:
+          "Të demokratizojmë teknologjinë arsimore duke ofruar mbështetje të qasshme, të përballueshme dhe të zbatueshme për edukatorët në mbarë botën."
+      }
+    },
+    values: {
+      title: "Vlerat Tona",
+      items: [
+        {
+          title: "Praktika mbi gjithçka",
+          description: "Çdo strategji duhet të funksionojë në klasa reale, jo vetëm në teori."
+        },
+        {
+          title: "E përqendruar te mësuesit",
+          description: "E kuptojmë sfidat e përditshme dhe mungesën e kohës me të cilat përballeni."
+        },
+        {
+          title: "Mësim i vazhdueshëm",
+          description: "Teknologjia evoluon dhe ashtu bëjnë edhe metodat dhe rekomandimet tona."
+        }
+      ]
+    },
+    stats: {
+      items: [
+        { number: "7+", label: "Vite përvojë" },
+        { number: "100+", label: "Shkolla të ndihmuara" },
+        { number: "1,000+", label: "Mësues të mbështetur" },
+        { number: "50+", label: "Mjete të testuara" }
+      ]
+    },
+    credentials: {
+      title: "Kredenciale & Partneritete",
+      certifications: {
+        title: "Certifikime",
+        items: [
+          "Google Certified Educator Level 2",
+          "Microsoft Innovative Educator",
+          "Apple Teacher",
+          "ISTE Certified Educator",
+          "Common Sense Digital Citizenship"
+        ]
+      },
+      featured: {
+        title: "Të prezantuar në",
+        items: ["EdTech Magazine", "Teaching Channel", "ASCD"]
+      },
+      partnerships: {
+        title: "Partneritete Shkollash",
+        description:
+          "Jemi krenarë që punojmë me shkolla në mbarë vendin për të pilotuar qasje të reja dhe për të mbledhur reagime reale. Shkollat partnere na ndihmojnë të sigurojmë që çdo strategji të jetë e provuar në klasë dhe e miratuar nga mësuesit.",
+        cta: "Bëhuni partner me ne"
+      }
+    },
+    cta: {
+      title: "Gati të transformoni mësimdhënien tuaj?",
+      description:
+        "Bashkohuni me mijëra mësues që kanë zbuluar se teknologjia nuk ka pse të jetë e mbingarkuar.",
+      primary: "Rezervo një konsultim",
+      secondary: "Shfleto burimet falas"
+    },
+    expertise: {
+      title: "Certifikime & Ekspertizë",
+      items: [
+        "ClassDojo Mentorship",
+        "Wordwall Certified",
+        "Canvas Certification",
+        "Microsoft Educator",
+        "AI Education",
+        "Leadership Management"
+      ]
+    },
+    testimonials: {
+      title: "Çfarë thonë mësuesit",
+      items: [
+        {
+          quote:
+            "Trajnimi për mjetet e AI-së transformoi mënyrën si krijoj plane mësimore. Po kursej orë çdo javë!",
+          name: "Sarah M.",
+          role: "Mësuese e klasës së 5-të"
+        },
+        {
+          quote:
+            "Më në fund dikush që kupton realitetin e klasës dhe nuk shtyn thjesht trendet më të fundit të teknologjisë.",
+          name: "Mike T.",
+          role: "Mësues i shkollës së mesme, shkencë"
+        },
+        {
+          quote:
+            "Shërbimi i konfigurimit të panelit revolucionarizoi menaxhimin e të dhënave në shkollën tonë. E rekomandoj shumë!",
+          name: "Drejtori Johnson",
+          role: "Shkollë fillore"
+        }
+      ]
+    },
+    faq: {
+      title: "Pyetje të shpeshta",
+      items: [
+        {
+          question: "Si qëndroni të përditësuar me EdTech?",
+          answer:
+            "Ne testojmë vazhdimisht mjete të reja, marrim pjesë në konferenca dhe bashkëpunojmë me mësues në mbarë botën për të siguruar që rekomandimet tona të jenë moderne dhe praktike."
+        },
+        {
+          question: "A punoni me shkolla jashtë Vietnamit?",
+          answer:
+            "Po! Edhe pse kemi bazën në Vietnam, ofrojmë konsulencë dhe trajnime online globalisht, me përvojë në sisteme të ndryshme arsimore."
+        },
+        {
+          question: "Çfarë e bën qasjen tuaj ndryshe?",
+          answer:
+            "Ne fokusohemi në zgjidhje praktike dhe të menjëhershme që funksionojnë brenda kufizimeve reale të klasës, jo në praktika teorike më të mira."
+        }
+      ]
+    }
   },
   services: {
     title: "Shërbimet Tona",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -50,25 +50,144 @@ export const vi = {
     }
   },
   about: {
-    title: "Về chúng tôi",
-    subtitle: "Dẫn đầu chuyển đổi số trong giáo dục",
-    mission: "Sứ mệnh của chúng tôi",
-    missionText: "Cách mạng hóa giáo dục thông qua các giải pháp công nghệ đổi mới giúp trao quyền cho các nhà giáo dục, thu hút học sinh và chuyển đổi kết quả học tập.",
-    vision: "Tầm nhìn của chúng tôi",
-    visionText: "Trở thành công ty hàng đầu toàn cầu về công nghệ giáo dục, tạo ra một thế giới nơi mọi học sinh đều có thể tiếp cận trải nghiệm học tập cá nhân hóa, hấp dẫn và hiệu quả.",
-    values: "Giá trị của chúng tôi",
-    innovation: "Đổi mới",
-    innovationText: "Liên tục vượt qua ranh giới với các giải pháp tiên tiến",
-    excellence: "Xuất sắc",
-    excellenceText: "Mang lại chất lượng đặc biệt trong mọi việc chúng tôi làm",
-    integrity: "Chính trực",
-    integrityText: "Xây dựng niềm tin thông qua minh bạch và thực hành đạo đức",
-    collaboration: "Hợp tác",
-    collaborationText: "Làm việc cùng nhau để đạt được kết quả phi thường",
-    teamTitle: "Gặp gỡ đội ngũ lãnh đạo của chúng tôi",
-    ceo: "Giám đốc điều hành",
-    cto: "Giám đốc công nghệ",
-    coo: "Giám đốc vận hành"
+    seo: {
+      title: "Về chúng tôi | SchoolTech Hub",
+      description:
+        "Tìm hiểu về sứ mệnh của SchoolTech Hub nhằm giúp công nghệ giáo dục trở nên dễ tiếp cận. Hơn 7 năm kinh nghiệm, hỗ trợ 100+ trường học, đội ngũ giáo viên được chứng nhận đồng hành cùng hành trình công nghệ của bạn.",
+      keywords:
+        "về SchoolTech Hub, công ty công nghệ giáo dục, tư vấn EdTech, chuyên gia đào tạo giáo viên, chuyên gia công nghệ lớp học",
+      canonical: "https://schooltechhub.com/about"
+    },
+    hero: {
+      title: "Về SchoolTech Hub",
+      subtitle: "Biến công nghệ giáo dục trở nên dễ tiếp cận và thực tiễn cho mọi giáo viên"
+    },
+    story: {
+      title: "Câu chuyện của chúng tôi",
+      paragraphs: [
+        "SchoolTech Hub được thành lập bởi các nhà giáo dục nhìn thấy khoảng cách giữa công nghệ tuyệt vời và những giáo viên đang quá tải. Chúng tôi thu hẹp khoảng cách đó bằng các giải pháp thực tế và đã được chứng minh."
+      ],
+      ceo: {
+        title: "Thông điệp từ CEO",
+        message:
+          "Công nghệ nên trao quyền cho giáo viên chứ không phải làm họ quá tải. Sứ mệnh của chúng tôi là giúp mọi nhà giáo tự tin với những công cụ có thể chuyển đổi lớp học của họ.",
+        signature: "- Donald Cjapi, CEO & Nhà sáng lập"
+      },
+      mission: {
+        title: "Sứ mệnh của chúng tôi",
+        description:
+          "Dân chủ hóa công nghệ giáo dục bằng cách cung cấp hỗ trợ dễ tiếp cận, phải chăng và khả thi cho giáo viên trên toàn thế giới."
+      }
+    },
+    values: {
+      title: "Giá trị cốt lõi",
+      items: [
+        {
+          title: "Thực tiễn là ưu tiên",
+          description: "Mọi chiến lược phải hoạt động trong lớp học thực tế chứ không chỉ trên lý thuyết."
+        },
+        {
+          title: "Lấy giáo viên làm trung tâm",
+          description: "Chúng tôi hiểu những thách thức hàng ngày và áp lực về thời gian mà bạn đối mặt."
+        },
+        {
+          title: "Học hỏi không ngừng",
+          description: "Công nghệ thay đổi và phương pháp cùng khuyến nghị của chúng tôi cũng vậy."
+        }
+      ]
+    },
+    stats: {
+      items: [
+        { number: "7+", label: "Năm kinh nghiệm" },
+        { number: "100+", label: "Trường học đã hỗ trợ" },
+        { number: "1,000+", label: "Giáo viên được đồng hành" },
+        { number: "50+", label: "Công cụ đã thử nghiệm" }
+      ]
+    },
+    credentials: {
+      title: "Chứng chỉ & Quan hệ hợp tác",
+      certifications: {
+        title: "Chứng chỉ",
+        items: [
+          "Google Certified Educator Level 2",
+          "Microsoft Innovative Educator",
+          "Apple Teacher",
+          "ISTE Certified Educator",
+          "Common Sense Digital Citizenship"
+        ]
+      },
+      featured: {
+        title: "Được giới thiệu trên",
+        items: ["EdTech Magazine", "Teaching Channel", "ASCD"]
+      },
+      partnerships: {
+        title: "Đối tác trường học",
+        description:
+          "Chúng tôi tự hào hợp tác với các trường học trên khắp cả nước để thử nghiệm phương pháp mới và thu thập phản hồi thực tế. Những trường đối tác giúp đảm bảo mọi chiến lược đều được kiểm chứng trong lớp học và được giáo viên tin tưởng.",
+        cta: "Hợp tác cùng chúng tôi"
+      }
+    },
+    cta: {
+      title: "Sẵn sàng thay đổi việc giảng dạy của bạn?",
+      description:
+        "Tham gia cùng hàng nghìn giáo viên đã nhận ra rằng công nghệ không nhất thiết phải gây choáng ngợp.",
+      primary: "Đặt lịch tư vấn",
+      secondary: "Xem tài nguyên miễn phí"
+    },
+    expertise: {
+      title: "Chứng chỉ & Chuyên môn",
+      items: [
+        "ClassDojo Mentorship",
+        "Wordwall Certified",
+        "Canvas Certification",
+        "Microsoft Educator",
+        "AI Education",
+        "Leadership Management"
+      ]
+    },
+    testimonials: {
+      title: "Giáo viên nói gì",
+      items: [
+        {
+          quote:
+            "Khóa đào tạo công cụ AI đã thay đổi cách tôi xây dựng giáo án. Tôi tiết kiệm được hàng giờ mỗi tuần!",
+          name: "Sarah M.",
+          role: "Giáo viên lớp 5"
+        },
+        {
+          quote:
+            "Cuối cùng cũng có người hiểu thực tế lớp học và không chỉ chạy theo xu hướng công nghệ mới nhất.",
+          name: "Mike T.",
+          role: "Giáo viên khoa học trung học"
+        },
+        {
+          quote:
+            "Dịch vụ thiết lập bảng điều khiển đã thay đổi hoàn toàn cách trường tôi quản lý dữ liệu. Rất đáng để thử!",
+          name: "Hiệu trưởng Johnson",
+          role: "Trường tiểu học"
+        }
+      ]
+    },
+    faq: {
+      title: "Câu hỏi thường gặp",
+      items: [
+        {
+          question: "Làm thế nào để bạn luôn cập nhật về EdTech?",
+          answer:
+            "Chúng tôi liên tục thử nghiệm công cụ mới, tham dự hội thảo và hợp tác với giáo viên trên toàn thế giới để đảm bảo khuyến nghị luôn hiện đại nhưng vẫn thực tiễn."
+        },
+        {
+          question: "Bạn có làm việc với các trường ngoài Việt Nam không?",
+          answer:
+            "Có! Dù đặt trụ sở tại Việt Nam, chúng tôi cung cấp dịch vụ tư vấn và đào tạo trực tuyến trên toàn cầu với kinh nghiệm ở nhiều hệ thống giáo dục khác nhau."
+        },
+        {
+          question: "Điều gì khiến phương pháp của bạn khác biệt?",
+          answer:
+            "Chúng tôi tập trung vào các giải pháp thiết thực, có thể triển khai ngay, phù hợp với những giới hạn thực tế trong lớp học chứ không chỉ là lý thuyết."
+        }
+      ]
+    }
   },
   services: {
     title: "Dịch vụ của chúng tôi",


### PR DESCRIPTION
## Summary
- Localize the About page hero, story, values, stats, credentials, calls-to-action, testimonials, and FAQ content through the language context.
- Populate English, Albanian, and Vietnamese translation files with structured about-page strings including SEO metadata, story details, stats, CTAs, testimonials, and FAQs.
- Drive mission cards, stats blocks, testimonial tiles, and FAQs from locale data so UI copy swaps cleanly per language.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce9e2f1afc83318ff3e051bcf6d74d