### PR TITLE
Refactor services page translations

### DIFF
--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,9 +1,8 @@
-import { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { CheckCircle, Clock, Users, Target, Calendar, Shield, GraduationCap, ArrowRight, FileText } from "lucide-react";
+import { CheckCircle, Clock, Users, Target, Calendar, Shield, FileText } from "lucide-react";
 import { Link } from "react-router-dom";
 import { SEO } from "@/components/SEO";
 import { StructuredData } from "@/components/StructuredData";
@@ -12,97 +11,36 @@ import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 // Import removed - useContent hook no longer exists
 
 const Services = () => {
-  const { language } = useLanguage();
+  const { language, t } = useLanguage();
 
-  const services = [
-    {
-      id: "consultation",
-      title: "1:1 Coaching",
-      price: "$30/session",
-      duration: "60 minutes",
-      description: "Get personalized support for your specific classroom tech challenges",
-      features: [
-        "Customized to your exact needs",
-        "Screen sharing for hands-on help",
-        "Action plan you can use tomorrow",
-        "Follow-up resources included",
-        "Recording available for review",
-      ],
-      ideal: "Teachers who need quick, targeted solutions",
-    },
-    {
-      id: "whole-staff-pd",
-      title: "Whole-Staff PD Program",
-      price: "$60",
-      duration: "per session",
-      description: "Up to 30 staff members (larger groups possible with prior arrangement). Schools can choose any edtech topic most relevant to their needs.",
-      features: [
-        "60-90 minutes of live, engaging professional development",
-        "Hands-on activities and demonstrations",
-        "Differentiated by staff experience level (beginners to advanced)",
-        "School receives a digital resource hub (guides, templates, links)",
-        "30-day follow-up Q&A session (online) for continued support",
-      ],
-      ideal: "Schools wanting affordable, practical training to build staff confidence in technology",
-    },
-    {
-      id: "custom-dashboard",
-      title: "Custom School Dashboard & Tracker Setup",
-      price: "$300",
-      duration: "flat rate",
-      description: "Design and implement custom digital dashboards tailored to your school's needs",
-      features: [
-        "60-minute consultation to identify your priorities and current tools",
-        "Build centralized dashboards (Google Sheets, Airtable, Notion, or Supabase)",
-        "Student performance trackers (grades, attendance, behavior, SEL)",
-        "Teacher workflow dashboards & leadership dashboards",
-        "Ready-to-use templates and staff training",
-        "30-day implementation support (email or video check-ins)",
-      ],
-      ideal: "Schools that want to improve organization, communication, and data-driven decision making",
-    },
-  ];
+  const pageContent = t.services.page;
+  const services = t.services.packages;
+  const guarantee = t.services.guarantee;
+  const steps = t.services.steps;
+  const faqs = t.services.faq;
 
-  const faqs = [
-    {
-      question: "What devices do I need?",
-      answer: "Any device with internet access works! We'll adapt to whatever you have - Chromebooks, iPads, laptops, or even smartphones.",
-    },
-    {
-      question: "What about school filters and restrictions?",
-      answer: "We specialize in working within school constraints. We'll find solutions that work with your existing security settings.",
-    },
-    {
-      question: "How do you handle student privacy?",
-      answer: "All recommendations are COPPA and FERPA compliant. We prioritize tools with strong privacy policies and minimal data collection.",
-    },
-    {
-      question: "Can you help with LMS integration?",
-      answer: "Yes! We work with Google Classroom, Canvas, Schoology, and most major learning management systems.",
-    },
-    {
-      question: "Do you provide receipts for reimbursement?",
-      answer: "Absolutely. You'll receive detailed invoices suitable for school reimbursement or professional development funds.",
-    },
-    {
-      question: "What can I expect after one session?",
-      answer: "You'll leave with at least 3 implementable strategies, relevant resources, and confidence to try something new immediately.",
-    },
-  ];
+  const iconMap = {
+    target: Target,
+    users: Users,
+    fileText: FileText,
+    check: CheckCircle,
+  } as const;
+
+  const defaultTab = steps?.tabs?.[0]?.value ?? "before";
 
   return (
     <div className="min-h-screen flex flex-col">
       <SEO
-        title="Services & Pricing"
-        description="Professional EdTech consulting services. 1:1 coaching ($30), whole-school PD programs ($60), and custom dashboard setup. Transform your classroom with expert guidance."
-        keywords="EdTech consulting, teacher coaching, professional development, school technology training, educational dashboard, classroom technology support"
+        title={pageContent.seo.title}
+        description={pageContent.seo.description}
+        keywords={pageContent.seo.keywords}
         canonicalUrl="https://schooltechhub.com/services"
       />
       <StructuredData
         type="Service"
         data={{
-          serviceType: "Educational Technology Consulting",
-          services: services.map(s => ({
+          serviceType: pageContent.structuredData.serviceType,
+          services: services.map((s) => ({
             "@type": "Offer",
             "itemOffered": {
               "@type": "Service",
@@ -118,9 +56,9 @@ const Services = () => {
       {/* Header */}
       <section className="py-16 px-4 bg-gradient-to-b from-primary/5 to-background">
         <div className="container mx-auto text-center">
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">Services & Pricing</h1>
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">{pageContent.header.title}</h1>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Get the support you need to transform your classroom
+            {pageContent.header.subtitle}
           </p>
         </div>
       </section>
@@ -131,9 +69,9 @@ const Services = () => {
           <div className="grid md:grid-cols-3 gap-8 mb-16">
             {services.map((service) => (
               <Card key={service.id} className="p-6 hover:shadow-large transition-shadow relative">
-                {service.id === "consultation" && (
+                {service.highlight && (
                   <Badge className="absolute -top-3 -right-3" variant="default">
-                    Most Popular
+                    {pageContent.badge}
                   </Badge>
                 )}
                 <div className="mb-4">
@@ -160,12 +98,12 @@ const Services = () => {
 
                 <div className="mb-6 p-3 bg-muted/50 rounded-lg">
                   <p className="text-sm">
-                    <span className="font-semibold">Ideal for:</span> {service.ideal}
+                    <span className="font-semibold">{pageContent.idealLabel}</span> {service.ideal}
                   </p>
                 </div>
 
                 <Link to={getLocalizedPath("/contact", language)}>
-                  <Button className="w-full">Book Now</Button>
+                  <Button className="w-full">{pageContent.bookNow}</Button>
                 </Link>
               </Card>
             ))}
@@ -174,9 +112,9 @@ const Services = () => {
           {/* Guarantee */}
           <Card className="p-8 text-center bg-gradient-to-r from-primary/5 to-secondary/5">
             <Shield className="h-12 w-12 text-primary mx-auto mb-4" />
-            <h3 className="text-2xl font-bold mb-4">Our Guarantee</h3>
+            <h3 className="text-2xl font-bold mb-4">{guarantee.title}</h3>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-              If you don't learn at least 3 implementable strategies in your first session, we'll refund your payment - no questions asked.
+              {guarantee.description}
             </p>
           </Card>
         </div>
@@ -185,91 +123,45 @@ const Services = () => {
       {/* Booking Process */}
       <section className="py-16 px-4 bg-muted/30">
         <div className="container mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-12">How It Works</h2>
-          
-          <Tabs defaultValue="before" className="max-w-3xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-12">{steps.title}</h2>
+
+          <Tabs defaultValue={defaultTab} className="max-w-3xl mx-auto">
             <TabsList className="grid w-full grid-cols-3">
-              <TabsTrigger value="before">Before</TabsTrigger>
-              <TabsTrigger value="during">During</TabsTrigger>
-              <TabsTrigger value="after">After</TabsTrigger>
+              {steps.tabs.map((tab) => (
+                <TabsTrigger key={tab.value} value={tab.value}>
+                  {tab.label}
+                </TabsTrigger>
+              ))}
             </TabsList>
-            
-            <TabsContent value="before" className="mt-8">
-              <Card className="p-6">
-                <h3 className="text-xl font-semibold mb-4">What to Prepare</h3>
-                <ul className="space-y-3">
-                  <li className="flex items-start gap-2">
-                    <Target className="h-5 w-5 text-primary mt-0.5" />
-                    <div>
-                      <p className="font-medium">Your biggest challenge</p>
-                      <p className="text-sm text-muted-foreground">What's the #1 thing you want to solve?</p>
-                    </div>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <Users className="h-5 w-5 text-primary mt-0.5" />
-                    <div>
-                      <p className="font-medium">Your classroom context</p>
-                      <p className="text-sm text-muted-foreground">Grade level, subject, class size</p>
-                    </div>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <FileText className="h-5 w-5 text-primary mt-0.5" />
-                    <div>
-                      <p className="font-medium">Available technology</p>
-                      <p className="text-sm text-muted-foreground">What devices and tools you can access</p>
-                    </div>
-                  </li>
-                </ul>
-              </Card>
-            </TabsContent>
-            
-            <TabsContent value="during" className="mt-8">
-              <Card className="p-6">
-                <h3 className="text-xl font-semibold mb-4">Your Session</h3>
-                <ul className="space-y-3">
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-5 w-5 text-secondary mt-0.5" />
-                    <span>Quick assessment of your current setup</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-5 w-5 text-secondary mt-0.5" />
-                    <span>Hands-on demonstration of solutions</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-5 w-5 text-secondary mt-0.5" />
-                    <span>Practice with immediate feedback</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-5 w-5 text-secondary mt-0.5" />
-                    <span>Q&A for your specific situation</span>
-                  </li>
-                </ul>
-              </Card>
-            </TabsContent>
-            
-            <TabsContent value="after" className="mt-8">
-              <Card className="p-6">
-                <h3 className="text-xl font-semibold mb-4">Follow-Up Support</h3>
-                <ul className="space-y-3">
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-5 w-5 text-secondary mt-0.5" />
-                    <span>Written summary of strategies discussed</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-5 w-5 text-secondary mt-0.5" />
-                    <span>Links to all resources mentioned</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-5 w-5 text-secondary mt-0.5" />
-                    <span>Recording available for 30 days (if applicable)</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-5 w-5 text-secondary mt-0.5" />
-                    <span>Email support for clarifications</span>
-                  </li>
-                </ul>
-              </Card>
-            </TabsContent>
+
+            {steps.tabs.map((tab) => (
+              <TabsContent key={tab.value} value={tab.value} className="mt-8">
+                <Card className="p-6">
+                  <h3 className="text-xl font-semibold mb-4">{tab.title}</h3>
+                  <ul className="space-y-3">
+                    {tab.items.map((item, index) => {
+                      const Icon = iconMap[item.icon as keyof typeof iconMap] ?? CheckCircle;
+
+                      return (
+                        <li key={index} className="flex items-start gap-2">
+                          <Icon className={`h-5 w-5 ${item.icon === "target" || item.icon === "users" || item.icon === "fileText" ? "text-primary" : "text-secondary"} mt-0.5 flex-shrink-0`} />
+                          {item.title ? (
+                            <div>
+                              <p className="font-medium">{item.title}</p>
+                              {item.description && (
+                                <p className="text-sm text-muted-foreground">{item.description}</p>
+                              )}
+                            </div>
+                          ) : (
+                            <span>{item.text}</span>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </Card>
+              </TabsContent>
+            ))}
           </Tabs>
         </div>
       </section>
@@ -277,25 +169,25 @@ const Services = () => {
       {/* FAQs */}
       <section className="py-16 px-4">
         <div className="container mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-12">Frequently Asked Questions</h2>
+          <h2 className="text-3xl font-bold text-center mb-12">{faqs.title}</h2>
           <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
-            {faqs.map((faq, index) => (
+            {faqs.items.map((faq, index) => (
               <Card key={index} className="p-6">
                 <h3 className="font-semibold mb-2">{faq.question}</h3>
                 <p className="text-muted-foreground">{faq.answer}</p>
               </Card>
             ))}
           </div>
-          
+
           <div className="text-center mt-12">
             <Link to={getLocalizedPath("/contact", language)}>
               <Button size="lg" className="shadow-large">
-                Book Your Session Today
+                {faqs.cta.button}
                 <Calendar className="ml-2 h-5 w-5" />
               </Button>
             </Link>
             <p className="text-sm text-muted-foreground mt-4">
-              Questions? Email us at dcjapi@gmail.com
+              {faqs.cta.note} <a className="underline" href={`mailto:${faqs.cta.email}`}>{faqs.cta.email}</a>
             </p>
           </div>
         </div>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -92,6 +92,166 @@ export const en = {
       title: "School Management Software",
       description: "Complete administrative solutions",
       features: ["Student information systems", "Attendance tracking", "Fee management", "Parent communication portals"]
+    },
+    page: {
+      seo: {
+        title: "Services & Pricing",
+        description:
+          "Professional EdTech consulting services. 1:1 coaching ($30), whole-school PD programs ($60), and custom dashboard setup. Transform your classroom with expert guidance.",
+        keywords:
+          "EdTech consulting, teacher coaching, professional development, school technology training, educational dashboard, classroom technology support"
+      },
+      header: {
+        title: "Services & Pricing",
+        subtitle: "Get the support you need to transform your classroom"
+      },
+      badge: "Most Popular",
+      bookNow: "Book Now",
+      idealLabel: "Ideal for:",
+      structuredData: {
+        serviceType: "Educational Technology Consulting"
+      }
+    },
+    packages: [
+      {
+        id: "consultation",
+        title: "1:1 Coaching",
+        price: "$30/session",
+        duration: "60 minutes",
+        description: "Get personalized support for your specific classroom tech challenges",
+        features: [
+          "Customized to your exact needs",
+          "Screen sharing for hands-on help",
+          "Action plan you can use tomorrow",
+          "Follow-up resources included",
+          "Recording available for review"
+        ],
+        ideal: "Teachers who need quick, targeted solutions",
+        highlight: true
+      },
+      {
+        id: "whole-staff-pd",
+        title: "Whole-Staff PD Program",
+        price: "$60",
+        duration: "per session",
+        description:
+          "Up to 30 staff members (larger groups possible with prior arrangement). Schools can choose any edtech topic most relevant to their needs.",
+        features: [
+          "60-90 minutes of live, engaging professional development",
+          "Hands-on activities and demonstrations",
+          "Differentiated by staff experience level (beginners to advanced)",
+          "School receives a digital resource hub (guides, templates, links)",
+          "30-day follow-up Q&A session (online) for continued support"
+        ],
+        ideal: "Schools wanting affordable, practical training to build staff confidence in technology"
+      },
+      {
+        id: "custom-dashboard",
+        title: "Custom School Dashboard & Tracker Setup",
+        price: "$300",
+        duration: "flat rate",
+        description: "Design and implement custom digital dashboards tailored to your school's needs",
+        features: [
+          "60-minute consultation to identify your priorities and current tools",
+          "Build centralized dashboards (Google Sheets, Airtable, Notion, or Supabase)",
+          "Student performance trackers (grades, attendance, behavior, SEL)",
+          "Teacher workflow dashboards & leadership dashboards",
+          "Ready-to-use templates and staff training",
+          "30-day implementation support (email or video check-ins)"
+        ],
+        ideal: "Schools that want to improve organization, communication, and data-driven decision making"
+      }
+    ],
+    guarantee: {
+      title: "Our Guarantee",
+      description:
+        "If you don't learn at least 3 implementable strategies in your first session, we'll refund your payment - no questions asked."
+    },
+    steps: {
+      title: "How It Works",
+      tabs: [
+        {
+          value: "before",
+          label: "Before",
+          title: "What to Prepare",
+          items: [
+            {
+              icon: "target",
+              title: "Your biggest challenge",
+              description: "What's the #1 thing you want to solve?"
+            },
+            {
+              icon: "users",
+              title: "Your classroom context",
+              description: "Grade level, subject, class size"
+            },
+            {
+              icon: "fileText",
+              title: "Available technology",
+              description: "What devices and tools you can access"
+            }
+          ]
+        },
+        {
+          value: "during",
+          label: "During",
+          title: "Your Session",
+          items: [
+            { icon: "check", text: "Quick assessment of your current setup" },
+            { icon: "check", text: "Hands-on demonstration of solutions" },
+            { icon: "check", text: "Practice with immediate feedback" },
+            { icon: "check", text: "Q&A for your specific situation" }
+          ]
+        },
+        {
+          value: "after",
+          label: "After",
+          title: "Follow-Up Support",
+          items: [
+            { icon: "check", text: "Written summary of strategies discussed" },
+            { icon: "check", text: "Links to all resources mentioned" },
+            { icon: "check", text: "Recording available for 30 days (if applicable)" },
+            { icon: "check", text: "Email support for clarifications" }
+          ]
+        }
+      ]
+    },
+    faq: {
+      title: "Frequently Asked Questions",
+      items: [
+        {
+          question: "What devices do I need?",
+          answer:
+            "Any device with internet access works! We'll adapt to whatever you have - Chromebooks, iPads, laptops, or even smartphones."
+        },
+        {
+          question: "What about school filters and restrictions?",
+          answer: "We specialize in working within school constraints. We'll find solutions that work with your existing security settings."
+        },
+        {
+          question: "How do you handle student privacy?",
+          answer:
+            "All recommendations are COPPA and FERPA compliant. We prioritize tools with strong privacy policies and minimal data collection."
+        },
+        {
+          question: "Can you help with LMS integration?",
+          answer: "Yes! We work with Google Classroom, Canvas, Schoology, and most major learning management systems."
+        },
+        {
+          question: "Do you provide receipts for reimbursement?",
+          answer: "Absolutely. You'll receive detailed invoices suitable for school reimbursement or professional development funds."
+        },
+        {
+          question: "What can I expect after one session?",
+          answer:
+            "You'll leave with at least 3 implementable strategies, relevant resources, and confidence to try something new immediately."
+        }
+      ],
+      cta: {
+        button: "Book Your Session Today",
+        note: "Questions? Email us at",
+        email: "dcjapi@gmail.com"
+      }
     }
   },
   blog: {

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -92,6 +92,166 @@ export const sq = {
       title: "Softueri i Menaxhimit të Shkollës",
       description: "Zgjidhje administrative të plota",
       features: ["Sistemet e informacionit të studentëve", "Ndjekja e pranisë", "Menaxhimi i tarifave", "Portalet e komunikimit me prindërit"]
+    },
+    page: {
+      seo: {
+        title: "Shërbimet & Çmimet",
+        description:
+          "Shërbime profesionale këshillimi EdTech. Trajnim individual ($30), programe PD për gjithë stafin ($60) dhe konfigurim i paneleve të personalizuara. Transformoni klasën tuaj me mbështetje eksperte.",
+        keywords:
+          "këshillim EdTech, trajnim mësuesish, zhvillim profesional, trajnim teknologjie shkollore, panel edukativ, mbështetje teknologjie në klasë"
+      },
+      header: {
+        title: "Shërbimet & Çmimet",
+        subtitle: "Merrni mbështetjen që ju nevojitet për të transformuar klasën tuaj"
+      },
+      badge: "Më i Kërkuari",
+      bookNow: "Rezervo Tani",
+      idealLabel: "Ideale për:",
+      structuredData: {
+        serviceType: "Këshillim në Teknologjinë Arsimore"
+      }
+    },
+    packages: [
+      {
+        id: "consultation",
+        title: "Këshillim 1:1",
+        price: "$30/seancë",
+        duration: "60 minuta",
+        description: "Merrni mbështetje të personalizuar për sfidat tuaja teknologjike në klasë",
+        features: [
+          "E përshtatur sipas nevojave tuaja të sakta",
+          "Ndarje ekrani për ndihmë praktike",
+          "Plan veprimi që mund ta përdorni nesër",
+          "Burime vijimësie të përfshira",
+          "Regjistrim i disponueshëm për rishikim"
+        ],
+        ideal: "Mësues që kanë nevojë për zgjidhje të shpejta dhe të fokusuara",
+        highlight: true
+      },
+      {
+        id: "whole-staff-pd",
+        title: "Programi PD për Gjithë Stafin",
+        price: "$60",
+        duration: "për seancë",
+        description:
+          "Deri në 30 anëtarë stafi (grupe më të mëdha me marrëveshje paraprake). Shkollat zgjedhin çdo temë edtech më të rëndësishme për ta.",
+        features: [
+          "60-90 minuta zhvillim profesional të drejtpërdrejtë dhe angazhues",
+          "Aktivitete praktike dhe demonstrime",
+          "Diferencuar sipas eksperiencës së stafit (fillestarë deri të avancuar)",
+          "Shkolla merr një qendër burimesh digjitale (udhëzues, shabllone, lidhje)",
+          "Seancë ndjekjeje Q&A 30-ditore (online) për mbështetje të vazhdueshme"
+        ],
+        ideal: "Shkolla që duan trajnim praktik dhe të përballueshëm për të rritur besimin në teknologji"
+      },
+      {
+        id: "custom-dashboard",
+        title: "Konfigurim Panelesh & Gjurmues të Personalizuara",
+        price: "$300",
+        duration: "tarifë fikse",
+        description: "Projektim dhe zbatim i paneleve digjitale të përshtatura për nevojat e shkollës suaj",
+        features: [
+          "Konsultim 60-minutësh për të identifikuar prioritetet dhe mjetet ekzistuese",
+          "Ndërtim i paneleve të centralizuara (Google Sheets, Airtable, Notion ose Supabase)",
+          "Gjurmues të performancës së nxënësve (nota, frekuentim, sjellje, SEL)",
+          "Panele të flukseve të punës për mësuesit & drejtuesit",
+          "Shabllone gati për përdorim dhe trajnim për stafin",
+          "Mbështetje zbatimi 30-ditore (email ose video)"
+        ],
+        ideal: "Shkolla që duan të përmirësojnë organizimin, komunikimin dhe vendimmarrjen e bazuar në të dhëna"
+      }
+    ],
+    guarantee: {
+      title: "Garancia Jonë",
+      description:
+        "Nëse nuk mësoni të paktën 3 strategji të zbatueshme në seancën e parë, ju rimbursojmë pagesën - pa pyetje."
+    },
+    steps: {
+      title: "Si Funksionon",
+      tabs: [
+        {
+          value: "before",
+          label: "Para",
+          title: "Çfarë të Përgatisni",
+          items: [
+            {
+              icon: "target",
+              title: "Sfida juaj më e madhe",
+              description: "Cila është gjëja #1 që dëshironi të zgjidhni?"
+            },
+            {
+              icon: "users",
+              title: "Konteksti i klasës suaj",
+              description: "Nivel klase, lënda, madhësia e klasës"
+            },
+            {
+              icon: "fileText",
+              title: "Teknologjia e disponueshme",
+              description: "Çfarë pajisjesh dhe mjetesh keni në dispozicion"
+            }
+          ]
+        },
+        {
+          value: "during",
+          label: "Gjatë",
+          title: "Seanca Juaj",
+          items: [
+            { icon: "check", text: "Vlerësim i shpejtë i konfigurimit aktual" },
+            { icon: "check", text: "Demonstrim praktik i zgjidhjeve" },
+            { icon: "check", text: "Praktikë me feedback të menjëhershëm" },
+            { icon: "check", text: "Pyetje & përgjigje për situatën tuaj specifike" }
+          ]
+        },
+        {
+          value: "after",
+          label: "Pas",
+          title: "Mbështetje Pas Seancës",
+          items: [
+            { icon: "check", text: "Përmbledhje me shkrim e strategjive të diskutuara" },
+            { icon: "check", text: "Lidhje për të gjitha burimet e përmendura" },
+            { icon: "check", text: "Regjistrim i disponueshëm për 30 ditë (nëse aplikohet)" },
+            { icon: "check", text: "Mbështetje me email për sqarime" }
+          ]
+        }
+      ]
+    },
+    faq: {
+      title: "Pyetje të Shpeshta",
+      items: [
+        {
+          question: "Çfarë pajisjesh më duhen?",
+          answer:
+            "Çdo pajisje me akses në internet funksionon! Ne përshtatemi me çfarëdo që keni - Chromebook, iPad, laptop apo edhe smartphone."
+        },
+        {
+          question: "Po filtrat dhe kufizimet e shkollës?",
+          answer: "Ne jemi të specializuar për të punuar brenda kufizimeve të shkollës. Gjejmë zgjidhje që funksionojnë me cilësimet tuaja të sigurisë."
+        },
+        {
+          question: "Si e trajtoni privatësinë e nxënësve?",
+          answer:
+            "Të gjitha rekomandimet janë në përputhje me COPPA dhe FERPA. Prioritet kemi mjetet me politika të forta privatësie dhe mbledhje minimale të të dhënave."
+        },
+        {
+          question: "A mund të ndihmoni me integrimin e LMS?",
+          answer: "Po! Punojmë me Google Classroom, Canvas, Schoology dhe shumicën e sistemeve kryesore të menaxhimit të të mësuarit."
+        },
+        {
+          question: "A siguroni fatura për rimbursim?",
+          answer: "Patjetër. Do të merrni fatura të detajuara të përshtatshme për rimbursim shkollor ose fonde zhvillimi profesional."
+        },
+        {
+          question: "Çfarë mund të pres pas një seance?",
+          answer:
+            "Do të largoheni me të paktën 3 strategji të zbatueshme, burime relevante dhe besim për të provuar diçka të re menjëherë."
+        }
+      ],
+      cta: {
+        button: "Rezervoni Seancën Tuaj Sot",
+        note: "Pyetje? Na shkruani në",
+        email: "dcjapi@gmail.com"
+      }
     }
   },
   blog: {

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -92,6 +92,166 @@ export const vi = {
       title: "Phần mềm quản lý trường học",
       description: "Giải pháp hành chính hoàn chỉnh",
       features: ["Hệ thống thông tin học sinh", "Theo dõi điểm danh", "Quản lý học phí", "Cổng thông tin phụ huynh"]
+    },
+    page: {
+      seo: {
+        title: "Dịch vụ & Bảng giá",
+        description:
+          "Dịch vụ tư vấn EdTech chuyên nghiệp. Huấn luyện 1:1 ($30), chương trình PD cho toàn bộ giáo viên ($60) và thiết lập bảng điều khiển tùy chỉnh. Biến đổi lớp học của bạn với sự hỗ trợ chuyên gia.",
+        keywords:
+          "tư vấn EdTech, huấn luyện giáo viên, phát triển chuyên môn, đào tạo công nghệ trường học, bảng điều khiển giáo dục, hỗ trợ công nghệ lớp học"
+      },
+      header: {
+        title: "Dịch vụ & Bảng giá",
+        subtitle: "Nhận sự hỗ trợ bạn cần để chuyển đổi lớp học"
+      },
+      badge: "Phổ biến nhất",
+      bookNow: "Đặt lịch ngay",
+      idealLabel: "Phù hợp cho:",
+      structuredData: {
+        serviceType: "Tư vấn công nghệ giáo dục"
+      }
+    },
+    packages: [
+      {
+        id: "consultation",
+        title: "Huấn luyện 1:1",
+        price: "$30/buổi",
+        duration: "60 phút",
+        description: "Nhận hỗ trợ cá nhân hóa cho những thách thức công nghệ trong lớp học của bạn",
+        features: [
+          "Tùy chỉnh chính xác theo nhu cầu của bạn",
+          "Chia sẻ màn hình để hỗ trợ trực tiếp",
+          "Kế hoạch hành động có thể áp dụng ngay ngày mai",
+          "Bao gồm tài nguyên theo dõi",
+          "Có bản ghi để xem lại"
+        ],
+        ideal: "Giáo viên cần các giải pháp nhanh chóng và tập trung",
+        highlight: true
+      },
+      {
+        id: "whole-staff-pd",
+        title: "Chương trình PD cho toàn bộ giáo viên",
+        price: "$60",
+        duration: "mỗi buổi",
+        description:
+          "Tối đa 30 nhân viên (nhóm lớn hơn cần thỏa thuận trước). Trường lựa chọn chủ đề edtech phù hợp nhất với nhu cầu.",
+        features: [
+          "60-90 phút phát triển chuyên môn trực tiếp, hấp dẫn",
+          "Hoạt động thực hành và minh họa",
+          "Phân hóa theo trình độ kinh nghiệm của giáo viên (mới đến nâng cao)",
+          "Trường nhận trung tâm tài nguyên số (hướng dẫn, mẫu, liên kết)",
+          "Phiên hỏi đáp sau 30 ngày (trực tuyến) để tiếp tục hỗ trợ"
+        ],
+        ideal: "Các trường muốn đào tạo thực tế, chi phí hợp lý để xây dựng sự tự tin về công nghệ"
+      },
+      {
+        id: "custom-dashboard",
+        title: "Thiết lập bảng điều khiển & bộ theo dõi tùy chỉnh cho trường",
+        price: "$300",
+        duration: "trọn gói",
+        description: "Thiết kế và triển khai bảng điều khiển số tùy chỉnh phù hợp với nhu cầu của trường bạn",
+        features: [
+          "Tư vấn 60 phút để xác định ưu tiên và công cụ hiện có",
+          "Xây dựng bảng điều khiển tập trung (Google Sheets, Airtable, Notion hoặc Supabase)",
+          "Bộ theo dõi hiệu suất học sinh (điểm số, chuyên cần, hành vi, SEL)",
+          "Bảng điều khiển quy trình công việc cho giáo viên & ban lãnh đạo",
+          "Mẫu sẵn sàng sử dụng và đào tạo cho nhân viên",
+          "Hỗ trợ triển khai trong 30 ngày (email hoặc video)"
+        ],
+        ideal: "Các trường muốn cải thiện tổ chức, giao tiếp và ra quyết định dựa trên dữ liệu"
+      }
+    ],
+    guarantee: {
+      title: "Cam kết của chúng tôi",
+      description:
+        "Nếu bạn không học được ít nhất 3 chiến lược có thể áp dụng trong buổi đầu tiên, chúng tôi sẽ hoàn tiền - không hỏi gì thêm."
+    },
+    steps: {
+      title: "Quy trình diễn ra",
+      tabs: [
+        {
+          value: "before",
+          label: "Trước buổi học",
+          title: "Chuẩn bị trước",
+          items: [
+            {
+              icon: "target",
+              title: "Thách thức lớn nhất của bạn",
+              description: "Điều quan trọng nhất bạn muốn giải quyết là gì?"
+            },
+            {
+              icon: "users",
+              title: "Bối cảnh lớp học",
+              description: "Khối lớp, môn học, sĩ số"
+            },
+            {
+              icon: "fileText",
+              title: "Công nghệ hiện có",
+              description: "Bạn có những thiết bị và công cụ nào"
+            }
+          ]
+        },
+        {
+          value: "during",
+          label: "Trong buổi học",
+          title: "Buổi làm việc của bạn",
+          items: [
+            { icon: "check", text: "Đánh giá nhanh thiết lập hiện tại" },
+            { icon: "check", text: "Trình diễn trực tiếp các giải pháp" },
+            { icon: "check", text: "Thực hành với phản hồi ngay lập tức" },
+            { icon: "check", text: "Hỏi đáp cho tình huống cụ thể của bạn" }
+          ]
+        },
+        {
+          value: "after",
+          label: "Sau buổi học",
+          title: "Hỗ trợ sau buổi học",
+          items: [
+            { icon: "check", text: "Tóm tắt bằng văn bản các chiến lược đã thảo luận" },
+            { icon: "check", text: "Liên kết tới tất cả tài nguyên đã đề cập" },
+            { icon: "check", text: "Bản ghi có sẵn trong 30 ngày (nếu áp dụng)" },
+            { icon: "check", text: "Hỗ trợ qua email để làm rõ" }
+          ]
+        }
+      ]
+    },
+    faq: {
+      title: "Câu hỏi thường gặp",
+      items: [
+        {
+          question: "Tôi cần thiết bị gì?",
+          answer:
+            "Bất kỳ thiết bị nào có kết nối internet đều được! Chúng tôi sẽ thích ứng với mọi thứ bạn có - Chromebook, iPad, máy tính xách tay hoặc thậm chí điện thoại thông minh."
+        },
+        {
+          question: "Còn bộ lọc và hạn chế của trường thì sao?",
+          answer: "Chúng tôi chuyên làm việc trong các giới hạn của trường. Chúng tôi sẽ tìm giải pháp hoạt động với cài đặt bảo mật hiện tại của bạn."
+        },
+        {
+          question: "Bạn xử lý quyền riêng tư của học sinh như thế nào?",
+          answer:
+            "Tất cả khuyến nghị đều tuân thủ COPPA và FERPA. Chúng tôi ưu tiên các công cụ có chính sách bảo mật mạnh và thu thập dữ liệu tối thiểu."
+        },
+        {
+          question: "Bạn có hỗ trợ tích hợp LMS không?",
+          answer: "Có! Chúng tôi làm việc với Google Classroom, Canvas, Schoology và hầu hết các hệ thống quản lý học tập phổ biến."
+        },
+        {
+          question: "Bạn có cung cấp hóa đơn để hoàn tiền không?",
+          answer: "Chắc chắn. Bạn sẽ nhận được hóa đơn chi tiết phù hợp cho hoàn tiền của trường hoặc quỹ phát triển chuyên môn."
+        },
+        {
+          question: "Tôi có thể mong đợi gì sau một buổi?",
+          answer:
+            "Bạn sẽ có ít nhất 3 chiến lược có thể áp dụng, tài nguyên phù hợp và tự tin thử điều gì đó mới ngay lập tức."
+        }
+      ],
+      cta: {
+        button: "Đặt buổi làm việc ngay hôm nay",
+        note: "Có câu hỏi? Gửi email tới",
+        email: "dcjapi@gmail.com"
+      }
     }
   },
   blog: {


### PR DESCRIPTION
## Summary
- refactor the Services page to consume localized content for headings, packages, booking steps, guarantee, FAQs, and CTA
- extend English, Albanian, and Vietnamese locale files with structured services content, including SEO metadata and CTA strings
- ensure structured data serialization uses translated service details

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce9e0b9a0083318979c340d63964e6