### PR TITLE
Add lesson plan serverless API and tests

### DIFF
--- a/api/__tests__/lesson-plans.test.ts
+++ b/api/__tests__/lesson-plans.test.ts
@@ -1,0 +1,317 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import listHandler from "../lesson-plans";
+import slugHandler from "../lesson-plans/[slug]";
+import pdfHandler from "../lesson-plans/[id]-pdf";
+import type { LessonPlanRecord } from "../../types/lesson-plans";
+import { decodeCursor } from "../_lib/lesson-plan-helpers";
+
+interface SupabaseResponse {
+  data: unknown;
+  error?: { message: string } | null;
+}
+
+const { SupabaseStub, createStub } = vi.hoisted(() => {
+  class StubQueryBuilder {
+    public readonly calls: Array<{ method: string; args: unknown[] }> = [];
+
+    constructor(private readonly response: SupabaseResponse) {}
+
+    select(field: string): this {
+      this.calls.push({ method: "select", args: [field] });
+      return this;
+    }
+
+    eq(column: string, value: unknown): this {
+      this.calls.push({ method: "eq", args: [column, value] });
+      return this;
+    }
+
+    in(column: string, values: unknown[]): this {
+      this.calls.push({ method: "in", args: [column, values] });
+      return this;
+    }
+
+    ilike(column: string, value: unknown): this {
+      this.calls.push({ method: "ilike", args: [column, value] });
+      return this;
+    }
+
+    overlaps(column: string, values: unknown[]): this {
+      this.calls.push({ method: "overlaps", args: [column, values] });
+      return this;
+    }
+
+    textSearch(column: string, query: string, options?: unknown): this {
+      this.calls.push({ method: "textSearch", args: [column, query, options] });
+      return this;
+    }
+
+    or(condition: string): this {
+      this.calls.push({ method: "or", args: [condition] });
+      return this;
+    }
+
+    order(column: string, options?: unknown): this {
+      this.calls.push({ method: "order", args: [column, options] });
+      return this;
+    }
+
+    range(from: number, to: number): this {
+      this.calls.push({ method: "range", args: [from, to] });
+      return this;
+    }
+
+    limit(value: number): this {
+      this.calls.push({ method: "limit", args: [value] });
+      return this;
+    }
+
+    maybeSingle() {
+      this.calls.push({ method: "maybeSingle", args: [] });
+      return Promise.resolve({
+        data: this.response.data,
+        error: this.response.error ?? null,
+      });
+    }
+
+    single() {
+      this.calls.push({ method: "single", args: [] });
+      return Promise.resolve({
+        data: this.response.data,
+        error: this.response.error ?? null,
+      });
+    }
+
+    then<T>(
+      onFulfilled: (value: { data: unknown; error: { message: string } | null }) => T
+    ): Promise<T> {
+      this.calls.push({ method: "then", args: [] });
+      return Promise.resolve(
+        onFulfilled({
+          data: this.response.data,
+          error: this.response.error ?? null,
+        })
+      );
+    }
+  }
+
+  class SupabaseStub {
+    public builders: StubQueryBuilder[] = [];
+    private responses: SupabaseResponse[] = [];
+
+    from() {
+      const response = this.responses.shift() ?? { data: null, error: null };
+      const builder = new StubQueryBuilder(response);
+      builder.calls.push({ method: "from", args: [] });
+      this.builders.push(builder);
+      return builder;
+    }
+
+    setResponses(responses: SupabaseResponse[]) {
+      this.responses = responses.map((response) => ({
+        data: response.data,
+        error: response.error ?? null,
+      }));
+      this.builders = [];
+    }
+  }
+
+  return {
+    SupabaseStub,
+    createStub: () => new SupabaseStub(),
+  };
+});
+
+vi.mock("../_lib/supabase", () => {
+  const stub = createStub();
+  return {
+    getSupabaseClient: () => stub,
+    __setResponses: (responses: SupabaseResponse[]) => stub.setResponses(responses),
+    __getStub: () => stub,
+  };
+});
+
+let setResponses: (responses: SupabaseResponse[]) => void;
+let getStub: () => InstanceType<typeof SupabaseStub>;
+
+beforeAll(async () => {
+  const supabaseModule = (await import("../_lib/supabase")) as unknown as {
+    __setResponses: (responses: SupabaseResponse[]) => void;
+    __getStub: () => InstanceType<typeof SupabaseStub>;
+  };
+  setResponses = supabaseModule.__setResponses;
+  getStub = supabaseModule.__getStub;
+});
+
+beforeEach(() => {
+  setResponses([]);
+});
+
+function createRecord(overrides: Partial<LessonPlanRecord> = {}): LessonPlanRecord {
+  const base: LessonPlanRecord = {
+    id: "plan-1",
+    slug: "plan-1",
+    title: "AI Lesson",
+    status: "published",
+    summary: "Engaging AI lesson",
+    stage: "Middle",
+    stages: ["Middle"],
+    subjects: ["Math"],
+    delivery_methods: ["in-person"],
+    technology_tags: ["ai"],
+    duration_minutes: 45,
+    pdf_url: null,
+    content: [
+      {
+        title: "Introduction",
+        description: "Warm-up",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "Discuss prior knowledge",
+          },
+        ],
+      },
+    ],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    published_at: new Date().toISOString(),
+  } as LessonPlanRecord;
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+describe("lesson plan list handler", () => {
+  it("returns paginated lesson plans and next cursor", async () => {
+    const records = [
+      createRecord({ id: "1", slug: "one" }),
+      createRecord({ id: "2", slug: "two" }),
+      createRecord({ id: "3", slug: "three" }),
+    ];
+    setResponses([{ data: records }]);
+
+    const response = await listHandler(
+      new Request("http://localhost/api/lesson-plans?limit=2")
+    );
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      items: Array<{ slug: string }>;
+      nextCursor: string | null;
+    };
+    expect(payload.items).toHaveLength(2);
+    expect(payload.items[0].slug).toBe("one");
+    expect(payload.items[1].slug).toBe("two");
+    expect(payload.nextCursor).not.toBeNull();
+    expect(decodeCursor(payload.nextCursor)).toBe(2);
+
+    const builder = getStub().builders[0];
+    expect(builder.calls.find((call) => call.method === "order")).toBeDefined();
+    expect(builder.calls.find((call) => call.method === "range")).toBeDefined();
+    expect(
+      builder.calls.find((call) => call.method === "textSearch")
+    ).toBeUndefined();
+  });
+
+  it("applies filters and full-text search", async () => {
+    setResponses([{ data: [] }]);
+
+    const response = await listHandler(
+      new Request(
+        "http://localhost/api/lesson-plans?q=ai&stage=middle,high&subjects=Math,Science&delivery=virtual&tech=vr"
+      )
+    );
+    expect(response.status).toBe(200);
+
+    const builder = getStub().builders[0];
+    expect(
+      builder.calls.find(
+        (call) => call.method === "textSearch" && call.args[1] === "ai"
+      )
+    ).toBeDefined();
+    expect(
+      builder.calls.find(
+        (call) => call.method === "in" && Array.isArray(call.args[1])
+      )
+    ).toBeDefined();
+    expect(
+      builder.calls.filter((call) => call.method === "overlaps").length
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("falls back to ilike search when full-text fails", async () => {
+    setResponses([
+      { data: null, error: { message: "missing column" } },
+      { data: [] },
+    ]);
+
+    const response = await listHandler(
+      new Request("http://localhost/api/lesson-plans?q=robots")
+    );
+    expect(response.status).toBe(200);
+
+    const builders = getStub().builders;
+    expect(
+      builders[0].calls.some((call) => call.method === "textSearch")
+    ).toBe(true);
+    expect(
+      builders[1].calls.some((call) => call.method === "or")
+    ).toBe(true);
+  });
+});
+
+describe("lesson plan detail handler", () => {
+  it("returns 404 when slug missing", async () => {
+    const response = await slugHandler(
+      new Request("http://localhost/api/lesson-plans/")
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("returns lesson plan detail", async () => {
+    const record = createRecord({ slug: "differentiation" });
+    setResponses([{ data: record }]);
+
+    const response = await slugHandler(
+      new Request("http://localhost/api/lesson-plans/differentiation")
+    );
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { slug: string; content: unknown[] };
+    expect(payload.slug).toBe("differentiation");
+    expect(Array.isArray(payload.content)).toBe(true);
+    const builder = getStub().builders[0];
+    expect(
+      builder.calls.find(
+        (call) => call.method === "eq" && call.args[0] === "slug"
+      )
+    ).toBeDefined();
+  });
+});
+
+describe("lesson plan pdf handler", () => {
+  it("redirects to hosted pdf when available", async () => {
+    const record = createRecord({ pdf_url: "https://example.com/plan.pdf" });
+    setResponses([{ data: record }]);
+
+    const response = await pdfHandler(
+      new Request("http://localhost/api/lesson-plans/plan-1/pdf")
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("https://example.com/plan.pdf");
+  });
+
+  it("streams a generated pdf when pdf_url missing", async () => {
+    const record = createRecord({ pdf_url: null });
+    setResponses([{ data: record }]);
+
+    const response = await pdfHandler(
+      new Request("http://localhost/api/lesson-plans/plan-1/pdf")
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+    const buffer = await response.arrayBuffer();
+    expect(buffer.byteLength).toBeGreaterThan(0);
+  });
+});

--- a/api/_lib/lesson-plan-helpers.tsx
+++ b/api/_lib/lesson-plan-helpers.tsx
@@ -1,0 +1,846 @@
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  StyleSheet,
+  renderToBuffer,
+} from "@react-pdf/renderer";
+import type { PostgrestFilterBuilder } from "@supabase/postgrest-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  LessonPlanContentBlock,
+  LessonPlanContentSection,
+  LessonPlanDetail,
+  LessonPlanListItem,
+  LessonPlanListResponse,
+  LessonPlanOverview,
+  LessonPlanRecord,
+  LessonPlanResource,
+  LessonPlanStatus,
+} from "../../types/lesson-plans";
+
+const BASE_URL = "http://localhost";
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+const BASE_SELECT = "*";
+const FULL_TEXT_COLUMN = "search_vector";
+
+export interface LessonPlanListFilters {
+  q: string | null;
+  stage: string[];
+  subjects: string[];
+  delivery: string[];
+  tech: string[];
+  limit: number;
+  offset: number;
+}
+
+export interface LessonPlanQueryOptions {
+  useFullTextSearch?: boolean;
+}
+
+export function parseRequestUrl(request: Request): URL {
+  try {
+    return new URL(request.url);
+  } catch {
+    return new URL(request.url, BASE_URL);
+  }
+}
+
+export function parseListFilters(url: URL): LessonPlanListFilters {
+  const params = url.searchParams;
+  const limit = clampLimit(parseInteger(params.get("limit")) ?? DEFAULT_LIMIT);
+  const cursorValue = params.get("cursor");
+  const page = parsePositiveInteger(params.get("page")) ?? null;
+  const offsetFromCursor = decodeCursor(cursorValue);
+  const offset =
+    offsetFromCursor ?? (page && page > 0 ? (page - 1) * limit : 0);
+
+  return {
+    q: sanitizeSearchTerm(params.get("q")),
+    stage: parseListParam(params, "stage"),
+    subjects: parseListParam(params, "subjects"),
+    delivery: parseListParam(params, "delivery"),
+    tech: parseListParam(params, "tech"),
+    limit,
+    offset,
+  };
+}
+
+export function parseListParam(params: URLSearchParams, key: string): string[] {
+  const values = params.getAll(key);
+  if (values.length === 0) {
+    const singular = params.get(`${key}[]`);
+    if (singular) {
+      values.push(singular);
+    }
+  }
+
+  if (values.length === 0) {
+    const fallback = params.get(key);
+    if (fallback) {
+      values.push(fallback);
+    }
+  }
+
+  const parsed = values
+    .flatMap((value) =>
+      value
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean)
+    )
+    .map((value) => value.toLowerCase());
+
+  return Array.from(new Set(parsed));
+}
+
+export function clampLimit(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(MAX_LIMIT, Math.max(1, Math.trunc(value)));
+}
+
+export function parseInteger(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function parsePositiveInteger(value: string | null): number | null {
+  const parsed = parseInteger(value);
+  return parsed && parsed > 0 ? parsed : null;
+}
+
+export function sanitizeSearchTerm(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function encodeCursor(offset: number): string {
+  return Buffer.from(JSON.stringify({ offset }), "utf8").toString("base64url");
+}
+
+export function decodeCursor(cursor: string | null): number | null {
+  if (!cursor) {
+    return null;
+  }
+  try {
+    const decoded = JSON.parse(
+      Buffer.from(cursor, "base64url").toString("utf8")
+    ) as { offset?: number };
+    if (typeof decoded.offset === "number" && decoded.offset >= 0) {
+      return Math.trunc(decoded.offset);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildLessonPlanQuery(
+  client: SupabaseClient,
+  filters: LessonPlanListFilters,
+  options: LessonPlanQueryOptions = {}
+): PostgrestFilterBuilder<LessonPlanRecord> {
+  const { useFullTextSearch = true } = options;
+
+  let query = client
+    .from<LessonPlanRecord>("lesson_plans")
+    .select(BASE_SELECT)
+    .eq("status", "published")
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false, nullsFirst: false });
+
+  if (filters.stage.length > 0) {
+    if (filters.stage.length === 1) {
+      query = query.ilike("stage", filters.stage[0]);
+    } else {
+      query = query.in("stage", filters.stage);
+    }
+  }
+
+  if (filters.subjects.length > 0) {
+    query = query.overlaps("subjects", filters.subjects);
+  }
+
+  if (filters.delivery.length > 0) {
+    query = query.overlaps("delivery_methods", filters.delivery);
+  }
+
+  if (filters.tech.length > 0) {
+    query = query.overlaps("technology_tags", filters.tech);
+  }
+
+  if (filters.q) {
+    if (useFullTextSearch) {
+      query = query.textSearch(
+        FULL_TEXT_COLUMN,
+        filters.q,
+        {
+          type: "websearch",
+          config: "english",
+        }
+      );
+    } else {
+      const escaped = escapeLike(filters.q);
+      const pattern = `%${escaped}%`;
+      query = query.or(
+        [
+          `title.ilike.${pattern}`,
+          `summary.ilike.${pattern}`,
+          `excerpt.ilike.${pattern}`,
+        ].join(",")
+      );
+    }
+  }
+
+  const end = filters.offset + filters.limit;
+  query = query.range(filters.offset, end);
+
+  return query;
+}
+
+export function mapRecordToListItem(record: LessonPlanRecord): LessonPlanListItem {
+  const stages = uniqStrings([
+    ...(ensureStringArray(record.stages)),
+    ...(ensureStringArray(record.stage_levels)),
+    ...ensureStringArray(record.stage ? [record.stage] : []),
+  ]);
+  const subjects = uniqStrings([
+    ...ensureStringArray(record.subjects),
+    ...ensureStringArray(record.subject ? [record.subject] : []),
+  ]);
+  const delivery = uniqStrings([
+    ...ensureStringArray(record.delivery_methods),
+    ...ensureStringArray(record.delivery),
+    ...ensureStringArray(record.delivery_modes),
+    ...ensureStringArray(record.delivery_format),
+  ]);
+  const tech = uniqStrings([
+    ...ensureStringArray(record.technology_tags),
+    ...ensureStringArray(record.technology),
+    ...ensureStringArray(record.tech),
+    ...ensureStringArray(record.tools),
+  ]);
+
+  const summary =
+    nullableString(record.summary) ??
+    nullableString(record.excerpt) ??
+    nullableString(record.description) ??
+    extractOverviewSummary(record);
+
+  const duration =
+    firstNumber([
+      record.duration_minutes,
+      record.duration,
+      record.time_required,
+      extractOverviewDuration(record),
+    ]);
+
+  const pdfUrl =
+    nullableString(record.pdf_url) ?? nullableString(record.pdf) ?? null;
+
+  return {
+    id: record.id,
+    slug: record.slug,
+    title: record.title,
+    summary,
+    stage: stages[0] ?? null,
+    stages,
+    subjects,
+    deliveryMethods: delivery,
+    technologyTags: tech,
+    durationMinutes: duration,
+    pdfUrl,
+    status: record.status ?? ("draft" as LessonPlanStatus),
+    createdAt: nullableString(record.created_at),
+    updatedAt: nullableString(record.updated_at),
+  };
+}
+
+export function mapRecordToDetail(record: LessonPlanRecord): LessonPlanDetail {
+  const base = mapRecordToListItem(record);
+  const overview = extractOverview(record, base);
+  const resources = extractResources(record);
+  const content = normalizeContent(record.content ?? record.body ?? null);
+
+  return {
+    ...base,
+    content,
+    overview,
+    resources,
+  };
+}
+
+export function buildListResponse(
+  records: LessonPlanRecord[],
+  filters: LessonPlanListFilters
+): LessonPlanListResponse {
+  const hasMore = records.length > filters.limit;
+  const items = hasMore ? records.slice(0, filters.limit) : records;
+  const mapped = items.map(mapRecordToListItem);
+  const nextCursor = hasMore
+    ? encodeCursor(filters.offset + filters.limit)
+    : null;
+
+  return {
+    items: mapped,
+    nextCursor,
+  };
+}
+
+export async function renderLessonPlanToPdf(
+  lesson: LessonPlanDetail
+): Promise<Uint8Array> {
+  const styles = StyleSheet.create({
+    page: {
+      padding: 48,
+      fontSize: 12,
+      fontFamily: "Helvetica",
+      lineHeight: 1.4,
+    },
+    title: {
+      fontSize: 22,
+      marginBottom: 16,
+      fontWeight: 700,
+    },
+    summary: {
+      marginBottom: 16,
+    },
+    metaGroup: {
+      marginBottom: 12,
+    },
+    metaLabel: {
+      fontWeight: 600,
+    },
+    section: {
+      marginTop: 16,
+    },
+    sectionTitle: {
+      fontSize: 16,
+      marginBottom: 8,
+      fontWeight: 600,
+    },
+    paragraph: {
+      marginBottom: 8,
+    },
+    listItem: {
+      marginLeft: 12,
+      marginBottom: 4,
+    },
+  });
+
+  const doc = (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <Text style={styles.title}>{lesson.title}</Text>
+        {lesson.summary ? (
+          <Text style={styles.summary}>{lesson.summary}</Text>
+        ) : null}
+        <View style={styles.metaGroup}>
+          {renderMetaLine("Stage", lesson.stage, styles)}
+          {renderMetaLine(
+            "Subjects",
+            lesson.subjects.join(", ") || null,
+            styles
+          )}
+          {renderMetaLine(
+            "Delivery",
+            lesson.deliveryMethods.join(", ") || null,
+            styles
+          )}
+          {renderMetaLine(
+            "Technology",
+            lesson.technologyTags.join(", ") || null,
+            styles
+          )}
+          {renderMetaLine(
+            "Duration",
+            lesson.durationMinutes != null
+              ? `${lesson.durationMinutes} minutes`
+              : null,
+            styles
+          )}
+        </View>
+        {lesson.content.length === 0 ? (
+          <Text style={styles.paragraph}>Lesson content coming soon.</Text>
+        ) : (
+          lesson.content.map((section, index) => (
+            <View key={section.id ?? index} style={styles.section}>
+              {section.title ? (
+                <Text style={styles.sectionTitle}>{section.title}</Text>
+              ) : null}
+              {section.description ? (
+                <Text style={styles.paragraph}>{section.description}</Text>
+              ) : null}
+              {section.blocks.map((block, blockIndex) =>
+                renderBlock(block, blockIndex, styles)
+              )}
+            </View>
+          ))
+        )}
+      </Page>
+    </Document>
+  );
+
+  const buffer = await renderToBuffer(doc);
+  return buffer as Uint8Array;
+}
+
+function renderMetaLine(
+  label: string,
+  value: string | null,
+  styles: ReturnType<typeof StyleSheet.create>
+): JSX.Element | null {
+  if (!value) {
+    return null;
+  }
+  return (
+    <Text style={styles.paragraph}>
+      <Text style={styles.metaLabel}>{`${label}: `}</Text>
+      {value}
+    </Text>
+  );
+}
+
+function renderBlock(
+  block: LessonPlanContentBlock,
+  index: number,
+  styles: ReturnType<typeof StyleSheet.create>
+): JSX.Element {
+  switch (block.type) {
+    case "paragraph":
+      return (
+        <Text key={index} style={styles.paragraph}>
+          {block.text}
+        </Text>
+      );
+    case "heading":
+      return (
+        <Text key={index} style={styles.sectionTitle}>
+          {block.text}
+        </Text>
+      );
+    case "list":
+      return (
+        <View key={index} style={styles.paragraph}>
+          {block.items.map((item, itemIndex) => (
+            <Text key={itemIndex} style={styles.listItem}>
+              {block.ordered ? `${itemIndex + 1}. ` : "• "}
+              {item}
+            </Text>
+          ))}
+        </View>
+      );
+    case "quote":
+      return (
+        <View key={index} style={styles.paragraph}>
+          <Text>“{block.text}”</Text>
+          {block.attribution ? <Text>- {block.attribution}</Text> : null}
+        </View>
+      );
+    default:
+      return (
+        <Text key={index} style={styles.paragraph}>
+          {JSON.stringify(block)}
+        </Text>
+      );
+  }
+}
+
+function ensureStringArray(value: unknown): string[] {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value
+      .flatMap((item) => ensureStringArray(item))
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === "number") {
+    return [String(value)];
+  }
+  if (typeof value === "object") {
+    const candidate = value as Record<string, unknown>;
+    const maybeValue = candidate.value ?? candidate.label ?? candidate.name;
+    if (
+      typeof maybeValue === "string" ||
+      typeof maybeValue === "number"
+    ) {
+      return ensureStringArray(maybeValue);
+    }
+  }
+  return [];
+}
+
+function uniqStrings(values: string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+function nullableString(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return null;
+}
+
+function firstNumber(values: Array<number | null | undefined>): number | null {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+function extractOverviewSummary(record: LessonPlanRecord): string | null {
+  const overview = record.overview ?? record.metadata;
+  if (typeof overview === "string") {
+    return overview;
+  }
+  if (typeof overview === "object" && overview) {
+    const summary = (overview as Record<string, unknown>).summary;
+    return nullableString(summary);
+  }
+  return null;
+}
+
+function extractOverviewDuration(record: LessonPlanRecord): number | null {
+  const overview = record.overview ?? record.metadata;
+  if (typeof overview === "object" && overview) {
+    const duration = (overview as Record<string, unknown>).durationMinutes ??
+      (overview as Record<string, unknown>).duration_minutes ??
+      (overview as Record<string, unknown>).duration;
+    if (typeof duration === "number" && Number.isFinite(duration)) {
+      return duration;
+    }
+  }
+  return null;
+}
+
+function extractOverview(
+  record: LessonPlanRecord,
+  base: LessonPlanListItem
+): LessonPlanOverview | null {
+  const overview = record.overview ?? record.metadata;
+  if (!overview || typeof overview !== "object") {
+    if (
+      base.summary ||
+      base.stage ||
+      base.subjects.length > 0 ||
+      base.deliveryMethods.length > 0 ||
+      base.technologyTags.length > 0 ||
+      base.durationMinutes != null
+    ) {
+      return {
+        summary: base.summary,
+        essentialQuestion: null,
+        objectives: [],
+        materials: [],
+        assessment: [],
+        technology: base.technologyTags,
+        delivery: base.deliveryMethods,
+        stage: base.stage,
+        subjects: base.subjects,
+        durationMinutes: base.durationMinutes,
+      };
+    }
+    return null;
+  }
+
+  const overviewRecord = overview as Record<string, unknown>;
+  const summary =
+    nullableString(overviewRecord.summary) ?? base.summary ?? null;
+  const essentialQuestion =
+    nullableString(overviewRecord.essentialQuestion) ??
+    nullableString(overviewRecord.essential_question);
+
+  const objectives = uniqStrings(
+    ensureStringArray(overviewRecord.objectives ?? overviewRecord.learningObjectives)
+  );
+  const materials = uniqStrings(
+    ensureStringArray(overviewRecord.materials ?? overviewRecord.materialsNeeded)
+  );
+  const assessment = uniqStrings(
+    ensureStringArray(overviewRecord.assessment ?? overviewRecord.assessments)
+  );
+  const technology = uniqStrings(
+    ensureStringArray(overviewRecord.technology ?? overviewRecord.technologyTools)
+  );
+  const delivery = uniqStrings(
+    ensureStringArray(overviewRecord.delivery ?? overviewRecord.deliveryMode)
+  );
+  const subjects = uniqStrings(
+    ensureStringArray(overviewRecord.subjects ?? base.subjects)
+  );
+  const stage =
+    nullableString(overviewRecord.stage) ?? base.stage ?? null;
+  const durationMinutes =
+    firstNumber([
+      overviewRecord.durationMinutes as number | undefined,
+      overviewRecord.duration_minutes as number | undefined,
+      overviewRecord.duration as number | undefined,
+      base.durationMinutes ?? undefined,
+    ]);
+
+  return {
+    summary,
+    essentialQuestion: essentialQuestion ?? null,
+    objectives,
+    materials,
+    assessment,
+    technology: technology.length ? technology : base.technologyTags,
+    delivery: delivery.length ? delivery : base.deliveryMethods,
+    stage,
+    subjects,
+    durationMinutes,
+  };
+}
+
+function extractResources(record: LessonPlanRecord): LessonPlanResource[] {
+  const raw = record.resources ?? record.attachments;
+  if (!raw) {
+    return [];
+  }
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .map((item) => normalizeResource(item))
+    .filter((resource): resource is LessonPlanResource => resource !== null);
+}
+
+function normalizeResource(input: unknown): LessonPlanResource | null {
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+  const record = input as Record<string, unknown>;
+  const title =
+    nullableString(record.title) ??
+    nullableString(record.name) ??
+    nullableString(record.label);
+  const url =
+    nullableString(record.url) ??
+    nullableString(record.link) ??
+    nullableString(record.href) ??
+    null;
+  const type =
+    nullableString(record.type) ??
+    nullableString(record.format) ??
+    nullableString(record.kind) ??
+    null;
+  const description = nullableString(record.description) ?? null;
+
+  if (!title && !url) {
+    return null;
+  }
+
+  return {
+    title: title ?? "Resource",
+    url,
+    type,
+    description,
+  };
+}
+
+function normalizeContent(raw: unknown): LessonPlanContentSection[] {
+  if (!raw) {
+    return [];
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return normalizeContent(parsed);
+    } catch {
+      return [
+        {
+          title: null,
+          description: null,
+          blocks: [
+            {
+              type: "paragraph",
+              text: raw,
+            },
+          ],
+        },
+      ];
+    }
+  }
+  if (Array.isArray(raw)) {
+    return raw
+      .map((section, index) => normalizeSection(section, index))
+      .filter((section): section is LessonPlanContentSection => section !== null);
+  }
+  if (typeof raw === "object") {
+    const record = raw as Record<string, unknown>;
+    if (Array.isArray(record.sections)) {
+      return normalizeContent(record.sections);
+    }
+    if (Array.isArray(record.blocks)) {
+      return [
+        {
+          title: nullableString(record.title),
+          description: nullableString(record.description),
+          blocks: normalizeBlocks(record.blocks),
+        },
+      ];
+    }
+  }
+  return [];
+}
+
+function normalizeSection(
+  input: unknown,
+  index: number
+): LessonPlanContentSection | null {
+  if (!input) {
+    return null;
+  }
+  if (typeof input === "string") {
+    return {
+      title: null,
+      description: null,
+      blocks: [
+        {
+          type: "paragraph",
+          text: input,
+        },
+      ],
+    };
+  }
+  if (typeof input !== "object") {
+    return null;
+  }
+  const record = input as Record<string, unknown>;
+  const title = nullableString(record.title) ?? nullableString(record.name);
+  const description = nullableString(record.description) ?? null;
+  const blocks = normalizeBlocks(record.blocks ?? record.items ?? record.content);
+
+  return {
+    id: nullableString(record.id) ?? undefined,
+    title: title ?? null,
+    description,
+    blocks,
+  };
+}
+
+function normalizeBlocks(input: unknown): LessonPlanContentBlock[] {
+  if (!input) {
+    return [];
+  }
+  if (typeof input === "string") {
+    return [
+      {
+        type: "paragraph",
+        text: input,
+      },
+    ];
+  }
+  if (!Array.isArray(input)) {
+    if (typeof input === "object") {
+      return normalizeBlocks([input]);
+    }
+    return [];
+  }
+
+  return input
+    .map((block) => normalizeBlock(block))
+    .filter((block): block is LessonPlanContentBlock => block !== null);
+}
+
+function normalizeBlock(input: unknown): LessonPlanContentBlock | null {
+  if (!input) {
+    return null;
+  }
+  if (typeof input === "string") {
+    return {
+      type: "paragraph",
+      text: input,
+    };
+  }
+  if (typeof input !== "object") {
+    return null;
+  }
+  const record = input as Record<string, unknown>;
+  const type = nullableString(record.type) ?? "paragraph";
+  if (type === "paragraph") {
+    const text =
+      nullableString(record.text) ??
+      nullableString(record.content) ??
+      nullableString(record.value) ??
+      null;
+    if (!text && Array.isArray(record.children)) {
+      const combined = record.children
+        .map((child) =>
+          typeof child === "string"
+            ? child
+            : nullableString((child as Record<string, unknown>).text) ?? ""
+        )
+        .join(" ")
+        .trim();
+      if (combined.length > 0) {
+        return {
+          type: "paragraph",
+          text: combined,
+        };
+      }
+    }
+    return {
+      type: "paragraph",
+      text: text ?? "",
+    };
+  }
+  if (type === "heading") {
+    return {
+      type: "heading",
+      text:
+        nullableString(record.text) ??
+        nullableString(record.content) ??
+        nullableString(record.value) ??
+        "",
+      level:
+        typeof record.level === "number" && Number.isFinite(record.level)
+          ? record.level
+          : undefined,
+    };
+  }
+  if (type === "list" || type === "bulleted-list" || type === "numbered-list") {
+    const items = ensureStringArray(record.items ?? record.children ?? []);
+    return {
+      type: "list",
+      items,
+      ordered: type === "numbered-list" || record.ordered === true,
+    };
+  }
+  if (type === "quote") {
+    return {
+      type: "quote",
+      text: nullableString(record.text) ?? "",
+      attribution: nullableString(record.attribution) ?? null,
+    };
+  }
+  return {
+    type,
+    ...record,
+  } as LessonPlanContentBlock;
+}

--- a/api/_lib/supabase.ts
+++ b/api/_lib/supabase.ts
@@ -1,0 +1,29 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const FALLBACK_URL = "https://ruybexkjupmannggnstn.supabase.co";
+const FALLBACK_KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJ1eWJleGtqdXBtYW5uZ2duc3RuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTcyNTk3MTYsImV4cCI6MjA3MjgzNTcxNn0.n2MlQf65ggrUVW1nSXKMvoSsyBe9cxY_ElOHvMD5Das";
+
+let cachedClient: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  const url = process.env.SUPABASE_URL ?? FALLBACK_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+    process.env.SUPABASE_ANON_KEY ??
+    process.env.VITE_SUPABASE_ANON_KEY ??
+    FALLBACK_KEY;
+
+  cachedClient = createClient(url, key, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+
+  return cachedClient;
+}

--- a/api/lesson-plans.ts
+++ b/api/lesson-plans.ts
@@ -1,0 +1,60 @@
+import type { LessonPlanRecord } from "../types/lesson-plans";
+import {
+  buildLessonPlanQuery,
+  buildListResponse,
+  parseListFilters,
+  parseRequestUrl,
+} from "./_lib/lesson-plan-helpers";
+import { getSupabaseClient } from "./_lib/supabase";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+function errorResponse(status: number, message: string): Response {
+  return jsonResponse({ error: message }, status);
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  if (request.method && request.method.toUpperCase() !== "GET") {
+    return new Response(null, {
+      status: 405,
+      headers: {
+        Allow: "GET",
+      },
+    });
+  }
+
+  const url = parseRequestUrl(request);
+  const filters = parseListFilters(url);
+  const supabase = getSupabaseClient();
+
+  const initialQuery = buildLessonPlanQuery(supabase, filters, {
+    useFullTextSearch: true,
+  });
+  let { data, error } = await initialQuery;
+
+  if (error && filters.q) {
+    const fallbackQuery = buildLessonPlanQuery(supabase, filters, {
+      useFullTextSearch: false,
+    });
+    const fallback = await fallbackQuery;
+    data = fallback.data;
+    error = fallback.error;
+  }
+
+  if (error) {
+    return errorResponse(500, "Failed to load lesson plans");
+  }
+
+  const records: LessonPlanRecord[] = data ?? [];
+  const payload = buildListResponse(records, filters);
+  return jsonResponse(payload);
+}

--- a/api/lesson-plans/[id]-pdf.ts
+++ b/api/lesson-plans/[id]-pdf.ts
@@ -1,0 +1,79 @@
+import type { LessonPlanRecord } from "../../types/lesson-plans";
+import {
+  mapRecordToDetail,
+  parseRequestUrl,
+  renderLessonPlanToPdf,
+} from "../_lib/lesson-plan-helpers";
+import { getSupabaseClient } from "../_lib/supabase";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  if (request.method && request.method.toUpperCase() !== "GET") {
+    return new Response(null, {
+      status: 405,
+      headers: {
+        Allow: "GET",
+      },
+    });
+  }
+
+  const url = parseRequestUrl(request);
+  const segments = url.pathname.split("/").filter(Boolean);
+  const lastSegment = segments.pop();
+  if (lastSegment?.toLowerCase() !== "pdf") {
+    return jsonResponse({ error: "Lesson plan not found" }, 404);
+  }
+  const id = segments.pop();
+
+  if (!id) {
+    return jsonResponse({ error: "Lesson plan not found" }, 404);
+  }
+
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from<LessonPlanRecord>("lesson_plans")
+    .select("*")
+    .eq("status", "published")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    return jsonResponse({ error: "Failed to load lesson plan" }, 500);
+  }
+
+  if (!data) {
+    return jsonResponse({ error: "Lesson plan not found" }, 404);
+  }
+
+  if (data.pdf_url && typeof data.pdf_url === "string") {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: data.pdf_url,
+      },
+    });
+  }
+
+  const detail = mapRecordToDetail(data);
+  const pdfBuffer = await renderLessonPlanToPdf(detail);
+
+  return new Response(pdfBuffer, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="${detail.slug}.pdf"`,
+      "Cache-Control": "public, max-age=3600",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}

--- a/api/lesson-plans/[slug].ts
+++ b/api/lesson-plans/[slug].ts
@@ -1,0 +1,55 @@
+import type { LessonPlanRecord } from "../../types/lesson-plans";
+import {
+  mapRecordToDetail,
+  parseRequestUrl,
+} from "../_lib/lesson-plan-helpers";
+import { getSupabaseClient } from "../_lib/supabase";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  if (request.method && request.method.toUpperCase() !== "GET") {
+    return new Response(null, {
+      status: 405,
+      headers: {
+        Allow: "GET",
+      },
+    });
+  }
+
+  const url = parseRequestUrl(request);
+  const segments = url.pathname.split("/").filter(Boolean);
+  const slug = segments.pop();
+
+  if (!slug) {
+    return jsonResponse({ error: "Lesson plan not found" }, 404);
+  }
+
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from<LessonPlanRecord>("lesson_plans")
+    .select("*")
+    .eq("status", "published")
+    .eq("slug", slug)
+    .maybeSingle();
+
+  if (error) {
+    return jsonResponse({ error: "Failed to load lesson plan" }, 500);
+  }
+
+  if (!data) {
+    return jsonResponse({ error: "Lesson plan not found" }, 404);
+  }
+
+  const payload = mapRecordToDetail(data);
+  return jsonResponse(payload);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@react-pdf/renderer": "^4.3.0",
         "@supabase/supabase-js": "^2.57.2",
         "@tanstack/react-query": "^5.83.0",
         "class-variance-authority": "^0.7.1",
@@ -2516,6 +2517,186 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
+      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.2.tgz",
+      "integrity": "sha512-/dAWu7Y2RD1RxarDZ9SkYPHgBYOhmcDnet4W/qN/m8k+A2Hr3ja54GymSR7GGxWBtxjKtNauVKrTa9LS1n8WUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^4.0.3",
+        "@react-pdf/types": "^2.9.0",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.0.3.tgz",
+      "integrity": "sha512-lvP5ryzYM3wpbO9bvqLZYwEr5XBDX9jcaRICvtnoRqdJOo7PRrMnmB4MMScyb+Xw10mGeIubZAAomNAG5ONQZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/png-js": "^3.0.0",
+        "jay-peg": "^1.1.1"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.4.0.tgz",
+      "integrity": "sha512-Aq+Cc6JYausWLoks2FvHe3PwK9cTuvksB2uJ0AnkKJEUtQbvCq8eCRb1bjbbwIji9OzFRTTzZij7LzkpKHjIeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/image": "^3.0.3",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.0",
+        "@react-pdf/textkit": "^6.0.0",
+        "@react-pdf/types": "^2.9.0",
+        "emoji-regex": "^10.3.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/layout/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-4.0.3.tgz",
+      "integrity": "sha512-k+Lsuq8vTwWsCqTp+CCB4+2N+sOTFrzwGA7aw3H9ix/PDWR9QksbmNg0YkzGbLAPI6CeawmiLHcf4trZ5ecLPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/png-js": "^3.0.0",
+        "browserify-zlib": "^0.2.0",
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "linebreak": "^1.1.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/png-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/png-js/-/png-js-3.0.0.tgz",
+      "integrity": "sha512-eSJnEItZ37WPt6Qv5pncQDxLJRK15eaRwPT+gZoujP548CodenOVp49GST8XJvKMFt9YqIBzGBV/j9AgrOQzVA==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.1.1.tgz",
+      "integrity": "sha512-IuhxYls1luJb7NUWy6q5avb1XrNaVj9bTNI40U9qGRuS6n7Hje/8H8Qi99Z9UKFV74bBP3DOf3L1wV2qZVgVrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-1.1.4.tgz",
+      "integrity": "sha512-oTQDiR/t4Z/Guxac88IavpU2UgN7eR0RMI9DRKvKnvPz2DUasGjXfChAdMqDNmJJxxV26mMy9xQOUV2UU5/okg==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.3.0.tgz",
+      "integrity": "sha512-MdWfWaqO6d7SZD75TZ2z5L35V+cHpyA43YNRlJNG0RJ7/MeVGDQv12y/BXOJgonZKkeEGdzM3EpAt9/g4E22WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/textkit": "^6.0.0",
+        "@react-pdf/types": "^2.9.0",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^1.9.1",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.3.0.tgz",
+      "integrity": "sha512-28gpA69fU9ZQrDzmd5xMJa1bDf8t0PT3ApUKBl2PUpoE/x4JlvCB5X66nMXrfFrgF2EZrA72zWQAkvbg7TE8zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/font": "^4.0.2",
+        "@react-pdf/layout": "^4.4.0",
+        "@react-pdf/pdfkit": "^4.0.3",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/reconciler": "^1.1.4",
+        "@react-pdf/render": "^4.3.0",
+        "@react-pdf/types": "^2.9.0",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.1.0.tgz",
+      "integrity": "sha512-BGZ2sYNUp38VJUegjva/jsri3iiRGnVNjWI+G9dTwAvLNOmwFvSJzqaCsEnqQ/DW5mrTBk/577FhDY7pv6AidA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/types": "^2.9.0",
+        "color-string": "^1.9.1",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.0.0.tgz",
+      "integrity": "sha512-fDt19KWaJRK/n2AaFoVm31hgGmpygmTV7LsHGJNGZkgzXcFyLsx+XUl63DTDPH3iqxj3xUX128t104GtOz8tTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.9.0.tgz",
+      "integrity": "sha512-ckj80vZLlvl9oYrQ4tovEaqKWP3O06Eb1D48/jQWbdwz1Yh7Y9v1cEmwlP8ET+a1Whp8xfdM0xduMexkuPANCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.2",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.0"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -3045,6 +3226,15 @@
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@swc/types": {
       "version": "0.1.23",
@@ -3728,6 +3918,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3913,11 +4109,30 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -3956,6 +4171,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -4132,6 +4365,15 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4175,6 +4417,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -4203,6 +4455,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-tree": {
       "version": "3.1.0",
@@ -4502,6 +4760,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
       "license": "MIT"
     },
     "node_modules/didyoumean": {
@@ -4857,6 +5121,15 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -4871,7 +5144,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -4996,6 +5268,23 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.0",
@@ -5157,6 +5446,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -5197,6 +5501,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.10.6.tgz",
+      "integrity": "sha512-fXHXcGFTXOvZTSkPJuGOQf5Lv5T/R2itiiCVPg9LxAje5D00O0pP83yJShFq5V89Ly//Gt6acj7z8pbBr34stw==",
+      "license": "ISC"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -5258,6 +5568,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/input-otp": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
@@ -5285,6 +5601,12 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -5359,6 +5681,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5378,6 +5706,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
       }
     },
     "node_modules/jiti": {
@@ -5540,6 +5877,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -6100,6 +6456,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6233,6 +6595,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6307,6 +6678,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6319,6 +6696,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -6656,6 +7039,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6970,7 +7362,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7002,6 +7393,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -7078,6 +7475,26 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7167,6 +7584,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/sonner": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
@@ -7199,6 +7625,15 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -7389,6 +7824,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -7472,6 +7913,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -7704,6 +8151,32 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -7896,6 +8369,20 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/vite-node": {
@@ -8251,6 +8738,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@react-pdf/renderer": "^4.3.0",
     "@supabase/supabase-js": "^2.57.2",
     "@tanstack/react-query": "^5.83.0",
     "class-variance-authority": "^0.7.1",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,6 +11,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "jsx": "react-jsx",
 
     /* Linting */
     "strict": true,
@@ -18,5 +19,5 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "api", "types"]
 }

--- a/types/lesson-plans.ts
+++ b/types/lesson-plans.ts
@@ -1,0 +1,117 @@
+export type LessonPlanStatus = "draft" | "published" | "archived";
+
+export interface LessonPlanListItem {
+  id: string;
+  slug: string;
+  title: string;
+  summary: string | null;
+  stage: string | null;
+  stages: string[];
+  subjects: string[];
+  deliveryMethods: string[];
+  technologyTags: string[];
+  durationMinutes: number | null;
+  pdfUrl: string | null;
+  status: LessonPlanStatus;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface LessonPlanOverview {
+  summary: string | null;
+  essentialQuestion: string | null;
+  objectives: string[];
+  materials: string[];
+  assessment: string[];
+  technology: string[];
+  delivery: string[];
+  stage: string | null;
+  subjects: string[];
+  durationMinutes: number | null;
+}
+
+export type LessonPlanContentBlock =
+  | {
+      type: "paragraph";
+      text: string;
+    }
+  | {
+      type: "heading";
+      text: string;
+      level?: number;
+    }
+  | {
+      type: "list";
+      items: string[];
+      ordered?: boolean;
+    }
+  | {
+      type: "quote";
+      text: string;
+      attribution?: string;
+    }
+  | ({
+      type: string;
+    } & Record<string, unknown>);
+
+export interface LessonPlanContentSection {
+  id?: string;
+  title: string | null;
+  description: string | null;
+  blocks: LessonPlanContentBlock[];
+}
+
+export interface LessonPlanResource {
+  title: string;
+  url: string | null;
+  type: string | null;
+  description: string | null;
+}
+
+export interface LessonPlanDetail extends LessonPlanListItem {
+  content: LessonPlanContentSection[];
+  overview: LessonPlanOverview | null;
+  resources: LessonPlanResource[];
+}
+
+export interface LessonPlanListResponse {
+  items: LessonPlanListItem[];
+  nextCursor: string | null;
+}
+
+export interface LessonPlanRecord {
+  id: string;
+  slug: string;
+  title: string;
+  status: LessonPlanStatus;
+  summary?: string | null;
+  excerpt?: string | null;
+  description?: string | null;
+  overview?: unknown;
+  stage?: string | null;
+  stages?: string[] | null;
+  stage_levels?: string[] | null;
+  subjects?: string[] | null;
+  subject?: string | null;
+  delivery_methods?: string[] | null;
+  delivery?: string[] | null;
+  delivery_modes?: string[] | null;
+  delivery_format?: string[] | null;
+  technology_tags?: string[] | null;
+  technology?: string[] | null;
+  tech?: string[] | null;
+  tools?: string[] | null;
+  duration_minutes?: number | null;
+  duration?: number | null;
+  time_required?: number | null;
+  pdf_url?: string | null;
+  pdf?: string | null;
+  attachments?: unknown;
+  resources?: unknown;
+  content?: unknown;
+  body?: unknown;
+  created_at?: string | null;
+  updated_at?: string | null;
+  published_at?: string | null;
+  metadata?: unknown;
+}


### PR DESCRIPTION
## Summary
- add shared TypeScript models for lesson plans
- implement serverless handlers for listing, fetching, and exporting lesson plans as PDFs
- add Supabase helper utilities plus integration tests for the new endpoints

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d022a7eae48331a33168cc44a345dd