### PR TITLE
feat: add localized account management page

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -14,6 +14,7 @@ import Edutech from '@/pages/Edutech';
 import TeacherDiary from '@/pages/TeacherDiary';
 import TeacherDiaryEntry from '@/pages/TeacherDiaryEntry';
 import Auth from '@/pages/Auth';
+import Account from '@/pages/Account';
 import NotFound from '@/pages/NotFound';
 import Sitemap from '@/pages/Sitemap';
 import Navigation from '@/components/Navigation';
@@ -54,6 +55,7 @@ export const LocalizedRoutes = () => {
       <Route path="/teacher-diary" element={<RouteWrapper><TeacherDiary /></RouteWrapper>} />
       <Route path="/teacher-diary/:slug" element={<RouteWrapper><TeacherDiaryEntry /></RouteWrapper>} />
       <Route path="/auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
+      <Route path="/account" element={<RouteWrapper><Account /></RouteWrapper>} />
       <Route path="/sitemap" element={<RouteWrapper><Sitemap /></RouteWrapper>} />
       
       {/* Localized routes for Albanian and Vietnamese */}
@@ -71,6 +73,7 @@ export const LocalizedRoutes = () => {
         <Route path="teacher-diary" element={<RouteWrapper><TeacherDiary /></RouteWrapper>} />
         <Route path="teacher-diary/:slug" element={<RouteWrapper><TeacherDiaryEntry /></RouteWrapper>} />
         <Route path="auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
+        <Route path="account" element={<RouteWrapper><Account /></RouteWrapper>} />
         <Route path="sitemap" element={<RouteWrapper><Sitemap /></RouteWrapper>} />
       </Route>
       

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -138,9 +138,16 @@ const Navigation = () => {
                     <User className="h-5 w-5" />
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuContent align="end" className="w-56">
                   <DropdownMenuItem className="text-sm text-muted-foreground">
                     {user.email}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => navigate(getLocalizedNavPath("/account"))}
+                  >
+                    <User className="mr-2 h-4 w-4" />
+                    {t.nav.profile}
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={handleSignOut}>
@@ -219,14 +226,22 @@ const Navigation = () => {
                 </div>
 
                 {user ? (
-                  <div className="border-t pt-4">
+                  <div className="border-t pt-4 space-y-3">
                     <p className="px-2 text-sm text-muted-foreground">{user.email}</p>
+                    <Link
+                      to={getLocalizedNavPath("/account")}
+                      onClick={() => setIsOpen(false)}
+                    >
+                      <Button className="w-full" variant="secondary">
+                        {t.nav.profile}
+                      </Button>
+                    </Link>
                     <Button
                       onClick={() => {
                         handleSignOut();
                         setIsOpen(false);
                       }}
-                      className="mt-3 w-full"
+                      className="w-full"
                       variant="outline"
                     >
                       <LogOut className="mr-2 h-4 w-4" />

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,0 +1,992 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { User as SupabaseUser } from "@supabase/supabase-js";
+import { format } from "date-fns";
+import { supabase } from "@/integrations/supabase/client";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+import { useToast } from "@/hooks/use-toast";
+import { SEO } from "@/components/SEO";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import {
+  Camera,
+  CheckCircle2,
+  FileText,
+  Lock,
+  LogOut,
+  MessageCircle,
+  ShieldCheck,
+  Sparkles,
+  BellRing,
+  Globe,
+} from "lucide-react";
+import type { Database, Json } from "@/integrations/supabase/types";
+
+const userRoleOptions: Database["public"]["Enums"]["user_role_enum"][] = [
+  "Teacher",
+  "Admin",
+  "Parent",
+  "Student",
+  "Other",
+];
+
+type NotificationPreferences = {
+  updates: boolean;
+  commentReplies: boolean;
+  productAnnouncements: boolean;
+  blogMentions: boolean;
+};
+
+type AccountSettings = {
+  timezone: string;
+  language: string;
+  theme: "system" | "light" | "dark";
+};
+
+const defaultNotificationPreferences: NotificationPreferences = {
+  updates: true,
+  commentReplies: true,
+  productAnnouncements: false,
+  blogMentions: true,
+};
+
+const defaultAccountSettings: AccountSettings = {
+  timezone: "",
+  language: "en",
+  theme: "system",
+};
+
+type CommentWithContent = Database["public"]["Tables"]["comments"]["Row"] & {
+  content_master: Pick<
+    Database["public"]["Tables"]["content_master"]["Row"],
+    "id" | "title" | "slug" | "page"
+  > | null;
+};
+
+type BlogSummary = Pick<
+  Database["public"]["Tables"]["content_master"]["Row"],
+  "id" | "title" | "slug" | "page" | "is_published" | "created_at" | "author" | "language"
+>;
+
+const Account = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { language, t } = useLanguage();
+
+  const [user, setUser] = useState<SupabaseUser | null>(null);
+  const [checkingSession, setCheckingSession] = useState(true);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [passwordForm, setPasswordForm] = useState({ newPassword: "", confirmPassword: "" });
+  const [notificationPreferences, setNotificationPreferences] = useState<NotificationPreferences>(defaultNotificationPreferences);
+  const [accountSettings, setAccountSettings] = useState<AccountSettings>(defaultAccountSettings);
+  const [profileForm, setProfileForm] = useState({
+    fullName: "",
+    role: userRoleOptions[0],
+    bio: "",
+  });
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (!user) {
+        navigate(getLocalizedPath("/auth", language));
+      } else {
+        setUser(user);
+        const metadataPrefs = (user.user_metadata?.notification_preferences ?? defaultNotificationPreferences) as NotificationPreferences;
+        setNotificationPreferences({
+          ...defaultNotificationPreferences,
+          ...metadataPrefs,
+        });
+        const metadataSettings = (user.user_metadata?.account_settings ?? defaultAccountSettings) as AccountSettings;
+        setAccountSettings({
+          ...defaultAccountSettings,
+          ...metadataSettings,
+        });
+        if (user.user_metadata?.avatar_url) {
+          setAvatarPreview(user.user_metadata.avatar_url as string);
+        }
+        if (user.user_metadata?.bio) {
+          setProfileForm(prev => ({ ...prev, bio: user.user_metadata.bio as string }));
+        }
+      }
+      setCheckingSession(false);
+    });
+  }, [navigate, language]);
+
+  useEffect(() => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!session?.user) {
+        navigate(getLocalizedPath("/auth", language));
+      } else {
+        setUser(session.user);
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, [navigate, language]);
+
+  const profileQuery = useQuery({
+    queryKey: ["profile", user?.id],
+    enabled: !!user?.id,
+    queryFn: async () => {
+      if (!user?.id) return null;
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("*")
+        .eq("id", user.id)
+        .single();
+
+      if (error && error.code !== "PGRST116") {
+        throw error;
+      }
+
+      return data;
+    },
+  });
+
+  useEffect(() => {
+    if (profileQuery.data) {
+      setProfileForm(prev => ({
+        ...prev,
+        fullName: profileQuery.data?.full_name ?? "",
+        role: (profileQuery.data?.role as Database["public"]["Enums"]["user_role_enum"] | null) ?? prev.role,
+      }));
+    } else if (user?.user_metadata?.full_name) {
+      setProfileForm(prev => ({
+        ...prev,
+        fullName: user.user_metadata.full_name as string,
+      }));
+    }
+  }, [profileQuery.data, user?.user_metadata?.full_name]);
+
+  const commentsQuery = useQuery({
+    queryKey: ["my-comments", user?.id],
+    enabled: !!user?.id,
+    queryFn: async () => {
+      if (!user?.id) return [];
+      const { data, error } = await supabase
+        .from("comments")
+        .select(`
+          id,
+          content,
+          created_at,
+          content_master:content_id (
+            id,
+            title,
+            slug,
+            page
+          )
+        `)
+        .eq("user_id", user.id)
+        .order("created_at", { ascending: false })
+        .limit(50);
+
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? []) as CommentWithContent[];
+    },
+  });
+
+  const blogsQuery = useQuery({
+    queryKey: ["my-blogs", user?.id, language],
+    enabled: !!user?.id,
+    queryFn: async () => {
+      if (!user?.id) return [];
+      const { data, error } = await supabase
+        .from("content_master")
+        .select("id,title,slug,page,is_published,created_at,author,language")
+        .in("page", ["research_blog", "edutech", "teacher_diary"])
+        .eq("language", language)
+        .order("created_at", { ascending: false })
+        .limit(50);
+
+      if (error) {
+        throw error;
+      }
+
+      const posts = (data ?? []) as BlogSummary[];
+      const filtered = posts.filter((post) => {
+        const authorPayload = post.author as Json | Json[] | null;
+
+        const matchesAuthor = (entry: Json | null) => {
+          if (!entry || typeof entry !== "object") return false;
+          const record = entry as Record<string, Json>;
+          const id = typeof record.id === "string" ? record.id : null;
+          const email = typeof record.email === "string" ? record.email : null;
+          return (id && id === user.id) || (email && email === user.email);
+        };
+
+        if (Array.isArray(authorPayload)) {
+          return authorPayload.some(item => matchesAuthor(item));
+        }
+
+        return matchesAuthor(authorPayload as Json | null);
+      });
+
+      return filtered;
+    },
+  });
+
+  const updateProfileMutation = useMutation({
+    mutationFn: async () => {
+      if (!user) return;
+      const { error } = await supabase
+        .from("profiles")
+        .upsert({
+          id: user.id,
+          email: user.email,
+          full_name: profileForm.fullName,
+          role: profileForm.role,
+          updated_at: new Date().toISOString(),
+        });
+
+      if (error) {
+        throw error;
+      }
+
+      const { error: metadataError } = await supabase.auth.updateUser({
+        data: {
+          full_name: profileForm.fullName,
+          role: profileForm.role,
+          bio: profileForm.bio,
+        },
+      });
+
+      if (metadataError) {
+        throw metadataError;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profile", user?.id] });
+      toast({
+        title: t.account.toast.profileUpdated,
+        variant: "default",
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: t.common.error,
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const updatePasswordMutation = useMutation({
+    mutationFn: async () => {
+      if (!user) return;
+      if (passwordForm.newPassword !== passwordForm.confirmPassword) {
+        throw new Error(t.account.toast.passwordMismatch);
+      }
+
+      if (passwordForm.newPassword.length < 8) {
+        throw new Error(t.account.toast.passwordLength);
+      }
+
+      const { error } = await supabase.auth.updateUser({
+        password: passwordForm.newPassword,
+      });
+
+      if (error) {
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      setPasswordForm({ newPassword: "", confirmPassword: "" });
+      toast({
+        title: t.account.toast.passwordUpdated,
+        variant: "default",
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: t.account.toast.passwordError,
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const updateNotificationsMutation = useMutation({
+    mutationFn: async () => {
+      if (!user) return;
+      const { error } = await supabase.auth.updateUser({
+        data: {
+          notification_preferences: notificationPreferences,
+        },
+      });
+
+      if (error) {
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      toast({
+        title: t.account.toast.notificationsUpdated,
+        variant: "default",
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: t.common.error,
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const updateAccountSettingsMutation = useMutation({
+    mutationFn: async () => {
+      if (!user) return;
+      const { error } = await supabase.auth.updateUser({
+        data: {
+          account_settings: accountSettings,
+        },
+      });
+
+      if (error) {
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      toast({
+        title: t.account.toast.settingsUpdated,
+        variant: "default",
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: t.common.error,
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const activitySummary = useMemo(() => ({
+    comments: commentsQuery.data?.length ?? 0,
+    posts: blogsQuery.data?.length ?? 0,
+    lastLogin: user?.last_sign_in_at ? format(new Date(user.last_sign_in_at), "PPP p") : null,
+  }), [commentsQuery.data?.length, blogsQuery.data?.length, user?.last_sign_in_at]);
+
+  const handleAvatarChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setSelectedFile(file);
+    const previewUrl = URL.createObjectURL(file);
+    setAvatarPreview(previewUrl);
+  };
+
+  const handleAvatarUpload = async () => {
+    if (!selectedFile || !user) return;
+    try {
+      const fileExt = selectedFile.name.split(".").pop();
+      const fileName = `${user.id}-${Date.now()}.${fileExt}`;
+      const { error: uploadError } = await supabase.storage
+        .from("profile-images")
+        .upload(fileName, selectedFile, {
+          upsert: true,
+          contentType: selectedFile.type,
+        });
+
+      if (uploadError) {
+        throw uploadError;
+      }
+
+      const { data: publicUrlData } = supabase.storage
+        .from("profile-images")
+        .getPublicUrl(fileName);
+
+      const { error: metadataError } = await supabase.auth.updateUser({
+        data: {
+          avatar_url: publicUrlData.publicUrl,
+        },
+      });
+
+      if (metadataError) {
+        throw metadataError;
+      }
+
+      setSelectedFile(null);
+      toast({
+        title: t.account.toast.avatarUpdated,
+        variant: "default",
+      });
+    } catch (error) {
+      const description = error instanceof Error ? error.message : t.common.error;
+      toast({
+        title: t.account.toast.avatarError,
+        description,
+        variant: "destructive",
+      });
+    }
+  };
+
+  const avatarInitials = useMemo(() => {
+    if (profileForm.fullName) {
+      const parts = profileForm.fullName.trim().split(" ");
+      if (parts.length === 1) {
+        return parts[0].charAt(0).toUpperCase();
+      }
+      return `${parts[0].charAt(0)}${parts[parts.length - 1].charAt(0)}`.toUpperCase();
+    }
+    if (user?.email) {
+      return user.email.charAt(0).toUpperCase();
+    }
+    return "?";
+  }, [profileForm.fullName, user?.email]);
+
+  if (checkingSession) {
+    return (
+      <div className="min-h-screen bg-muted/10 py-10">
+        <div className="container space-y-6">
+          <Skeleton className="h-10 w-40" />
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-muted/10 pb-16">
+      <SEO
+        title={t.account.seo.title}
+        description={t.account.seo.description}
+        canonicalUrl={t.account.seo.canonical}
+      />
+
+      <div className="relative overflow-hidden bg-gradient-to-br from-primary/5 via-background to-background">
+        <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.15),_transparent_50%)]" />
+        <div className="container relative z-10 space-y-8 py-12">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="flex items-center gap-5">
+              <Avatar className="h-20 w-20 border-2 border-background shadow-lg">
+                {avatarPreview ? (
+                  <AvatarImage src={avatarPreview} alt={profileForm.fullName || t.account.heading.title} />
+                ) : (
+                  <AvatarFallback className="bg-primary text-primary-foreground text-xl">
+                    {avatarInitials}
+                  </AvatarFallback>
+                )}
+              </Avatar>
+              <div>
+                <h1 className="text-3xl font-bold tracking-tight">{t.account.heading.title}</h1>
+                <p className="text-muted-foreground">{t.account.heading.subtitle}</p>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <Badge variant="outline" className="gap-1">
+                    <ShieldCheck className="h-4 w-4 text-primary" />
+                    {profileForm.role}
+                  </Badge>
+                  {user?.email && (
+                    <Badge variant="secondary" className="gap-1">
+                      <Sparkles className="h-4 w-4 text-primary" />
+                      {user.email}
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Button variant="outline" className="gap-2" onClick={() => fileInputRef.current?.click()}>
+                <Camera className="h-4 w-4" />
+                {t.account.image.changeButton}
+              </Button>
+              <Button
+                onClick={() => navigate(getLocalizedPath("/", language))}
+                variant="ghost"
+                className="gap-2"
+              >
+                <LogOut className="h-4 w-4" />
+                {t.account.actions.backToHome}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="container space-y-8 pt-10">
+        <input
+          type="file"
+          accept="image/*"
+          className="hidden"
+          ref={fileInputRef}
+          onChange={handleAvatarChange}
+        />
+
+        {selectedFile && (
+          <Card className="border-dashed border-primary/40 bg-primary/5">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Camera className="h-5 w-5" />
+                {t.account.image.title}
+              </CardTitle>
+              <CardDescription>{t.account.image.description}</CardDescription>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-4">
+                <Avatar className="h-16 w-16">
+                  <AvatarImage src={avatarPreview ?? undefined} alt="Preview" />
+                  <AvatarFallback>{avatarInitials}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="font-medium">{selectedFile.name}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {(selectedFile.size / 1024).toFixed(1)} KB • {selectedFile.type}
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button variant="outline" onClick={() => {
+                  setSelectedFile(null);
+                  setAvatarPreview(user?.user_metadata?.avatar_url ?? null);
+                }}>
+                  {t.common.cancel}
+                </Button>
+                <Button onClick={handleAvatarUpload}>
+                  {t.account.image.uploadButton}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        <Tabs defaultValue="overview" className="space-y-6">
+          <TabsList className="w-full justify-start overflow-x-auto">
+            <TabsTrigger value="overview" className="gap-2">
+              <Sparkles className="h-4 w-4" />
+              {t.account.tabs.overview}
+            </TabsTrigger>
+            <TabsTrigger value="security" className="gap-2">
+              <Lock className="h-4 w-4" />
+              {t.account.tabs.security}
+            </TabsTrigger>
+            <TabsTrigger value="activity" className="gap-2">
+              <MessageCircle className="h-4 w-4" />
+              {t.account.tabs.activity}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="overview" className="space-y-6">
+            <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+              <div className="space-y-6">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <FileText className="h-5 w-5 text-primary" />
+                      {t.account.profile.title}
+                    </CardTitle>
+                    <CardDescription>{t.account.profile.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <div className="space-y-2">
+                        <Label htmlFor="full-name">{t.account.profile.fullNameLabel}</Label>
+                        <Input
+                          id="full-name"
+                          value={profileForm.fullName}
+                          placeholder={t.account.profile.fullNamePlaceholder}
+                          onChange={(event) => setProfileForm(prev => ({ ...prev, fullName: event.target.value }))}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>{t.account.profile.roleLabel}</Label>
+                        <Select
+                          value={profileForm.role}
+                          onValueChange={(value: Database["public"]["Enums"]["user_role_enum"]) =>
+                            setProfileForm(prev => ({ ...prev, role: value }))
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder={t.account.profile.rolePlaceholder} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {userRoleOptions.map(option => (
+                              <SelectItem key={option} value={option}>
+                                {t.account.profile.roles[option] ?? option}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="bio">{t.account.profile.bioLabel}</Label>
+                      <Textarea
+                        id="bio"
+                        value={profileForm.bio}
+                        onChange={(event) => setProfileForm(prev => ({ ...prev, bio: event.target.value }))}
+                        placeholder={t.account.profile.bioPlaceholder}
+                        rows={4}
+                      />
+                    </div>
+                  </CardContent>
+                  <CardFooter className="justify-end gap-2">
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        if (profileQuery.data) {
+                          setProfileForm({
+                            fullName: profileQuery.data.full_name ?? "",
+                            role: (profileQuery.data.role as Database["public"]["Enums"]["user_role_enum"] | null) ?? userRoleOptions[0],
+                            bio: (user?.user_metadata?.bio as string | undefined) ?? "",
+                          });
+                        }
+                      }}
+                    >
+                      {t.common.cancel}
+                    </Button>
+                    <Button onClick={() => updateProfileMutation.mutate()} disabled={updateProfileMutation.isPending}>
+                      {updateProfileMutation.isPending ? t.common.loading : t.common.save}
+                    </Button>
+                  </CardFooter>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <Globe className="h-5 w-5 text-primary" />
+                      {t.account.settings.title}
+                    </CardTitle>
+                    <CardDescription>{t.account.settings.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="grid gap-4 md:grid-cols-3">
+                    <div className="space-y-2">
+                      <Label htmlFor="timezone">{t.account.settings.timezone}</Label>
+                      <Input
+                        id="timezone"
+                        value={accountSettings.timezone}
+                        placeholder={t.account.settings.timezonePlaceholder}
+                        onChange={(event) => setAccountSettings(prev => ({ ...prev, timezone: event.target.value }))}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="language">{t.account.settings.language}</Label>
+                      <Select
+                        value={accountSettings.language}
+                        onValueChange={(value) => setAccountSettings(prev => ({ ...prev, language: value }))}
+                      >
+                        <SelectTrigger id="language">
+                          <SelectValue placeholder={t.account.settings.languagePlaceholder} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="en">English</SelectItem>
+                          <SelectItem value="sq">Shqip</SelectItem>
+                          <SelectItem value="vi">Tiếng Việt</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="theme">{t.account.settings.theme}</Label>
+                      <Select
+                        value={accountSettings.theme}
+                        onValueChange={(value: AccountSettings["theme"]) => setAccountSettings(prev => ({ ...prev, theme: value }))}
+                      >
+                        <SelectTrigger id="theme">
+                          <SelectValue placeholder={t.account.settings.themePlaceholder} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="system">{t.account.settings.themeOptions.system}</SelectItem>
+                          <SelectItem value="light">{t.account.settings.themeOptions.light}</SelectItem>
+                          <SelectItem value="dark">{t.account.settings.themeOptions.dark}</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </CardContent>
+                  <CardFooter className="justify-end">
+                    <Button onClick={() => updateAccountSettingsMutation.mutate()} disabled={updateAccountSettingsMutation.isPending}>
+                      {updateAccountSettingsMutation.isPending ? t.common.loading : t.common.save}
+                    </Button>
+                  </CardFooter>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <BellRing className="h-5 w-5 text-primary" />
+                      {t.account.notifications.title}
+                    </CardTitle>
+                    <CardDescription>{t.account.notifications.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="flex items-center justify-between rounded-lg border p-4">
+                      <div>
+                        <p className="font-medium">{t.account.notifications.updates}</p>
+                        <p className="text-sm text-muted-foreground">{t.account.notifications.updatesDescription}</p>
+                      </div>
+                      <Switch
+                        checked={notificationPreferences.updates}
+                        onCheckedChange={(checked) => setNotificationPreferences(prev => ({ ...prev, updates: checked }))}
+                      />
+                    </div>
+                    <div className="flex items-center justify-between rounded-lg border p-4">
+                      <div>
+                        <p className="font-medium">{t.account.notifications.commentReplies}</p>
+                        <p className="text-sm text-muted-foreground">{t.account.notifications.commentRepliesDescription}</p>
+                      </div>
+                      <Switch
+                        checked={notificationPreferences.commentReplies}
+                        onCheckedChange={(checked) => setNotificationPreferences(prev => ({ ...prev, commentReplies: checked }))}
+                      />
+                    </div>
+                    <div className="flex items-center justify-between rounded-lg border p-4">
+                      <div>
+                        <p className="font-medium">{t.account.notifications.productAnnouncements}</p>
+                        <p className="text-sm text-muted-foreground">{t.account.notifications.productAnnouncementsDescription}</p>
+                      </div>
+                      <Switch
+                        checked={notificationPreferences.productAnnouncements}
+                        onCheckedChange={(checked) => setNotificationPreferences(prev => ({ ...prev, productAnnouncements: checked }))}
+                      />
+                    </div>
+                    <div className="flex items-center justify-between rounded-lg border p-4">
+                      <div>
+                        <p className="font-medium">{t.account.notifications.blogMentions}</p>
+                        <p className="text-sm text-muted-foreground">{t.account.notifications.blogMentionsDescription}</p>
+                      </div>
+                      <Switch
+                        checked={notificationPreferences.blogMentions}
+                        onCheckedChange={(checked) => setNotificationPreferences(prev => ({ ...prev, blogMentions: checked }))}
+                      />
+                    </div>
+                  </CardContent>
+                  <CardFooter className="justify-end">
+                    <Button onClick={() => updateNotificationsMutation.mutate()} disabled={updateNotificationsMutation.isPending}>
+                      {updateNotificationsMutation.isPending ? t.common.loading : t.common.save}
+                    </Button>
+                  </CardFooter>
+                </Card>
+              </div>
+
+              <div className="space-y-6">
+                <Card className="border-primary/30">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <CheckCircle2 className="h-5 w-5 text-primary" />
+                      {t.account.activity.title}
+                    </CardTitle>
+                    <CardDescription>{t.account.activity.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="flex items-center justify-between rounded-lg border bg-muted/40 p-4">
+                      <div>
+                        <p className="text-sm text-muted-foreground">{t.account.activity.comments}</p>
+                        <p className="text-2xl font-semibold">{activitySummary.comments}</p>
+                      </div>
+                      <MessageCircle className="h-8 w-8 text-primary" />
+                    </div>
+                    <div className="flex items-center justify-between rounded-lg border bg-muted/40 p-4">
+                      <div>
+                        <p className="text-sm text-muted-foreground">{t.account.activity.posts}</p>
+                        <p className="text-2xl font-semibold">{activitySummary.posts}</p>
+                      </div>
+                      <FileText className="h-8 w-8 text-primary" />
+                    </div>
+                    <Separator />
+                    <div>
+                      <p className="text-sm text-muted-foreground">{t.account.activity.lastLogin}</p>
+                      <p className="mt-1 font-medium">
+                        {activitySummary.lastLogin ?? t.account.activity.neverLoggedIn}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle>{t.account.support.title}</CardTitle>
+                    <CardDescription>{t.account.support.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3 text-sm text-muted-foreground">
+                    <p>{t.account.support.contact}</p>
+                    <p>{t.account.support.response}</p>
+                    <Button
+                      variant="outline"
+                      onClick={() => navigate(getLocalizedPath("/contact", language))}
+                      className="w-full"
+                    >
+                      {t.account.support.cta}
+                    </Button>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="security">
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Lock className="h-5 w-5 text-primary" />
+                    {t.account.password.title}
+                  </CardTitle>
+                  <CardDescription>{t.account.password.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="new-password">{t.account.password.newPassword}</Label>
+                    <Input
+                      id="new-password"
+                      type="password"
+                      value={passwordForm.newPassword}
+                      placeholder={t.account.password.newPasswordPlaceholder}
+                      onChange={(event) => setPasswordForm(prev => ({ ...prev, newPassword: event.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="confirm-password">{t.account.password.confirmPassword}</Label>
+                    <Input
+                      id="confirm-password"
+                      type="password"
+                      value={passwordForm.confirmPassword}
+                      placeholder={t.account.password.confirmPasswordPlaceholder}
+                      onChange={(event) => setPasswordForm(prev => ({ ...prev, confirmPassword: event.target.value }))}
+                    />
+                  </div>
+                </CardContent>
+                <CardFooter className="justify-end">
+                  <Button onClick={() => updatePasswordMutation.mutate()} disabled={updatePasswordMutation.isPending}>
+                    {updatePasswordMutation.isPending ? t.common.loading : t.account.password.updateButton}
+                  </Button>
+                </CardFooter>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <ShieldCheck className="h-5 w-5 text-primary" />
+                    {t.account.securityTips.title}
+                  </CardTitle>
+                  <CardDescription>{t.account.securityTips.description}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+                    {t.account.securityTips.tips.map((tip: string) => (
+                      <li key={tip}>{tip}</li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="activity">
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <MessageCircle className="h-5 w-5 text-primary" />
+                    {t.account.comments.title}
+                  </CardTitle>
+                  <CardDescription>{t.account.comments.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {commentsQuery.isLoading && (
+                    <div className="space-y-3">
+                      <Skeleton className="h-20 w-full" />
+                      <Skeleton className="h-20 w-full" />
+                    </div>
+                  )}
+                  {!commentsQuery.isLoading && commentsQuery.data?.length === 0 && (
+                    <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+                      {t.account.comments.empty}
+                    </div>
+                  )}
+                  {commentsQuery.data?.map(comment => (
+                    <div key={comment.id} className="rounded-lg border p-4">
+                      <p className="text-sm text-muted-foreground">
+                        {comment.created_at ? format(new Date(comment.created_at), "PPP p") : ""}
+                      </p>
+                      <p className="mt-2 text-sm">{comment.content}</p>
+                      {comment.content_master && (
+                        <Button
+                          variant="link"
+                          className="mt-2 h-auto px-0 text-primary"
+                          onClick={() => navigate(getLocalizedPath(`/blog/${comment.content_master.slug}`, language))}
+                        >
+                          {t.account.comments.viewPost}
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <FileText className="h-5 w-5 text-primary" />
+                    {t.account.blogs.title}
+                  </CardTitle>
+                  <CardDescription>{t.account.blogs.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {blogsQuery.isLoading && (
+                    <div className="space-y-3">
+                      <Skeleton className="h-20 w-full" />
+                      <Skeleton className="h-20 w-full" />
+                    </div>
+                  )}
+                  {!blogsQuery.isLoading && blogsQuery.data?.length === 0 && (
+                    <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+                      {t.account.blogs.empty}
+                    </div>
+                  )}
+                  {blogsQuery.data?.map(post => (
+                    <div key={post.id} className="rounded-lg border p-4">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="font-medium">{post.title}</p>
+                          <p className="text-sm text-muted-foreground">
+                            {post.created_at ? format(new Date(post.created_at), "PPP") : ""}
+                          </p>
+                        </div>
+                        <Badge variant={post.is_published ? "default" : "secondary"}>
+                          {post.is_published ? t.account.blogs.statusPublished : t.account.blogs.statusDraft}
+                        </Badge>
+                      </div>
+                      <Button
+                        variant="link"
+                        className="mt-2 h-auto px-0 text-primary"
+                        onClick={() => navigate(getLocalizedPath(`/blog/${post.slug}`, language))}
+                      >
+                        {t.account.blogs.readPost}
+                      </Button>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+};
+
+export default Account;

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -911,6 +911,134 @@ export const en = {
       vi: "Vietnamese"
     }
   },
+  account: {
+    seo: {
+      title: "My Account | SchoolTech Hub",
+      description: "Manage your SchoolTech Hub profile, preferences, notifications, and security settings in one place.",
+      canonical: "https://schooltechhub.com/account"
+    },
+    heading: {
+      title: "My Account",
+      subtitle: "Keep your personal details, privacy settings, and activity up to date."
+    },
+    image: {
+      title: "Ready to upload",
+      description: "Upload a square image under 2MB. We'll optimise it across SchoolTech Hub.",
+      changeButton: "Change avatar",
+      uploadButton: "Save new avatar"
+    },
+    actions: {
+      backToHome: "Back to homepage"
+    },
+    tabs: {
+      overview: "Overview",
+      security: "Security",
+      activity: "Activity"
+    },
+    profile: {
+      title: "Profile details",
+      description: "This information is visible to collaborators across the platform.",
+      fullNameLabel: "Full name",
+      fullNamePlaceholder: "Your name as it should appear",
+      roleLabel: "Role",
+      rolePlaceholder: "Select a role",
+      roles: {
+        Teacher: "Teacher",
+        Admin: "Administrator",
+        Parent: "Parent",
+        Student: "Student",
+        Other: "Other"
+      },
+      bioLabel: "Bio",
+      bioPlaceholder: "Tell the community a little about yourself (optional)"
+    },
+    settings: {
+      title: "Account preferences",
+      description: "Customise how SchoolTech Hub works for you.",
+      timezone: "Time zone",
+      timezonePlaceholder: "e.g. GMT+1, Hanoi",
+      language: "Content language",
+      languagePlaceholder: "Choose a language",
+      theme: "Theme",
+      themePlaceholder: "Select a theme",
+      themeOptions: {
+        system: "Match system",
+        light: "Light",
+        dark: "Dark"
+      }
+    },
+    notifications: {
+      title: "Notifications",
+      description: "Decide when you'd like to hear from us.",
+      updates: "Product and newsletter updates",
+      updatesDescription: "Occasional product announcements and curated resources.",
+      commentReplies: "Comment replies",
+      commentRepliesDescription: "Email me when someone responds to my comments.",
+      productAnnouncements: "Service announcements",
+      productAnnouncementsDescription: "Important information about maintenance or downtime.",
+      blogMentions: "Blog mentions",
+      blogMentionsDescription: "Alerts when one of my articles is published or featured."
+    },
+    activity: {
+      title: "Activity summary",
+      description: "Track your engagement at a glance.",
+      comments: "Comments",
+      posts: "Published posts",
+      lastLogin: "Last sign in",
+      neverLoggedIn: "No sign-in recorded yet"
+    },
+    support: {
+      title: "Need help?",
+      description: "Our team is here to support any account changes.",
+      contact: "Contact us if you need assistance updating your details or accessing content.",
+      response: "We reply to most messages within one business day.",
+      cta: "Contact support"
+    },
+    password: {
+      title: "Reset password",
+      description: "Choose a strong password that you haven't used elsewhere.",
+      newPassword: "New password",
+      newPasswordPlaceholder: "Enter a new password",
+      confirmPassword: "Confirm password",
+      confirmPasswordPlaceholder: "Re-enter the new password",
+      updateButton: "Update password"
+    },
+    securityTips: {
+      title: "Security recommendations",
+      description: "Best practices to keep your account safe.",
+      tips: [
+        "Enable multi-factor authentication when it becomes available.",
+        "Use a password manager to generate unique passwords.",
+        "Review your account activity regularly for unfamiliar changes.",
+        "Sign out on shared devices after each session."
+      ]
+    },
+    comments: {
+      title: "My comments",
+      description: "Jump back into conversations you've started or joined.",
+      empty: "You haven't posted any comments yet.",
+      viewPost: "View blog post"
+    },
+    blogs: {
+      title: "My blog posts",
+      description: "Keep an eye on the posts you're contributing to.",
+      empty: "No blog posts are linked to your account yet.",
+      statusPublished: "Published",
+      statusDraft: "Draft",
+      readPost: "Open article"
+    },
+    toast: {
+      profileUpdated: "Profile updated",
+      passwordMismatch: "Passwords must match",
+      passwordLength: "Passwords need to be at least 8 characters.",
+      passwordUpdated: "Password updated",
+      passwordError: "We couldn't update your password",
+      notificationsUpdated: "Notification preferences saved",
+      settingsUpdated: "Account settings saved",
+      avatarUpdated: "Profile image updated",
+      avatarError: "We couldn't upload that image"
+    }
+  },
   common: {
     loading: "Loading...",
     error: "An error occurred",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -915,6 +915,134 @@ export const sq = {
       vi: "Vietnamisht"
     }
   },
+  account: {
+    seo: {
+      title: "Llogaria Ime | SchoolTech Hub",
+      description: "Menaxho profilin, preferencat, njoftimet dhe sigurinë tënde në një vend.",
+      canonical: "https://schooltechhub.com/account"
+    },
+    heading: {
+      title: "Llogaria ime",
+      subtitle: "Përditëso të dhënat personale dhe qëndro në kontroll të aktivitetit tënd."
+    },
+    image: {
+      title: "Gati për ngarkim",
+      description: "Ngarkoni një foto katrore nën 2MB. Ne e optimizojmë në të gjithë SchoolTech Hub.",
+      changeButton: "Ndrysho foton",
+      uploadButton: "Ruaj avatarin"
+    },
+    actions: {
+      backToHome: "Kthehu në faqen kryesore"
+    },
+    tabs: {
+      overview: "Përmbledhje",
+      security: "Siguria",
+      activity: "Aktiviteti"
+    },
+    profile: {
+      title: "Detajet e profilit",
+      description: "Këto të dhëna duken nga bashkëpunëtorët tuaj në platformë.",
+      fullNameLabel: "Emri i plotë",
+      fullNamePlaceholder: "Emri që dëshironi të shfaqet",
+      roleLabel: "Roli",
+      rolePlaceholder: "Zgjidh një rol",
+      roles: {
+        Teacher: "Mësues",
+        Admin: "Administrator",
+        Parent: "Prind",
+        Student: "Student",
+        Other: "Tjetër"
+      },
+      bioLabel: "Bio",
+      bioPlaceholder: "Tregoni pak për veten (opsionale)"
+    },
+    settings: {
+      title: "Preferencat e llogarisë",
+      description: "Përshtat përvojën tënde në SchoolTech Hub.",
+      timezone: "Zona kohore",
+      timezonePlaceholder: "p.sh. GMT+1, Tiranë",
+      language: "Gjuha e përmbajtjes",
+      languagePlaceholder: "Zgjidh gjuhën",
+      theme: "Tema",
+      themePlaceholder: "Zgjidh temën",
+      themeOptions: {
+        system: "Si sistemi",
+        light: "E çelët",
+        dark: "E errët"
+      }
+    },
+    notifications: {
+      title: "Njoftimet",
+      description: "Zgjidh kur dëshiron të të kontaktojmë.",
+      updates: "Përditësime dhe newsletter",
+      updatesDescription: "Njoftime të rralla rreth risive dhe burimeve kryesore.",
+      commentReplies: "Përgjigjet e komenteve",
+      commentRepliesDescription: "Merr email kur dikush përgjigjet në komentet e tua.",
+      productAnnouncements: "Njoftime shërbimi",
+      productAnnouncementsDescription: "Informacione të rëndësishme për mirëmbajtje ose ndërprerje.",
+      blogMentions: "Përmendje në blog",
+      blogMentionsDescription: "Sinjalizime kur artikujt e tu publikohen ose veçohen."
+    },
+    activity: {
+      title: "Përmbledhja e aktivitetit",
+      description: "Shiko shpejt angazhimin tënd.",
+      comments: "Komente",
+      posts: "Postime",
+      lastLogin: "Hyrja e fundit",
+      neverLoggedIn: "Nuk ka ende hyrje të regjistruar"
+    },
+    support: {
+      title: "Keni nevojë për ndihmë?",
+      description: "Ekipi ynë është gati të ndihmojë për çdo ndryshim në llogari.",
+      contact: "Na kontaktoni nëse keni nevojë për asistencë me të dhënat ose qasjen.",
+      response: "Përgjigjemi zakonisht brenda një dite pune.",
+      cta: "Kontakto mbështetjen"
+    },
+    password: {
+      title: "Rivendos fjalëkalimin",
+      description: "Zgjidh një fjalëkalim të fortë dhe unik.",
+      newPassword: "Fjalëkalimi i ri",
+      newPasswordPlaceholder: "Shkruaj fjalëkalimin e ri",
+      confirmPassword: "Konfirmo fjalëkalimin",
+      confirmPasswordPlaceholder: "Rishkruaj fjalëkalimin e ri",
+      updateButton: "Përditëso fjalëkalimin"
+    },
+    securityTips: {
+      title: "Rekomandime sigurie",
+      description: "Praktikat më të mira për të mbrojtur llogarinë.",
+      tips: [
+        "Aktivizo verifikimin me shumë faktorë kur të jetë i disponueshëm.",
+        "Përdor një menaxher fjalëkalimesh për të krijuar kode unike.",
+        "Rishiko rregullisht aktivitetin e llogarisë për ndryshime të panjohura.",
+        "Dil nga pajisjet e përbashkëta pasi të përfundosh."
+      ]
+    },
+    comments: {
+      title: "Komentet e mia",
+      description: "Rikthehu shpejt te bisedat ku ke marrë pjesë.",
+      empty: "Nuk keni postuar ende komente.",
+      viewPost: "Shiko artikullin"
+    },
+    blogs: {
+      title: "Postimet e mia",
+      description: "Ndjek statusin e artikujve ku ke kontribuar.",
+      empty: "Asnjë postim blogu nuk lidhet me llogarinë tuaj.",
+      statusPublished: "Publikuar",
+      statusDraft: "Draft",
+      readPost: "Hap artikullin"
+    },
+    toast: {
+      profileUpdated: "Profili u përditësua",
+      passwordMismatch: "Fjalëkalimet duhet të përputhen",
+      passwordLength: "Fjalëkalimi duhet të ketë të paktën 8 karaktere.",
+      passwordUpdated: "Fjalëkalimi u përditësua",
+      passwordError: "Nuk mundëm të përditësojmë fjalëkalimin",
+      notificationsUpdated: "Preferencat e njoftimeve u ruajtën",
+      settingsUpdated: "Preferencat e llogarisë u ruajtën",
+      avatarUpdated: "Fotoja e profilit u përditësua",
+      avatarError: "Nuk mundëm të ngarkojmë imazhin"
+    }
+  },
   common: {
     loading: "Duke ngarkuar...",
     error: "Ndodhi një gabim",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -915,6 +915,134 @@ export const vi = {
       vi: "Tiếng Việt"
     }
   },
+  account: {
+    seo: {
+      title: "Tài khoản của tôi | SchoolTech Hub",
+      description: "Quản lý hồ sơ, tùy chọn, thông báo và bảo mật của bạn tại SchoolTech Hub.",
+      canonical: "https://schooltechhub.com/account"
+    },
+    heading: {
+      title: "Tài khoản của tôi",
+      subtitle: "Cập nhật thông tin cá nhân và theo dõi hoạt động của bạn."
+    },
+    image: {
+      title: "Sẵn sàng tải lên",
+      description: "Tải ảnh vuông dưới 2MB. Chúng tôi sẽ tối ưu cho toàn bộ nền tảng.",
+      changeButton: "Thay đổi ảnh",
+      uploadButton: "Lưu ảnh đại diện"
+    },
+    actions: {
+      backToHome: "Quay về trang chủ"
+    },
+    tabs: {
+      overview: "Tổng quan",
+      security: "Bảo mật",
+      activity: "Hoạt động"
+    },
+    profile: {
+      title: "Thông tin hồ sơ",
+      description: "Các cộng sự của bạn có thể nhìn thấy những thông tin này.",
+      fullNameLabel: "Họ và tên",
+      fullNamePlaceholder: "Tên bạn muốn hiển thị",
+      roleLabel: "Vai trò",
+      rolePlaceholder: "Chọn vai trò",
+      roles: {
+        Teacher: "Giáo viên",
+        Admin: "Quản trị",
+        Parent: "Phụ huynh",
+        Student: "Học sinh",
+        Other: "Khác"
+      },
+      bioLabel: "Giới thiệu",
+      bioPlaceholder: "Chia sẻ vài dòng về bản thân (tùy chọn)"
+    },
+    settings: {
+      title: "Tùy chọn tài khoản",
+      description: "Tùy chỉnh trải nghiệm của bạn trên SchoolTech Hub.",
+      timezone: "Múi giờ",
+      timezonePlaceholder: "vd. GMT+7, Hà Nội",
+      language: "Ngôn ngữ nội dung",
+      languagePlaceholder: "Chọn ngôn ngữ",
+      theme: "Giao diện",
+      themePlaceholder: "Chọn giao diện",
+      themeOptions: {
+        system: "Theo hệ thống",
+        light: "Sáng",
+        dark: "Tối"
+      }
+    },
+    notifications: {
+      title: "Thông báo",
+      description: "Chọn thời điểm bạn muốn nhận thông tin từ chúng tôi.",
+      updates: "Cập nhật sản phẩm và bản tin",
+      updatesDescription: "Thông báo quan trọng và tài nguyên nổi bật.",
+      commentReplies: "Phản hồi bình luận",
+      commentRepliesDescription: "Nhận email khi có người trả lời bình luận của bạn.",
+      productAnnouncements: "Thông báo dịch vụ",
+      productAnnouncementsDescription: "Thông tin về bảo trì hoặc gián đoạn hệ thống.",
+      blogMentions: "Bài viết của tôi",
+      blogMentionsDescription: "Báo khi bài viết của bạn được xuất bản hoặc giới thiệu."
+    },
+    activity: {
+      title: "Tổng quan hoạt động",
+      description: "Theo dõi nhanh mức độ tương tác của bạn.",
+      comments: "Bình luận",
+      posts: "Bài viết",
+      lastLogin: "Lần đăng nhập gần nhất",
+      neverLoggedIn: "Chưa có lần đăng nhập nào"
+    },
+    support: {
+      title: "Cần hỗ trợ?",
+      description: "Chúng tôi luôn sẵn sàng giúp bạn thay đổi cài đặt tài khoản.",
+      contact: "Liên hệ nếu bạn cần hỗ trợ cập nhật thông tin hoặc quyền truy cập.",
+      response: "Thông thường chúng tôi phản hồi trong vòng một ngày làm việc.",
+      cta: "Liên hệ hỗ trợ"
+    },
+    password: {
+      title: "Đặt lại mật khẩu",
+      description: "Hãy chọn một mật khẩu mạnh và duy nhất.",
+      newPassword: "Mật khẩu mới",
+      newPasswordPlaceholder: "Nhập mật khẩu mới",
+      confirmPassword: "Xác nhận mật khẩu",
+      confirmPasswordPlaceholder: "Nhập lại mật khẩu mới",
+      updateButton: "Cập nhật mật khẩu"
+    },
+    securityTips: {
+      title: "Gợi ý bảo mật",
+      description: "Các bước tốt nhất để bảo vệ tài khoản.",
+      tips: [
+        "Bật xác thực nhiều lớp khi tính năng sẵn sàng.",
+        "Sử dụng trình quản lý mật khẩu để tạo mật khẩu duy nhất.",
+        "Kiểm tra hoạt động tài khoản thường xuyên để phát hiện bất thường.",
+        "Đăng xuất khỏi thiết bị dùng chung sau khi sử dụng."
+      ]
+    },
+    comments: {
+      title: "Bình luận của tôi",
+      description: "Quay lại các cuộc trao đổi bạn đã tham gia.",
+      empty: "Bạn chưa có bình luận nào.",
+      viewPost: "Xem bài viết"
+    },
+    blogs: {
+      title: "Bài viết của tôi",
+      description: "Theo dõi trạng thái các bài viết bạn tham gia.",
+      empty: "Chưa có bài viết nào được liên kết với tài khoản của bạn.",
+      statusPublished: "Đã xuất bản",
+      statusDraft: "Bản nháp",
+      readPost: "Mở bài viết"
+    },
+    toast: {
+      profileUpdated: "Đã cập nhật hồ sơ",
+      passwordMismatch: "Mật khẩu nhập lại chưa khớp",
+      passwordLength: "Mật khẩu cần ít nhất 8 ký tự.",
+      passwordUpdated: "Đã cập nhật mật khẩu",
+      passwordError: "Không thể cập nhật mật khẩu",
+      notificationsUpdated: "Đã lưu tùy chọn thông báo",
+      settingsUpdated: "Đã lưu tùy chọn tài khoản",
+      avatarUpdated: "Đã cập nhật ảnh đại diện",
+      avatarError: "Không thể tải ảnh lên"
+    }
+  },
   common: {
     loading: "Đang tải...",
     error: "Đã xảy ra lỗi",


### PR DESCRIPTION
## Summary
- add a dedicated account dashboard with profile editing, notification, security, and activity sections
- expose the new account page through localized routing and navigation shortcuts for authenticated users
- localize the account experience strings for English, Albanian, and Vietnamese users

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cebb39daa48331a2d094460517d12a