### PR TITLE
feat: add lesson plans table

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -11,6 +11,8 @@ The Supabase client is already configured with the following credentials:
 - **URL**: `https://ruybexkjupmannggnstn.supabase.co`
 - **Anon Key**: Already configured in `src/integrations/supabase/client.ts`
 
+> **Service role access:** Administrative scripts that seed or moderate lesson plans should run with the Supabase service role key. Store it as `SUPABASE_SERVICE_ROLE_KEY` in server-side environments only.
+
 ### Database Schema
 
 #### Tables Created
@@ -27,10 +29,16 @@ The Supabase client is already configured with the following credentials:
    - Tracks progress, status, and notes
    - Statuses: enrolled, completed, dropped, pending
 
+4. **lesson_plans** - Curriculum-ready lesson outlines for discovery
+   - Fields: title, summary, subject, grade levels, objectives, materials, activities, standards, status
+   - Search: generated `search_vector` column backed by GIN indexes for fast keyword lookups
+   - Access: defaults to `draft`; only `status = 'published'` rows are exposed through public RLS policies
+
 #### Row Level Security (RLS)
 - All tables have RLS enabled
 - Users can only view/modify their own data
 - Classes are publicly viewable but only instructors can modify
+- Lesson plans are publicly readable only when `status = 'published'`; use a service role key for inserts, updates, or moderation tasks.
 
 ## Features Implemented
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -495,6 +495,63 @@ export type Database = {
         }
         Relationships: []
       }
