### PR TITLE
Localize Edutech page content and filters

### DIFF
--- a/src/pages/Edutech.tsx
+++ b/src/pages/Edutech.tsx
@@ -2,14 +2,21 @@ import { useState, useEffect } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Search, Clock, Zap, Cpu, BookOpen, Activity } from "lucide-react";
+import { Search, Clock, Cpu, BookOpen, Activity } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { SEO } from "@/components/SEO";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+
+type FilterKey =
+  | "contentType"
+  | "deliveryType"
+  | "payment"
+  | "stage"
+  | "subject"
+  | "instructionType";
 
 const Edutech = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -17,7 +24,7 @@ const Edutech = () => {
   const [selectedCategory, setSelectedCategory] = useState(searchParams.get("category") || "all");
   const [content, setContent] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
-  const [filters, setFilters] = useState({
+  const [filters, setFilters] = useState<Record<FilterKey, string[]>>({
     contentType: searchParams.getAll("contentType") || [],
     deliveryType: searchParams.getAll("deliveryType") || [],
     payment: searchParams.getAll("payment") || [],
@@ -25,23 +32,83 @@ const Edutech = () => {
     subject: searchParams.getAll("subject") || [],
     instructionType: searchParams.getAll("instructionType") || []
   });
-  const { language } = useLanguage();
+  const { language, t } = useLanguage();
 
   const categories = [
-    { value: "all", label: "All" },
-    { value: "Lesson Planning", label: "Lesson Planning" },
-    { value: "Lesson Delivery", label: "Lesson Delivery" },
-    { value: "Engagement", label: "Engagement" },
-    { value: "Evaluation", label: "Evaluation" }
+    { value: "all", label: t.edutech.categories.all },
+    { value: "Lesson Planning", label: t.edutech.categories.lessonPlanning },
+    { value: "Lesson Delivery", label: t.edutech.categories.lessonDelivery },
+    { value: "Engagement", label: t.edutech.categories.engagement },
+    { value: "Evaluation", label: t.edutech.categories.evaluation }
   ];
 
-  const filterOptions = {
-    contentType: ["tutorial", "teaching_technique", "activity"],
-    deliveryType: ["In-class", "Online", "Hybrid", "Self-paced", "Distance Learning", "Live"],
-    payment: ["Free", "Freemium", "Paid", "Free Trial", "Education Discount"],
-    stage: ["Early Childhood", "Pre-K", "Kindergarten", "Lower Primary", "Upper Primary", "Primary", "Secondary", "High School", "K-12", "K-5"],
-    subject: ["Phonics", "Reading", "Writing", "Grammar", "Spelling", "Vocabulary", "English/ELA", "Math", "Science", "Biology", "Chemistry", "Physics", "Earth Science", "ICT", "STEM", "STEAM"],
-    instructionType: ["Direct Instruction", "Differentiated Instruction", "Inquiry-Based Learning", "Project-Based Learning", "Problem-Based Learning", "Play-Based Learning", "Game-Based Learning", "Gamification", "Cooperative Learning", "Experiential Learning", "Design Thinking", "Socratic Seminar", "Station Rotation", "Blended Learning"]
+  const filterOptions: Record<FilterKey, { value: string; label: string }[]> = {
+    contentType: [
+      { value: "tutorial", label: t.edutech.filters.groups.contentType.options.tutorial },
+      { value: "teaching_technique", label: t.edutech.filters.groups.contentType.options.teachingTechnique },
+      { value: "activity", label: t.edutech.filters.groups.contentType.options.activity }
+    ],
+    deliveryType: [
+      { value: "In-class", label: t.edutech.filters.groups.deliveryType.options.inClass },
+      { value: "Online", label: t.edutech.filters.groups.deliveryType.options.online },
+      { value: "Hybrid", label: t.edutech.filters.groups.deliveryType.options.hybrid },
+      { value: "Self-paced", label: t.edutech.filters.groups.deliveryType.options.selfPaced },
+      { value: "Distance Learning", label: t.edutech.filters.groups.deliveryType.options.distanceLearning },
+      { value: "Live", label: t.edutech.filters.groups.deliveryType.options.live }
+    ],
+    payment: [
+      { value: "Free", label: t.edutech.filters.groups.payment.options.free },
+      { value: "Freemium", label: t.edutech.filters.groups.payment.options.freemium },
+      { value: "Paid", label: t.edutech.filters.groups.payment.options.paid },
+      { value: "Free Trial", label: t.edutech.filters.groups.payment.options.freeTrial },
+      { value: "Education Discount", label: t.edutech.filters.groups.payment.options.educationDiscount }
+    ],
+    stage: [
+      { value: "Early Childhood", label: t.edutech.filters.groups.stage.options.earlyChildhood },
+      { value: "Pre-K", label: t.edutech.filters.groups.stage.options.preK },
+      { value: "Kindergarten", label: t.edutech.filters.groups.stage.options.kindergarten },
+      { value: "Lower Primary", label: t.edutech.filters.groups.stage.options.lowerPrimary },
+      { value: "Upper Primary", label: t.edutech.filters.groups.stage.options.upperPrimary },
+      { value: "Primary", label: t.edutech.filters.groups.stage.options.primary },
+      { value: "Secondary", label: t.edutech.filters.groups.stage.options.secondary },
+      { value: "High School", label: t.edutech.filters.groups.stage.options.highSchool },
+      { value: "K-12", label: t.edutech.filters.groups.stage.options.k12 },
+      { value: "K-5", label: t.edutech.filters.groups.stage.options.k5 }
+    ],
+    subject: [
+      { value: "Phonics", label: t.edutech.filters.groups.subject.options.phonics },
+      { value: "Reading", label: t.edutech.filters.groups.subject.options.reading },
+      { value: "Writing", label: t.edutech.filters.groups.subject.options.writing },
+      { value: "Grammar", label: t.edutech.filters.groups.subject.options.grammar },
+      { value: "Spelling", label: t.edutech.filters.groups.subject.options.spelling },
+      { value: "Vocabulary", label: t.edutech.filters.groups.subject.options.vocabulary },
+      { value: "English/ELA", label: t.edutech.filters.groups.subject.options.englishEla },
+      { value: "Math", label: t.edutech.filters.groups.subject.options.math },
+      { value: "Science", label: t.edutech.filters.groups.subject.options.science },
+      { value: "Biology", label: t.edutech.filters.groups.subject.options.biology },
+      { value: "Chemistry", label: t.edutech.filters.groups.subject.options.chemistry },
+      { value: "Physics", label: t.edutech.filters.groups.subject.options.physics },
+      { value: "Earth Science", label: t.edutech.filters.groups.subject.options.earthScience },
+      { value: "ICT", label: t.edutech.filters.groups.subject.options.ict },
+      { value: "STEM", label: t.edutech.filters.groups.subject.options.stem },
+      { value: "STEAM", label: t.edutech.filters.groups.subject.options.steam }
+    ],
+    instructionType: [
+      { value: "Direct Instruction", label: t.edutech.filters.groups.instructionType.options.directInstruction },
+      { value: "Differentiated Instruction", label: t.edutech.filters.groups.instructionType.options.differentiatedInstruction },
+      { value: "Inquiry-Based Learning", label: t.edutech.filters.groups.instructionType.options.inquiryBasedLearning },
+      { value: "Project-Based Learning", label: t.edutech.filters.groups.instructionType.options.projectBasedLearning },
+      { value: "Problem-Based Learning", label: t.edutech.filters.groups.instructionType.options.problemBasedLearning },
+      { value: "Play-Based Learning", label: t.edutech.filters.groups.instructionType.options.playBasedLearning },
+      { value: "Game-Based Learning", label: t.edutech.filters.groups.instructionType.options.gameBasedLearning },
+      { value: "Gamification", label: t.edutech.filters.groups.instructionType.options.gamification },
+      { value: "Cooperative Learning", label: t.edutech.filters.groups.instructionType.options.cooperativeLearning },
+      { value: "Experiential Learning", label: t.edutech.filters.groups.instructionType.options.experientialLearning },
+      { value: "Design Thinking", label: t.edutech.filters.groups.instructionType.options.designThinking },
+      { value: "Socratic Seminar", label: t.edutech.filters.groups.instructionType.options.socraticSeminar },
+      { value: "Station Rotation", label: t.edutech.filters.groups.instructionType.options.stationRotation },
+      { value: "Blended Learning", label: t.edutech.filters.groups.instructionType.options.blendedLearning }
+    ]
   };
 
   const contentTypeIcons = {
@@ -50,10 +117,26 @@ const Edutech = () => {
     activity: <Activity className="h-4 w-4" />
   };
 
-  const contentTypeLabels = {
-    tutorial: "Tutorial",
-    teaching_technique: "Teaching Technique",
-    activity: "Activity"
+  const contentTypeLabels: Record<string, string> = {
+    tutorial: t.edutech.filters.groups.contentType.options.tutorial,
+    teaching_technique: t.edutech.filters.groups.contentType.options.teachingTechnique,
+    activity: t.edutech.filters.groups.contentType.options.activity
+  };
+
+  const filterOptionLabelMap = Object.entries(filterOptions).reduce(
+    (acc, [key, options]) => {
+      acc[key as FilterKey] = options.reduce<Record<string, string>>((optionAcc, option) => {
+        optionAcc[option.value] = option.label;
+        return optionAcc;
+      }, {});
+      return acc;
+    },
+    {} as Record<FilterKey, Record<string, string>>
+  );
+
+  const getLocalizedFilterValue = (filterType: FilterKey, value?: string | null) => {
+    if (!value) return value;
+    return filterOptionLabelMap[filterType][value] ?? value;
   };
 
   useEffect(() => {
@@ -112,7 +195,7 @@ const Edutech = () => {
     }
   };
 
-  const toggleFilter = (filterType: keyof typeof filters, value: string) => {
+  const toggleFilter = (filterType: FilterKey, value: string) => {
     const newFilters = {
       ...filters,
       [filterType]: filters[filterType].includes(value)
@@ -145,20 +228,20 @@ const Edutech = () => {
         canonicalUrl="https://schooltechhub.com/edutech"
       />
       <main className="flex-1">
-        <div className="container py-12">
-          <div className="mb-8">
-            <h1 className="text-4xl font-bold mb-2">Edutech Hub</h1>
-            <p className="text-muted-foreground">
-              Learn new technologies, teaching techniques, activities, and AI lesson planning.
-            </p>
-          </div>
+          <div className="container py-12">
+            <div className="mb-8">
+              <h1 className="text-4xl font-bold mb-2">{t.edutech.title}</h1>
+              <p className="text-muted-foreground">
+                {t.edutech.subtitle}
+              </p>
+            </div>
 
           <div className="mb-8">
             <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" />
               <Input
                 type="text"
-                placeholder="Search tutorials, techniques, activities..."
+                placeholder={t.edutech.searchPlaceholder}
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="pl-10"
@@ -178,166 +261,180 @@ const Edutech = () => {
 
           <div className="grid lg:grid-cols-4 gap-8">
             <div className="lg:col-span-1">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Filters</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                  <div>
-                    <h4 className="font-medium mb-3">Blog Type</h4>
-                    {filterOptions.contentType.map((type) => (
-                      <label key={type} className="flex items-center space-x-2 mb-2">
-                        <input
-                          type="checkbox"
-                          checked={filters.contentType.includes(type)}
-                          onChange={() => toggleFilter("contentType", type)}
-                          className="rounded border-gray-300"
-                        />
-                        <span className="text-sm flex items-center gap-1">
-                          {contentTypeIcons[type as keyof typeof contentTypeIcons]}
-                          {contentTypeLabels[type as keyof typeof contentTypeLabels]}
-                        </span>
-                      </label>
-                    ))}
-                  </div>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>{t.edutech.filters.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-6">
+                    <div>
+                      <h4 className="font-medium mb-3">{t.edutech.filters.groups.contentType.title}</h4>
+                      {filterOptions.contentType.map((option) => (
+                        <label key={option.value} className="flex items-center space-x-2 mb-2">
+                          <input
+                            type="checkbox"
+                            checked={filters.contentType.includes(option.value)}
+                            onChange={() => toggleFilter("contentType", option.value)}
+                            className="rounded border-gray-300"
+                          />
+                          <span className="text-sm flex items-center gap-1">
+                            {contentTypeIcons[option.value as keyof typeof contentTypeIcons]}
+                            {option.label}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
 
-                  <div>
-                    <h4 className="font-medium mb-3">Delivery Type</h4>
-                    {filterOptions.deliveryType.map((type) => (
-                      <label key={type} className="flex items-center space-x-2 mb-2">
-                        <input
-                          type="checkbox"
-                          checked={filters.deliveryType.includes(type)}
-                          onChange={() => toggleFilter("deliveryType", type)}
-                          className="rounded border-gray-300"
-                        />
-                        <span className="text-sm">{type}</span>
-                      </label>
-                    ))}
-                  </div>
+                    <div>
+                      <h4 className="font-medium mb-3">{t.edutech.filters.groups.deliveryType.title}</h4>
+                      {filterOptions.deliveryType.map((option) => (
+                        <label key={option.value} className="flex items-center space-x-2 mb-2">
+                          <input
+                            type="checkbox"
+                            checked={filters.deliveryType.includes(option.value)}
+                            onChange={() => toggleFilter("deliveryType", option.value)}
+                            className="rounded border-gray-300"
+                          />
+                          <span className="text-sm">{option.label}</span>
+                        </label>
+                      ))}
+                    </div>
 
-                  <div>
-                    <h4 className="font-medium mb-3">Payment</h4>
-                    {filterOptions.payment.map((type) => (
-                      <label key={type} className="flex items-center space-x-2 mb-2">
-                        <input
-                          type="checkbox"
-                          checked={filters.payment.includes(type)}
-                          onChange={() => toggleFilter("payment", type)}
-                          className="rounded border-gray-300"
-                        />
-                        <span className="text-sm">{type}</span>
-                      </label>
-                    ))}
-                  </div>
+                    <div>
+                      <h4 className="font-medium mb-3">{t.edutech.filters.groups.payment.title}</h4>
+                      {filterOptions.payment.map((option) => (
+                        <label key={option.value} className="flex items-center space-x-2 mb-2">
+                          <input
+                            type="checkbox"
+                            checked={filters.payment.includes(option.value)}
+                            onChange={() => toggleFilter("payment", option.value)}
+                            className="rounded border-gray-300"
+                          />
+                          <span className="text-sm">{option.label}</span>
+                        </label>
+                      ))}
+                    </div>
 
-                  <div>
-                    <h4 className="font-medium mb-3">Stage</h4>
-                    {filterOptions.stage.map((stage) => (
-                      <label key={stage} className="flex items-center space-x-2 mb-2">
-                        <input
-                          type="checkbox"
-                          checked={filters.stage.includes(stage)}
-                          onChange={() => toggleFilter("stage", stage)}
-                          className="rounded border-gray-300"
-                        />
-                        <span className="text-sm">{stage}</span>
-                      </label>
-                    ))}
-                  </div>
+                    <div>
+                      <h4 className="font-medium mb-3">{t.edutech.filters.groups.stage.title}</h4>
+                      {filterOptions.stage.map((option) => (
+                        <label key={option.value} className="flex items-center space-x-2 mb-2">
+                          <input
+                            type="checkbox"
+                            checked={filters.stage.includes(option.value)}
+                            onChange={() => toggleFilter("stage", option.value)}
+                            className="rounded border-gray-300"
+                          />
+                          <span className="text-sm">{option.label}</span>
+                        </label>
+                      ))}
+                    </div>
 
-                  <div>
-                    <h4 className="font-medium mb-3">Subject</h4>
-                    {filterOptions.subject.map((subject) => (
-                      <label key={subject} className="flex items-center space-x-2 mb-2">
-                        <input
-                          type="checkbox"
-                          checked={filters.subject.includes(subject)}
-                          onChange={() => toggleFilter("subject", subject)}
-                          className="rounded border-gray-300"
-                        />
-                        <span className="text-sm">{subject}</span>
-                      </label>
-                    ))}
-                  </div>
+                    <div>
+                      <h4 className="font-medium mb-3">{t.edutech.filters.groups.subject.title}</h4>
+                      {filterOptions.subject.map((option) => (
+                        <label key={option.value} className="flex items-center space-x-2 mb-2">
+                          <input
+                            type="checkbox"
+                            checked={filters.subject.includes(option.value)}
+                            onChange={() => toggleFilter("subject", option.value)}
+                            className="rounded border-gray-300"
+                          />
+                          <span className="text-sm">{option.label}</span>
+                        </label>
+                      ))}
+                    </div>
 
-                  <div>
-                    <h4 className="font-medium mb-3">Instruction Type</h4>
-                    {filterOptions.instructionType.map((type) => (
-                      <label key={type} className="flex items-center space-x-2 mb-2">
-                        <input
-                          type="checkbox"
-                          checked={filters.instructionType.includes(type)}
-                          onChange={() => toggleFilter("instructionType", type)}
-                          className="rounded border-gray-300"
-                        />
-                        <span className="text-sm">{type}</span>
-                      </label>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
+                    <div>
+                      <h4 className="font-medium mb-3">{t.edutech.filters.groups.instructionType.title}</h4>
+                      {filterOptions.instructionType.map((option) => (
+                        <label key={option.value} className="flex items-center space-x-2 mb-2">
+                          <input
+                            type="checkbox"
+                            checked={filters.instructionType.includes(option.value)}
+                            onChange={() => toggleFilter("instructionType", option.value)}
+                            className="rounded border-gray-300"
+                          />
+                          <span className="text-sm">{option.label}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
             </div>
 
-            <div className="lg:col-span-3">
-              {loading ? (
-                <div className="flex justify-center items-center h-64">
-                  <p className="text-muted-foreground">Loading content...</p>
-                </div>
-              ) : content.length === 0 ? (
-                <div className="text-center py-12">
-                  <p className="text-muted-foreground">No content found matching your criteria.</p>
-                </div>
-              ) : (
-                <div className="grid md:grid-cols-2 gap-6">
-                  {content.map((item) => (
-                    <Card key={item.id} className="hover:shadow-lg transition-shadow">
-                      <CardContent className="p-6">
-                        <div className="flex justify-between items-start mb-4">
-                          <div className="flex gap-2">
-                            <Badge variant="secondary" className="flex items-center gap-1">
-                              {contentTypeIcons[item.content_type as keyof typeof contentTypeIcons]}
-                              {contentTypeLabels[item.content_type as keyof typeof contentTypeLabels]}
-                            </Badge>
-                            {item.prep_level && (
-                              <Badge className={getPrepLevelColor(item.prep_level)}>
-                                {item.prep_level}
+              <div className="lg:col-span-3">
+                {loading ? (
+                  <div className="flex justify-center items-center h-64">
+                    <p className="text-muted-foreground">{t.edutech.states.loading}</p>
+                  </div>
+                ) : content.length === 0 ? (
+                  <div className="text-center py-12">
+                    <p className="text-muted-foreground">{t.edutech.states.empty}</p>
+                  </div>
+                ) : (
+                  <div className="grid md:grid-cols-2 gap-6">
+                    {content.map((item) => (
+                      <Card key={item.id} className="hover:shadow-lg transition-shadow">
+                        <CardContent className="p-6">
+                          <div className="flex justify-between items-start mb-4">
+                            <div className="flex gap-2">
+                              <Badge variant="secondary" className="flex items-center gap-1">
+                                {contentTypeIcons[item.content_type as keyof typeof contentTypeIcons]}
+                                {contentTypeLabels[item.content_type] ?? item.content_type}
+                              </Badge>
+                              {item.prep_level && (
+                                <Badge className={getPrepLevelColor(item.prep_level)}>
+                                  {item.prep_level}
+                                </Badge>
+                              )}
+                            </div>
+                            {item.delivery_type && (
+                              <Badge variant="outline">
+                                {getLocalizedFilterValue("deliveryType", item.delivery_type)}
                               </Badge>
                             )}
                           </div>
-                          {item.delivery_type && (
-                            <Badge variant="outline">{item.delivery_type}</Badge>
+
+                          <h3 className="text-lg font-semibold mb-2">
+                            <Link
+                              to={getLocalizedPath(`/edutech/${item.slug}`, language)}
+                              className="hover:text-primary"
+                            >
+                              {item.title}
+                            </Link>
+                          </h3>
+
+                          {item.subtitle && (
+                            <p className="text-sm text-muted-foreground mb-2">{item.subtitle}</p>
                           )}
-                        </div>
-                        
-                        <h3 className="text-lg font-semibold mb-2">
-                          <Link
-                            to={getLocalizedPath(`/edutech/${item.slug}`, language)}
-                            className="hover:text-primary"
-                          >
-                            {item.title}
-                          </Link>
-                        </h3>
-                        
-                        {item.subtitle && (
-                          <p className="text-sm text-muted-foreground mb-2">{item.subtitle}</p>
-                        )}
-                        
-                        <p className="text-sm text-muted-foreground mb-4">
-                          {item.excerpt || "Click to learn more..."}
-                        </p>
-                        
-                        <div className="flex flex-wrap gap-2 mb-4">
-                          {item.stage && <Badge variant="outline">{item.stage}</Badge>}
-                          {item.subject && <Badge variant="outline">{item.subject}</Badge>}
-                          {item.payment && <Badge variant="outline">{item.payment}</Badge>}
-                          {item.time_required && (
-                            <Badge variant="outline" className="flex items-center gap-1">
-                              <Clock className="h-3 w-3" />
-                              {item.time_required}
-                            </Badge>
-                          )}
-                        </div>
+
+                          <p className="text-sm text-muted-foreground mb-4">
+                            {item.excerpt || t.edutech.cta.learnMore}
+                          </p>
+
+                          <div className="flex flex-wrap gap-2 mb-4">
+                            {item.stage && (
+                              <Badge variant="outline">
+                                {getLocalizedFilterValue("stage", item.stage)}
+                              </Badge>
+                            )}
+                            {item.subject && (
+                              <Badge variant="outline">
+                                {getLocalizedFilterValue("subject", item.subject)}
+                              </Badge>
+                            )}
+                            {item.payment && (
+                              <Badge variant="outline">
+                                {getLocalizedFilterValue("payment", item.payment)}
+                              </Badge>
+                            )}
+                            {item.time_required && (
+                              <Badge variant="outline" className="flex items-center gap-1">
+                                <Clock className="h-3 w-3" />
+                                {item.time_required}
+                              </Badge>
+                            )}
+                          </div>
                         
                         {item.tags && item.tags.length > 0 && (
                           <div className="flex flex-wrap gap-1">

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -221,17 +221,112 @@ export const en = {
     subtitle: "Find answers to common questions about our services"
   },
   edutech: {
-    title: "Educational Technology Resources",
-    subtitle: "Explore our comprehensive collection of EdTech tools and resources",
-    searchPlaceholder: "Search resources...",
-    filterByType: "Filter by Type",
-    filterByCategory: "Filter by Category",
-    filterByAudience: "Filter by Audience",
-    filterByPayment: "Filter by Payment",
-    filterByPlatform: "Filter by Platform",
-    free: "Free",
-    visit: "Visit",
-    learnMore: "Learn More"
+    title: "Edutech Hub",
+    subtitle: "Learn new technologies, teaching techniques, activities, and AI lesson planning.",
+    searchPlaceholder: "Search tutorials, techniques, activities...",
+    categories: {
+      all: "All",
+      lessonPlanning: "Lesson Planning",
+      lessonDelivery: "Lesson Delivery",
+      engagement: "Engagement",
+      evaluation: "Evaluation"
+    },
+    filters: {
+      title: "Filters",
+      groups: {
+        contentType: {
+          title: "Blog Type",
+          options: {
+            tutorial: "Tutorial",
+            teachingTechnique: "Teaching Technique",
+            activity: "Activity"
+          }
+        },
+        deliveryType: {
+          title: "Delivery Type",
+          options: {
+            inClass: "In-class",
+            online: "Online",
+            hybrid: "Hybrid",
+            selfPaced: "Self-paced",
+            distanceLearning: "Distance Learning",
+            live: "Live"
+          }
+        },
+        payment: {
+          title: "Payment",
+          options: {
+            free: "Free",
+            freemium: "Freemium",
+            paid: "Paid",
+            freeTrial: "Free Trial",
+            educationDiscount: "Education Discount"
+          }
+        },
+        stage: {
+          title: "Stage",
+          options: {
+            earlyChildhood: "Early Childhood",
+            preK: "Pre-K",
+            kindergarten: "Kindergarten",
+            lowerPrimary: "Lower Primary",
+            upperPrimary: "Upper Primary",
+            primary: "Primary",
+            secondary: "Secondary",
+            highSchool: "High School",
+            k12: "K-12",
+            k5: "K-5"
+          }
+        },
+        subject: {
+          title: "Subject",
+          options: {
+            phonics: "Phonics",
+            reading: "Reading",
+            writing: "Writing",
+            grammar: "Grammar",
+            spelling: "Spelling",
+            vocabulary: "Vocabulary",
+            englishEla: "English/ELA",
+            math: "Math",
+            science: "Science",
+            biology: "Biology",
+            chemistry: "Chemistry",
+            physics: "Physics",
+            earthScience: "Earth Science",
+            ict: "ICT",
+            stem: "STEM",
+            steam: "STEAM"
+          }
+        },
+        instructionType: {
+          title: "Instruction Type",
+          options: {
+            directInstruction: "Direct Instruction",
+            differentiatedInstruction: "Differentiated Instruction",
+            inquiryBasedLearning: "Inquiry-Based Learning",
+            projectBasedLearning: "Project-Based Learning",
+            problemBasedLearning: "Problem-Based Learning",
+            playBasedLearning: "Play-Based Learning",
+            gameBasedLearning: "Game-Based Learning",
+            gamification: "Gamification",
+            cooperativeLearning: "Cooperative Learning",
+            experientialLearning: "Experiential Learning",
+            designThinking: "Design Thinking",
+            socraticSeminar: "Socratic Seminar",
+            stationRotation: "Station Rotation",
+            blendedLearning: "Blended Learning"
+          }
+        }
+      }
+    },
+    states: {
+      loading: "Loading content...",
+      empty: "No content found matching your criteria."
+    },
+    cta: {
+      learnMore: "Click to learn more..."
+    }
   },
   teacherDiary: {
     title: "Teacher's Digital Diary",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -221,17 +221,112 @@ export const sq = {
     subtitle: "Gjeni përgjigje për pyetjet e zakonshme rreth shërbimeve tona"
   },
   edutech: {
-    title: "Burimet e Teknologjisë Arsimore",
-    subtitle: "Eksploroni koleksionin tonë gjithëpërfshirës të mjeteve dhe burimeve EdTech",
-    searchPlaceholder: "Kërko burime...",
-    filterByType: "Filtro sipas Tipit",
-    filterByCategory: "Filtro sipas Kategorisë",
-    filterByAudience: "Filtro sipas Audiencës",
-    filterByPayment: "Filtro sipas Pagesës",
-    filterByPlatform: "Filtro sipas Platformës",
-    free: "Falas",
-    visit: "Vizito",
-    learnMore: "Mëso Më Shumë"
+    title: "Qendra Edutech",
+    subtitle: "Mësoni teknologji të reja, teknika mësimdhënieje, aktivitete dhe planifikim mësimor me AI.",
+    searchPlaceholder: "Kërko tutoriale, teknika, aktivitete...",
+    categories: {
+      all: "Të gjitha",
+      lessonPlanning: "Planifikim mësimi",
+      lessonDelivery: "Realizim mësimi",
+      engagement: "Angazhim",
+      evaluation: "Vlerësim"
+    },
+    filters: {
+      title: "Filtrat",
+      groups: {
+        contentType: {
+          title: "Lloji i blogut",
+          options: {
+            tutorial: "Tutorial",
+            teachingTechnique: "Teknikë mësimdhënieje",
+            activity: "Aktivitet"
+          }
+        },
+        deliveryType: {
+          title: "Lloji i dorëzimit",
+          options: {
+            inClass: "Në klasë",
+            online: "Online",
+            hybrid: "Hibrid",
+            selfPaced: "Në ritmin vetjak",
+            distanceLearning: "Mësim në distancë",
+            live: "Drejtpërdrejt"
+          }
+        },
+        payment: {
+          title: "Pagesa",
+          options: {
+            free: "Falas",
+            freemium: "Freemium",
+            paid: "Me pagesë",
+            freeTrial: "Provë falas",
+            educationDiscount: "Zbritje për arsim"
+          }
+        },
+        stage: {
+          title: "Niveli",
+          options: {
+            earlyChildhood: "Fëmijëria e hershme",
+            preK: "Para-K",
+            kindergarten: "Kopshti",
+            lowerPrimary: "Cikli i ulët",
+            upperPrimary: "Cikli i lartë",
+            primary: "Fillore",
+            secondary: "Sekondare",
+            highSchool: "Shkollë e mesme",
+            k12: "K-12",
+            k5: "K-5"
+          }
+        },
+        subject: {
+          title: "Lënda",
+          options: {
+            phonics: "Fonetikë",
+            reading: "Lexim",
+            writing: "Shkrim",
+            grammar: "Gramatikë",
+            spelling: "Drejtshkrim",
+            vocabulary: "Fjalor",
+            englishEla: "Anglisht/ELA",
+            math: "Matematikë",
+            science: "Shkencë",
+            biology: "Biologji",
+            chemistry: "Kimi",
+            physics: "Fizikë",
+            earthScience: "Shkencat e Tokës",
+            ict: "TIK",
+            stem: "STEM",
+            steam: "STEAM"
+          }
+        },
+        instructionType: {
+          title: "Lloji i mësimdhënies",
+          options: {
+            directInstruction: "Mësim i drejtpërdrejtë",
+            differentiatedInstruction: "Mësim i diferencuar",
+            inquiryBasedLearning: "Mësim i bazuar në hulumtim",
+            projectBasedLearning: "Mësim i bazuar në projekte",
+            problemBasedLearning: "Mësim i bazuar në probleme",
+            playBasedLearning: "Mësim i bazuar në lojë",
+            gameBasedLearning: "Mësim i bazuar në lojëra",
+            gamification: "Gamifikim",
+            cooperativeLearning: "Mësim bashkëpunues",
+            experientialLearning: "Mësim përvojues",
+            designThinking: "Mendim projektues",
+            socraticSeminar: "Seminar sokratik",
+            stationRotation: "Rotacion stacionesh",
+            blendedLearning: "Mësim i kombinuar"
+          }
+        }
+      }
+    },
+    states: {
+      loading: "Duke ngarkuar përmbajtjen...",
+      empty: "Nuk u gjet përmbajtje që përputhet me kriteret tuaja."
+    },
+    cta: {
+      learnMore: "Kliko për të mësuar më shumë..."
+    }
   },
   teacherDiary: {
     title: "Ditari Dixhital i Mësuesit",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -221,17 +221,112 @@ export const vi = {
     subtitle: "Tìm câu trả lời cho các câu hỏi phổ biến về dịch vụ của chúng tôi"
   },
   edutech: {
-    title: "Tài nguyên công nghệ giáo dục",
-    subtitle: "Khám phá bộ sưu tập toàn diện các công cụ và tài nguyên EdTech của chúng tôi",
-    searchPlaceholder: "Tìm kiếm tài nguyên...",
-    filterByType: "Lọc theo loại",
-    filterByCategory: "Lọc theo danh mục",
-    filterByAudience: "Lọc theo đối tượng",
-    filterByPayment: "Lọc theo thanh toán",
-    filterByPlatform: "Lọc theo nền tảng",
-    free: "Miễn phí",
-    visit: "Truy cập",
-    learnMore: "Tìm hiểu thêm"
+    title: "Trung tâm Edutech",
+    subtitle: "Học công nghệ mới, kỹ thuật giảng dạy, hoạt động và lập kế hoạch bài học bằng AI.",
+    searchPlaceholder: "Tìm kiếm hướng dẫn, kỹ thuật, hoạt động...",
+    categories: {
+      all: "Tất cả",
+      lessonPlanning: "Lập kế hoạch bài học",
+      lessonDelivery: "Triển khai bài học",
+      engagement: "Tương tác",
+      evaluation: "Đánh giá"
+    },
+    filters: {
+      title: "Bộ lọc",
+      groups: {
+        contentType: {
+          title: "Loại nội dung",
+          options: {
+            tutorial: "Hướng dẫn",
+            teachingTechnique: "Kỹ thuật giảng dạy",
+            activity: "Hoạt động"
+          }
+        },
+        deliveryType: {
+          title: "Hình thức triển khai",
+          options: {
+            inClass: "Tại lớp",
+            online: "Trực tuyến",
+            hybrid: "Kết hợp",
+            selfPaced: "Tự học theo tiến độ",
+            distanceLearning: "Học từ xa",
+            live: "Trực tiếp"
+          }
+        },
+        payment: {
+          title: "Thanh toán",
+          options: {
+            free: "Miễn phí",
+            freemium: "Freemium",
+            paid: "Trả phí",
+            freeTrial: "Dùng thử miễn phí",
+            educationDiscount: "Ưu đãi giáo dục"
+          }
+        },
+        stage: {
+          title: "Cấp học",
+          options: {
+            earlyChildhood: "Mầm non sớm",
+            preK: "Mẫu giáo lớn (Pre-K)",
+            kindergarten: "Mẫu giáo",
+            lowerPrimary: "Tiểu học đầu cấp",
+            upperPrimary: "Tiểu học cuối cấp",
+            primary: "Tiểu học",
+            secondary: "Trung học cơ sở",
+            highSchool: "Trung học phổ thông",
+            k12: "K-12",
+            k5: "K-5"
+          }
+        },
+        subject: {
+          title: "Môn học",
+          options: {
+            phonics: "Ngữ âm",
+            reading: "Đọc hiểu",
+            writing: "Viết",
+            grammar: "Ngữ pháp",
+            spelling: "Chính tả",
+            vocabulary: "Từ vựng",
+            englishEla: "Tiếng Anh/ELA",
+            math: "Toán",
+            science: "Khoa học",
+            biology: "Sinh học",
+            chemistry: "Hóa học",
+            physics: "Vật lý",
+            earthScience: "Khoa học Trái Đất",
+            ict: "CNTT",
+            stem: "STEM",
+            steam: "STEAM"
+          }
+        },
+        instructionType: {
+          title: "Phương pháp giảng dạy",
+          options: {
+            directInstruction: "Giảng dạy trực tiếp",
+            differentiatedInstruction: "Giảng dạy phân hóa",
+            inquiryBasedLearning: "Học tập dựa trên tìm tòi",
+            projectBasedLearning: "Học tập dựa trên dự án",
+            problemBasedLearning: "Học tập dựa trên vấn đề",
+            playBasedLearning: "Học qua trò chơi",
+            gameBasedLearning: "Học dựa trên trò chơi",
+            gamification: "Gamification",
+            cooperativeLearning: "Học tập hợp tác",
+            experientialLearning: "Học tập trải nghiệm",
+            designThinking: "Tư duy thiết kế",
+            socraticSeminar: "Thảo luận kiểu Socrates",
+            stationRotation: "Luân chuyển trạm",
+            blendedLearning: "Học tập kết hợp"
+          }
+        }
+      }
+    },
+    states: {
+      loading: "Đang tải nội dung...",
+      empty: "Không tìm thấy nội dung phù hợp với tiêu chí của bạn."
+    },
+    cta: {
+      learnMore: "Nhấp để tìm hiểu thêm..."
+    }
   },
   teacherDiary: {
     title: "Nhật ký số của giáo viên",


### PR DESCRIPTION
## Summary
- localize the Edutech hub hero, search field, tabs, and filter controls via the language context and translation metadata
- add localized fallback labels for filter badges and CTA copy when rendering content cards
- expand the English, Albanian, and Vietnamese translation dictionaries with an edutech namespace covering categories, filter groups, state messages, and CTA text

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9e1ec6248331b659d6c3416ae254