### PR TITLE
Localize contact page content

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -14,9 +14,11 @@ import { supabase } from "@/integrations/supabase/client";
 import { SEO } from "@/components/SEO";
 import { format } from "date-fns";
 import { cn } from "@/lib/utils";
+import { useLanguage } from "@/contexts/LanguageContext";
 
 const Contact = () => {
   const { toast } = useToast();
+  const { t, language } = useLanguage();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState({
     name: "",
@@ -42,8 +44,8 @@ const Contact = () => {
       // For now, just simulate success
 
       toast({
-        title: "Booking request sent!",
-        description: "We'll get back to you within 24 hours to confirm your session.",
+        title: t.contact.form.toast.successTitle,
+        description: t.contact.form.toast.successDescription,
       });
 
       // Reset form
@@ -58,10 +60,16 @@ const Contact = () => {
         preferredTime: "",
         message: "",
       });
-    } catch (error: any) {
+    } catch (error) {
+      const fallbackDescription = t.contact.form.toast.errorDescription;
+      const description =
+        error instanceof Error && error.message
+          ? error.message
+          : fallbackDescription;
+
       toast({
-        title: "Error",
-        description: error.message || "Failed to send booking request. Please try again.",
+        title: t.contact.form.toast.errorTitle,
+        description,
         variant: "destructive",
       });
     } finally {
@@ -80,18 +88,19 @@ const Contact = () => {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <SEO 
-        title="Contact & Book a Session"
-        description="Book your EdTech consultation today. Get personalized 1:1 coaching or whole-school training. Contact SchoolTech Hub for expert educational technology support."
-        keywords="book consultation, EdTech support, contact education consultant, schedule training, teacher coaching booking"
+      <SEO
+        title={t.contact.seo.title}
+        description={t.contact.seo.description}
+        keywords={t.contact.seo.keywords}
         canonicalUrl="https://schooltechhub.com/contact"
+        lang={language}
       />
       {/* Header */}
       <section className="py-16 px-4 bg-gradient-to-b from-primary/5 to-background">
         <div className="container mx-auto text-center">
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">Get In Touch</h1>
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">{t.contact.hero.title}</h1>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Book a consultation or ask us anything about educational technology
+            {t.contact.hero.subtitle}
           </p>
         </div>
       </section>
@@ -103,28 +112,28 @@ const Contact = () => {
             {/* Contact Information */}
             <div className="lg:col-span-1 space-y-6">
               <Card className="p-6">
-                <h3 className="font-semibold mb-4">Quick Contact</h3>
+                <h3 className="font-semibold mb-4">{t.contact.info.quickContact.title}</h3>
                 <div className="space-y-4">
                   <div className="flex items-start gap-3">
                     <Mail className="h-5 w-5 text-primary mt-0.5" />
                     <div>
-                      <p className="font-medium">Email</p>
-                      <p className="text-sm text-muted-foreground">dcjapi@gmail.com</p>
+                      <p className="font-medium">{t.contact.info.quickContact.email.label}</p>
+                      <p className="text-sm text-muted-foreground">{t.contact.info.quickContact.email.value}</p>
                     </div>
                   </div>
                   <div className="flex items-start gap-3">
                     <Phone className="h-5 w-5 text-primary mt-0.5" />
                     <div>
-                      <p className="font-medium">Phone</p>
-                      <p className="text-sm text-muted-foreground">+84 0372725432</p>
-                      <p className="text-sm text-muted-foreground">WhatsApp: +84 0372725432</p>
+                      <p className="font-medium">{t.contact.info.quickContact.phone.label}</p>
+                      <p className="text-sm text-muted-foreground">{t.contact.info.quickContact.phone.value}</p>
+                      <p className="text-sm text-muted-foreground">{t.contact.info.quickContact.phone.whatsapp}</p>
                     </div>
                   </div>
                   <div className="flex items-start gap-3">
                     <MapPin className="h-5 w-5 text-primary mt-0.5" />
                     <div>
-                      <p className="font-medium">Location</p>
-                      <p className="text-sm text-muted-foreground">Available worldwide for online consultations</p>
+                      <p className="font-medium">{t.contact.info.quickContact.location.label}</p>
+                      <p className="text-sm text-muted-foreground">{t.contact.info.quickContact.location.description}</p>
                     </div>
                   </div>
                 </div>
@@ -132,20 +141,19 @@ const Contact = () => {
 
               <Card className="p-6 bg-gradient-to-br from-primary/5 to-secondary/5">
                 <CalendarIcon className="h-8 w-8 text-primary mb-3" />
-                <h3 className="font-semibold mb-2">Office Hours</h3>
+                <h3 className="font-semibold mb-2">{t.contact.info.officeHours.title}</h3>
                 <div className="space-y-1 text-sm text-muted-foreground">
-                  <p>Monday - Friday: 8am - 6pm EST</p>
-                  <p>Saturday: 10am - 2pm EST</p>
-                  <p>Sunday: Closed</p>
+                  <p>{t.contact.info.officeHours.weekdays}</p>
+                  <p>{t.contact.info.officeHours.saturday}</p>
+                  <p>{t.contact.info.officeHours.sunday}</p>
                 </div>
               </Card>
 
               <Card className="p-6">
                 <MessageSquare className="h-8 w-8 text-primary mb-3" />
-                <h3 className="font-semibold mb-2">Response Time</h3>
+                <h3 className="font-semibold mb-2">{t.contact.info.responseTime.title}</h3>
                 <p className="text-sm text-muted-foreground">
-                  We typically respond within 24 hours during business days. 
-                  Urgent requests are prioritized.
+                  {t.contact.info.responseTime.description}
                 </p>
               </Card>
             </div>
@@ -153,22 +161,22 @@ const Contact = () => {
             {/* Contact Form */}
             <div className="lg:col-span-2">
               <Card className="p-8">
-                <h2 className="text-2xl font-bold mb-6">Book a Session</h2>
+                <h2 className="text-2xl font-bold mb-6">{t.contact.form.title}</h2>
                 <form onSubmit={handleSubmit} className="space-y-6">
                   <div className="grid md:grid-cols-2 gap-6">
                     <div>
-                      <Label htmlFor="name">Full Name *</Label>
+                      <Label htmlFor="name">{t.contact.form.fields.name.label}</Label>
                       <Input
                         id="name"
                         name="name"
                         value={formData.name}
                         onChange={handleChange}
                         required
-                        placeholder="Jane Smith"
+                        placeholder={t.contact.form.fields.name.placeholder}
                       />
                     </div>
                     <div>
-                      <Label htmlFor="email">Email Address *</Label>
+                      <Label htmlFor="email">{t.contact.form.fields.email.label}</Label>
                       <Input
                         id="email"
                         name="email"
@@ -176,37 +184,37 @@ const Contact = () => {
                         value={formData.email}
                         onChange={handleChange}
                         required
-                        placeholder="jane@school.edu"
+                        placeholder={t.contact.form.fields.email.placeholder}
                       />
                     </div>
                   </div>
 
                   <div className="grid md:grid-cols-2 gap-6">
                     <div>
-                      <Label htmlFor="phone">Phone Number</Label>
+                      <Label htmlFor="phone">{t.contact.form.fields.phone.label}</Label>
                       <Input
                         id="phone"
                         name="phone"
                         type="tel"
                         value={formData.phone}
                         onChange={handleChange}
-                        placeholder="(555) 123-4567"
+                        placeholder={t.contact.form.fields.phone.placeholder}
                       />
                     </div>
                     <div>
-                      <Label htmlFor="school">School/Organization</Label>
+                      <Label htmlFor="school">{t.contact.form.fields.school.label}</Label>
                       <Input
                         id="school"
                         name="school"
                         value={formData.school}
                         onChange={handleChange}
-                        placeholder="Lincoln Elementary"
+                        placeholder={t.contact.form.fields.school.placeholder}
                       />
                     </div>
                   </div>
 
                   <div>
-                    <Label>Service Type *</Label>
+                    <Label>{t.contact.form.serviceType.label}</Label>
                     <RadioGroup
                       value={formData.bookingType}
                       onValueChange={(value) =>
@@ -217,13 +225,13 @@ const Contact = () => {
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem value="consultation" id="consultation" />
                         <Label htmlFor="consultation" className="font-normal">
-                          1:1 Consulting ($30)
+                          {t.contact.form.serviceType.options.consultation}
                         </Label>
                       </div>
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem value="whole_school" id="whole_school" />
                         <Label htmlFor="whole_school" className="font-normal">
-                          Whole School Consulting ($60)
+                          {t.contact.form.serviceType.options.wholeSchool}
                         </Label>
                       </div>
                     </RadioGroup>
@@ -231,7 +239,7 @@ const Contact = () => {
 
                   <div className="grid md:grid-cols-2 gap-6">
                     <div>
-                      <Label htmlFor="preferredDate">Preferred Date</Label>
+                      <Label htmlFor="preferredDate">{t.contact.form.fields.preferredDate.label}</Label>
                       <Popover>
                         <PopoverTrigger asChild>
                           <Button
@@ -242,7 +250,9 @@ const Contact = () => {
                             )}
                           >
                             <CalendarIcon className="mr-2 h-4 w-4" />
-                            {formData.preferredDate ? format(new Date(formData.preferredDate), "PPP") : <span>Pick a date</span>}
+                            {formData.preferredDate
+                              ? format(new Date(formData.preferredDate), "PPP")
+                              : <span>{t.contact.form.fields.preferredDate.placeholder}</span>}
                           </Button>
                         </PopoverTrigger>
                         <PopoverContent className="w-auto p-0 z-[100]" align="start">
@@ -265,65 +275,61 @@ const Contact = () => {
                       </Popover>
                     </div>
                     <div>
-                      <Label htmlFor="preferredTime">Preferred Time</Label>
+                      <Label htmlFor="preferredTime">{t.contact.form.fields.preferredTime.label}</Label>
                       <Select
                         value={formData.preferredTime}
                         onValueChange={(value) => setFormData(prev => ({ ...prev, preferredTime: value }))}
                       >
                         <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Select preferred time" />
+                          <SelectValue placeholder={t.contact.form.fields.preferredTime.placeholder} />
                         </SelectTrigger>
                         <SelectContent className="z-[100]">
-                          <SelectItem value="09:00">9:00 AM</SelectItem>
-                          <SelectItem value="10:00">10:00 AM</SelectItem>
-                          <SelectItem value="11:00">11:00 AM</SelectItem>
-                          <SelectItem value="12:00">12:00 PM</SelectItem>
-                          <SelectItem value="13:00">1:00 PM</SelectItem>
-                          <SelectItem value="14:00">2:00 PM</SelectItem>
-                          <SelectItem value="15:00">3:00 PM</SelectItem>
-                          <SelectItem value="16:00">4:00 PM</SelectItem>
+                          {t.contact.form.fields.preferredTime.options.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
                         </SelectContent>
                       </Select>
                     </div>
                   </div>
 
                   <div>
-                    <Label htmlFor="topic">Topic/Challenge to Address</Label>
+                    <Label htmlFor="topic">{t.contact.form.fields.topic.label}</Label>
                     <Input
                       id="topic"
                       name="topic"
                       value={formData.topic}
                       onChange={handleChange}
-                      placeholder="e.g., Implementing AI tools, Google Classroom setup"
+                      placeholder={t.contact.form.fields.topic.placeholder}
                     />
                   </div>
 
                   <div>
-                    <Label htmlFor="message">Additional Information</Label>
+                    <Label htmlFor="message">{t.contact.form.fields.message.label}</Label>
                     <Textarea
                       id="message"
                       name="message"
                       value={formData.message}
                       onChange={handleChange}
-                      placeholder="Tell us more about your goals and any specific requirements..."
+                      placeholder={t.contact.form.fields.message.placeholder}
                       className="min-h-[120px]"
                     />
                   </div>
 
                   <Button type="submit" size="lg" className="w-full" disabled={isSubmitting}>
                     {isSubmitting ? (
-                      "Sending..."
+                      t.contact.form.cta.loading
                     ) : (
                       <>
-                        Send Booking Request
+                        {t.contact.form.cta.idle}
                         <Send className="ml-2 h-5 w-5" />
                       </>
                     )}
                   </Button>
 
                   <p className="text-sm text-muted-foreground text-center">
-                    By submitting this form, you agree to our terms of service and privacy policy. 
-                    We'll never share your information with third parties.
+                    {t.contact.form.disclaimer}
                   </p>
                 </form>
               </Card>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -119,32 +119,111 @@ export const en = {
     }
   },
   contact: {
-    title: "Get in Touch",
-    subtitle: "We're here to help transform your educational institution",
-    form: {
-      name: "Name",
-      namePlaceholder: "Your name",
-      email: "Email",
-      emailPlaceholder: "your@email.com",
-      school: "School/Organization",
-      schoolPlaceholder: "Your school or organization",
-      subject: "Subject",
-      subjectPlaceholder: "How can we help?",
-      message: "Message",
-      messagePlaceholder: "Tell us about your needs...",
-      submit: "Send Message",
-      sending: "Sending...",
-      successTitle: "Message sent successfully!",
-      successMessage: "We'll get back to you as soon as possible.",
-      errorTitle: "Failed to send message",
-      errorMessage: "Please try again later."
+    seo: {
+      title: "Contact & Book a Session",
+      description:
+        "Book your EdTech consultation today. Get personalized 1:1 coaching or whole-school training. Contact School Tech Hub for expert educational technology support.",
+      keywords:
+        "book consultation, EdTech support, contact education consultant, schedule training, teacher coaching booking"
+    },
+    hero: {
+      title: "Get In Touch",
+      subtitle: "Book a consultation or ask us anything about educational technology"
     },
     info: {
-      title: "Contact Information",
-      address: "123 Education Boulevard, Tech City, TC 12345",
-      phone: "+1 (555) 123-4567",
-      email: "info@schooltechhub.com",
-      hours: "Monday - Friday: 9:00 AM - 6:00 PM"
+      quickContact: {
+        title: "Quick Contact",
+        email: {
+          label: "Email",
+          value: "dcjapi@gmail.com"
+        },
+        phone: {
+          label: "Phone",
+          value: "+84 0372725432",
+          whatsapp: "WhatsApp: +84 0372725432"
+        },
+        location: {
+          label: "Location",
+          description: "Available worldwide for online consultations"
+        }
+      },
+      officeHours: {
+        title: "Office Hours",
+        weekdays: "Monday - Friday: 8am - 6pm EST",
+        saturday: "Saturday: 10am - 2pm EST",
+        sunday: "Sunday: Closed"
+      },
+      responseTime: {
+        title: "Response Time",
+        description:
+          "We typically respond within 24 hours during business days. Urgent requests are prioritized."
+      }
+    },
+    form: {
+      title: "Book a Session",
+      fields: {
+        name: {
+          label: "Full Name *",
+          placeholder: "Jane Smith"
+        },
+        email: {
+          label: "Email Address *",
+          placeholder: "jane@school.edu"
+        },
+        phone: {
+          label: "Phone Number",
+          placeholder: "(555) 123-4567"
+        },
+        school: {
+          label: "School/Organization",
+          placeholder: "Lincoln Elementary"
+        },
+        preferredDate: {
+          label: "Preferred Date",
+          placeholder: "Pick a date"
+        },
+        preferredTime: {
+          label: "Preferred Time",
+          placeholder: "Select preferred time",
+          options: [
+            { value: "09:00", label: "9:00 AM" },
+            { value: "10:00", label: "10:00 AM" },
+            { value: "11:00", label: "11:00 AM" },
+            { value: "12:00", label: "12:00 PM" },
+            { value: "13:00", label: "1:00 PM" },
+            { value: "14:00", label: "2:00 PM" },
+            { value: "15:00", label: "3:00 PM" },
+            { value: "16:00", label: "4:00 PM" }
+          ]
+        },
+        topic: {
+          label: "Topic/Challenge to Address",
+          placeholder: "e.g., Implementing AI tools, Google Classroom setup"
+        },
+        message: {
+          label: "Additional Information",
+          placeholder: "Tell us more about your goals and any specific requirements..."
+        }
+      },
+      serviceType: {
+        label: "Service Type *",
+        options: {
+          consultation: "1:1 Consulting ($30)",
+          wholeSchool: "Whole School Consulting ($60)"
+        }
+      },
+      cta: {
+        idle: "Send Booking Request",
+        loading: "Sending..."
+      },
+      disclaimer:
+        "By submitting this form, you agree to our terms of service and privacy policy. We'll never share your information with third parties.",
+      toast: {
+        successTitle: "Booking request sent!",
+        successDescription: "We'll get back to you within 24 hours to confirm your session.",
+        errorTitle: "Error",
+        errorDescription: "Failed to send booking request. Please try again."
+      }
     }
   },
   footer: {

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -119,32 +119,111 @@ export const sq = {
     }
   },
   contact: {
-    title: "Na Kontaktoni",
-    subtitle: "Jemi këtu për të ndihmuar në transformimin e institucionit tuaj arsimor",
-    form: {
-      name: "Emri",
-      namePlaceholder: "Emri juaj",
-      email: "Email",
-      emailPlaceholder: "juaj@email.com",
-      school: "Shkolla/Organizata",
-      schoolPlaceholder: "Shkolla ose organizata juaj",
-      subject: "Subjekti",
-      subjectPlaceholder: "Si mund t'ju ndihmojmë?",
-      message: "Mesazhi",
-      messagePlaceholder: "Na tregoni për nevojat tuaja...",
-      submit: "Dërgo Mesazhin",
-      sending: "Duke dërguar...",
-      successTitle: "Mesazhi u dërgua me sukses!",
-      successMessage: "Do t'ju përgjigjemi sa më shpejt të jetë e mundur.",
-      errorTitle: "Dështoi dërgimi i mesazhit",
-      errorMessage: "Ju lutemi provoni përsëri më vonë."
+    seo: {
+      title: "Kontakt & Rezervo një Sesion",
+      description:
+        "Rezervoni konsultimin tuaj EdTech sot. Merrni trajnim të personalizuar 1:1 ose trajnime për gjithë shkollën. Kontaktoni School Tech Hub për mbështetje të specializuar në teknologjinë arsimore.",
+      keywords:
+        "rezervo konsultim, mbështetje EdTech, kontakto konsulent arsimi, planifiko trajnim, rezervim coaching mësuesish"
+    },
+    hero: {
+      title: "Lidhu me Ne",
+      subtitle: "Rezervoni një konsultim ose na pyesni për çdo gjë rreth teknologjisë arsimore"
     },
     info: {
-      title: "Informacioni i Kontaktit",
-      address: "123 Bulevardi i Arsimit, Qyteti Teknologjik, QT 12345",
-      phone: "+1 (555) 123-4567",
-      email: "info@schooltechhub.com",
-      hours: "E Hënë - E Premte: 9:00 - 18:00"
+      quickContact: {
+        title: "Kontakt i Shpejtë",
+        email: {
+          label: "Email",
+          value: "dcjapi@gmail.com"
+        },
+        phone: {
+          label: "Telefoni",
+          value: "+84 0372725432",
+          whatsapp: "WhatsApp: +84 0372725432"
+        },
+        location: {
+          label: "Vendndodhja",
+          description: "Në dispozicion globalisht për konsultime online"
+        }
+      },
+      officeHours: {
+        title: "Orari i Zyrës",
+        weekdays: "E hënë - E premte: 08:00 - 18:00 EST",
+        saturday: "E shtunë: 10:00 - 14:00 EST",
+        sunday: "E diel: Mbyllur"
+      },
+      responseTime: {
+        title: "Koha e Përgjigjes",
+        description:
+          "Përgjigjemi zakonisht brenda 24 orëve gjatë ditëve të punës. Kërkesat urgjente marrin përparësi."
+      }
+    },
+    form: {
+      title: "Rezervoni një Sesion",
+      fields: {
+        name: {
+          label: "Emri i Plotë *",
+          placeholder: "Arta Hoxha"
+        },
+        email: {
+          label: "Adresa e Emailit *",
+          placeholder: "arta@shkolla.edu"
+        },
+        phone: {
+          label: "Numri i Telefonit",
+          placeholder: "+355 69 123 4567"
+        },
+        school: {
+          label: "Shkolla/Organizata",
+          placeholder: "Shkolla \"Naim Frashëri\""
+        },
+        preferredDate: {
+          label: "Data e Preferuar",
+          placeholder: "Zgjidhni një datë"
+        },
+        preferredTime: {
+          label: "Ora e Preferuar",
+          placeholder: "Zgjidhni orarin e preferuar",
+          options: [
+            { value: "09:00", label: "09:00" },
+            { value: "10:00", label: "10:00" },
+            { value: "11:00", label: "11:00" },
+            { value: "12:00", label: "12:00" },
+            { value: "13:00", label: "13:00" },
+            { value: "14:00", label: "14:00" },
+            { value: "15:00", label: "15:00" },
+            { value: "16:00", label: "16:00" }
+          ]
+        },
+        topic: {
+          label: "Tema/Sfida për t'u Trajtuar",
+          placeholder: "p.sh., Zbatimi i mjeteve AI, konfigurimi i Google Classroom"
+        },
+        message: {
+          label: "Informacione Shtesë",
+          placeholder: "Na tregoni më shumë për qëllimet tuaja dhe çdo kërkesë specifike..."
+        }
+      },
+      serviceType: {
+        label: "Lloji i Shërbimit *",
+        options: {
+          consultation: "Konsultim 1:1 (30$)",
+          wholeSchool: "Konsultim për gjithë shkollën (60$)"
+        }
+      },
+      cta: {
+        idle: "Dërgo Kërkesën për Rezervim",
+        loading: "Duke dërguar..."
+      },
+      disclaimer:
+        "Duke dërguar këtë formular, ju pranoni kushtet e shërbimit dhe politikën e privatësisë. Nuk do ta ndajmë kurrë informacionin tuaj me palë të treta.",
+      toast: {
+        successTitle: "Kërkesa për rezervim u dërgua!",
+        successDescription: "Do t'ju kontaktojmë brenda 24 orëve për të konfirmuar sesionin.",
+        errorTitle: "Gabim",
+        errorDescription: "Dështoi dërgimi i kërkesës për rezervim. Ju lutemi provoni përsëri."
+      }
     }
   },
   footer: {

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -119,32 +119,111 @@ export const vi = {
     }
   },
   contact: {
-    title: "Liên hệ",
-    subtitle: "Chúng tôi ở đây để giúp chuyển đổi tổ chức giáo dục của bạn",
-    form: {
-      name: "Tên",
-      namePlaceholder: "Tên của bạn",
-      email: "Email",
-      emailPlaceholder: "email@example.com",
-      school: "Trường/Tổ chức",
-      schoolPlaceholder: "Trường hoặc tổ chức của bạn",
-      subject: "Chủ đề",
-      subjectPlaceholder: "Chúng tôi có thể giúp gì cho bạn?",
-      message: "Tin nhắn",
-      messagePlaceholder: "Cho chúng tôi biết về nhu cầu của bạn...",
-      submit: "Gửi tin nhắn",
-      sending: "Đang gửi...",
-      successTitle: "Tin nhắn đã được gửi thành công!",
-      successMessage: "Chúng tôi sẽ liên hệ lại với bạn sớm nhất có thể.",
-      errorTitle: "Không thể gửi tin nhắn",
-      errorMessage: "Vui lòng thử lại sau."
+    seo: {
+      title: "Liên hệ & Đặt lịch tư vấn",
+      description:
+        "Đặt lịch tư vấn EdTech ngay hôm nay. Nhận coaching 1:1 cá nhân hóa hoặc đào tạo toàn trường. Liên hệ School Tech Hub để được hỗ trợ công nghệ giáo dục chuyên sâu.",
+      keywords:
+        "đặt lịch tư vấn, hỗ trợ EdTech, liên hệ chuyên gia giáo dục, lên lịch đào tạo, đặt lịch huấn luyện giáo viên"
+    },
+    hero: {
+      title: "Kết nối với chúng tôi",
+      subtitle: "Đặt lịch tư vấn hoặc hỏi bất cứ điều gì về công nghệ giáo dục"
     },
     info: {
-      title: "Thông tin liên hệ",
-      address: "123 Đại lộ Giáo dục, Thành phố Công nghệ, TC 12345",
-      phone: "+1 (555) 123-4567",
-      email: "info@schooltechhub.com",
-      hours: "Thứ Hai - Thứ Sáu: 9:00 - 18:00"
+      quickContact: {
+        title: "Liên hệ nhanh",
+        email: {
+          label: "Email",
+          value: "dcjapi@gmail.com"
+        },
+        phone: {
+          label: "Điện thoại",
+          value: "+84 0372725432",
+          whatsapp: "WhatsApp: +84 0372725432"
+        },
+        location: {
+          label: "Địa điểm",
+          description: "Hỗ trợ tư vấn trực tuyến trên toàn thế giới"
+        }
+      },
+      officeHours: {
+        title: "Giờ làm việc",
+        weekdays: "Thứ Hai - Thứ Sáu: 8:00 - 18:00 (EST)",
+        saturday: "Thứ Bảy: 10:00 - 14:00 (EST)",
+        sunday: "Chủ Nhật: Nghỉ"
+      },
+      responseTime: {
+        title: "Thời gian phản hồi",
+        description:
+          "Chúng tôi thường phản hồi trong vòng 24 giờ vào ngày làm việc. Yêu cầu khẩn cấp sẽ được ưu tiên."
+      }
+    },
+    form: {
+      title: "Đặt lịch hẹn",
+      fields: {
+        name: {
+          label: "Họ và tên *",
+          placeholder: "Nguyễn Thị Lan"
+        },
+        email: {
+          label: "Địa chỉ email *",
+          placeholder: "lan@truong.edu"
+        },
+        phone: {
+          label: "Số điện thoại",
+          placeholder: "0901 234 567"
+        },
+        school: {
+          label: "Trường/Tổ chức",
+          placeholder: "Trường Tiểu học Bình Minh"
+        },
+        preferredDate: {
+          label: "Ngày mong muốn",
+          placeholder: "Chọn ngày"
+        },
+        preferredTime: {
+          label: "Giờ mong muốn",
+          placeholder: "Chọn khung giờ mong muốn",
+          options: [
+            { value: "09:00", label: "09:00 sáng" },
+            { value: "10:00", label: "10:00 sáng" },
+            { value: "11:00", label: "11:00 sáng" },
+            { value: "12:00", label: "12:00 trưa" },
+            { value: "13:00", label: "13:00 chiều" },
+            { value: "14:00", label: "14:00 chiều" },
+            { value: "15:00", label: "15:00 chiều" },
+            { value: "16:00", label: "16:00 chiều" }
+          ]
+        },
+        topic: {
+          label: "Chủ đề/thách thức cần trao đổi",
+          placeholder: "vd: Ứng dụng công cụ AI, thiết lập Google Classroom"
+        },
+        message: {
+          label: "Thông tin bổ sung",
+          placeholder: "Hãy cho chúng tôi biết mục tiêu và yêu cầu cụ thể của bạn..."
+        }
+      },
+      serviceType: {
+        label: "Loại dịch vụ *",
+        options: {
+          consultation: "Tư vấn 1:1 (30$)",
+          wholeSchool: "Tư vấn toàn trường (60$)"
+        }
+      },
+      cta: {
+        idle: "Gửi yêu cầu đặt lịch",
+        loading: "Đang gửi..."
+      },
+      disclaimer:
+        "Khi gửi biểu mẫu này, bạn đồng ý với điều khoản dịch vụ và chính sách bảo mật của chúng tôi. Chúng tôi sẽ không bao giờ chia sẻ thông tin của bạn với bên thứ ba.",
+      toast: {
+        successTitle: "Đã gửi yêu cầu đặt lịch!",
+        successDescription: "Chúng tôi sẽ phản hồi trong vòng 24 giờ để xác nhận buổi làm việc.",
+        errorTitle: "Lỗi",
+        errorDescription: "Gửi yêu cầu thất bại. Vui lòng thử lại."
+      }
     }
   },
   footer: {


### PR DESCRIPTION
## Summary
- wire the contact page to use the language context and translated strings for all hero, sidebar, and form copy
- expand the English, Albanian, and Vietnamese dictionaries with detailed contact content including booking form options and toast messages
- surface localized SEO metadata and submission feedback so translations appear consistently end to end

## Testing
- npm run lint *(fails: existing lint errors across unrelated files for no-explicit-any rules)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9e0213f88331be85ce5669d8118e