+      lesson_plans: {
+        Row: {
+          activities: Json
+          created_at: string
+          duration_minutes: number | null
+          grade_levels: string[]
+          id: string
+          materials: string[]
+          objectives: string[]
+          search_vector: unknown
+          slug: string
+          standards: string[]
+          status: string
+          subject: string | null
+          summary: string | null
+          tags: string[]
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          activities?: Json
+          created_at?: string
+          duration_minutes?: number | null
+          grade_levels?: string[]
+          id?: string
+          materials?: string[]
+          objectives?: string[]
+          search_vector?: unknown
+          slug: string
+          standards?: string[]
+          status?: string
+          subject?: string | null
+          summary?: string | null
+          tags?: string[]
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          activities?: Json
+          created_at?: string
+          duration_minutes?: number | null
+          grade_levels?: string[]
+          id?: string
+          materials?: string[]
+          objectives?: string[]
+          search_vector?: unknown
+          slug?: string
+          standards?: string[]
+          status?: string
+          subject?: string | null
+          summary?: string | null
+          tags?: string[]
+          title?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       newsletter_subscribers: {
         Row: {
           audience: string | null

--- a/supabase/migrations/20250907160000_3b8c4d10-lesson-plans.sql
+++ b/supabase/migrations/20250907160000_3b8c4d10-lesson-plans.sql
@@ -1,0 +1,134 @@
+-- Create lesson_plans table with search support and RLS policies
+create table if not exists public.lesson_plans (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  title text not null,
+  slug text not null unique,
+  summary text,
+  subject text,
+  grade_levels text[] not null default '{}'::text[],
+  duration_minutes integer,
+  objectives text[] not null default '{}'::text[],
+  materials text[] not null default '{}'::text[],
+  activities jsonb not null default '[]'::jsonb,
+  standards text[] not null default '{}'::text[],
+  tags text[] not null default '{}'::text[],
+  status text not null default 'draft' check (status in ('draft', 'published', 'archived')),
+  search_vector tsvector generated always as (
+    setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(summary, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(array_to_string(objectives, ' '), '')), 'C') ||
+    setweight(to_tsvector('english', coalesce(array_to_string(tags, ' '), '')), 'D')
+  ) stored
+);
+
+drop trigger if exists lesson_plans_updated_at on public.lesson_plans;
+
+create trigger lesson_plans_updated_at
+  before update on public.lesson_plans
+  for each row
+  execute function public.update_updated_at_column();
+
+create index if not exists lesson_plans_search_idx
+  on public.lesson_plans using gin (search_vector);
+
+create index if not exists lesson_plans_tags_idx
+  on public.lesson_plans using gin (tags);
+
+create index if not exists lesson_plans_grade_levels_idx
+  on public.lesson_plans using gin (grade_levels);
+
+-- Seed published lesson plans for local/testing environments
+insert into public.lesson_plans (
+  title,
+  slug,
+  summary,
+  subject,
+  grade_levels,
+  duration_minutes,
+  objectives,
+  materials,
+  activities,
+  standards,
+  tags,
+  status
+) values
+  (
+    'Introduction to Fractions',
+    'introduction-to-fractions',
+    'Students explore fractions through manipulatives and collaborative problem solving.',
+    'Mathematics',
+    array['Grade 3', 'Grade 4'],
+    45,
+    array[
+      'Students will identify fractions as parts of a whole.',
+      'Students will represent fractions using area models.'
+    ],
+    array['Fraction tiles', 'Whiteboard', 'Exit ticket worksheet'],
+    jsonb_build_array(
+      jsonb_build_object('step', 'Warm Up', 'description', 'Review equal parts using shapes.'),
+      jsonb_build_object('step', 'Guided Practice', 'description', 'Use fraction tiles to model halves and quarters.'),
+      jsonb_build_object('step', 'Exit Ticket', 'description', 'Students create their own fraction model.')
+    ),
+    array['CCSS.MATH.CONTENT.3.NF.A.1'],
+    array['fractions', 'numeracy', 'hands-on'],
+    'published'
+  ),
+  (
+    'Community Helpers Writing Workshop',
+    'community-helpers-writing-workshop',
+    'Learners draft short informational paragraphs about community helpers and share with peers.',
+    'English Language Arts',
+    array['Grade 2'],
+    50,
+    array[
+      'Students will research a community helper and identify key responsibilities.',
+      'Students will write a focused informational paragraph with a topic sentence and details.'
+    ],
+    array['Chart paper', 'Chromebooks or tablets', 'Anchor chart markers'],
+    jsonb_build_array(
+      jsonb_build_object('step', 'Mini Lesson', 'description', 'Model drafting an informational paragraph about firefighters.'),
+      jsonb_build_object('step', 'Writing Workshop', 'description', 'Students draft and revise their paragraphs in pairs.'),
+      jsonb_build_object('step', 'Author Share', 'description', 'Volunteers read their paragraphs aloud for feedback.')
+    ),
+    array['CCSS.ELA-LITERACY.W.2.2'],
+    array['writing', 'community', 'literacy'],
+    'published'
+  ),
+  (
+    'Ecosystems Field Investigation',
+    'ecosystems-field-investigation',
+    'Students analyze biotic and abiotic factors during an outdoor ecosystem walk.',
+    'Science',
+    array['Grade 5'],
+    60,
+    array[
+      'Students will differentiate between biotic and abiotic components of an ecosystem.',
+      'Students will collect observational data and summarize findings.'
+    ],
+    array['Field notebooks', 'Clipboards', 'Temperature probes'],
+    jsonb_build_array(
+      jsonb_build_object('step', 'Pre-Trip Briefing', 'description', 'Review safety expectations and observation focus areas.'),
+      jsonb_build_object('step', 'Field Walk', 'description', 'Teams collect observations using data tables.'),
+      jsonb_build_object('step', 'Debrief', 'description', 'Class discusses patterns found in the ecosystem.')
+    ),
+    array['NGSS.5-LS2-1'],
+    array['ecosystems', 'science', 'field-study'],
+    'published'
+  )
+  on conflict (slug) do nothing;
+
+-- Apply RLS policies
+ALTER TABLE public.lesson_plans ENABLE ROW LEVEL SECURITY;
+
+create policy if not exists "Public can read published lesson plans"
+  on public.lesson_plans
+  for select
+  using (status = 'published');
+
+create policy if not exists "Service role can manage lesson plans"
+  on public.lesson_plans
+  for all
+  using (auth.role() = 'service_role')
+  with check (true);


### PR DESCRIPTION
## Summary
- add a migration that creates the public.lesson_plans table with search indexes, seed data, and RLS policies
- refresh the Supabase generated types so lesson_plans is exposed through the typed client
- document service role requirements for managing lesson plans in the Supabase setup guide

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d022971b888331acae141b3ab1f757