### PR TITLE
Gracefully handle missing language provider

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -20,7 +20,17 @@ const translations: Record<Language, Translations> = {
 };
 const supportedLanguages = Object.keys(translations) as Language[];
 
-const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
+const defaultLanguageContext: LanguageContextType = {
+  language: 'en',
+  setLanguage: (lang: Language) => {
+    console.warn(
+      `setLanguage called outside of LanguageProvider. Requested language: ${lang}`
+    );
+  },
+  t: translations.en,
+};
+
+const LanguageContext = createContext<LanguageContextType>(defaultLanguageContext);
 
 export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const navigate = useNavigate();
@@ -80,8 +90,10 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
 export const useLanguage = () => {
   const context = useContext(LanguageContext);
-  if (!context) {
-    throw new Error('useLanguage must be used within a LanguageProvider');
+
+  if (context === defaultLanguageContext) {
+    console.warn('useLanguage was called outside of a LanguageProvider. Falling back to defaults.');
   }
+
   return context;
 };


### PR DESCRIPTION
## Summary
- provide a default language context so components can fall back to English when no provider is mounted
- log helpful warnings when setLanguage or useLanguage are invoked without an active LanguageProvider

## Testing
- npm run lint *(fails: pre-existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cea19c3660833192f5f79c87e0380e