### PR TITLE
Add lesson plan listing and detail pages

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -13,6 +13,8 @@ import FAQ from '@/pages/FAQ';
 import Edutech from '@/pages/Edutech';
 import TeacherDiary from '@/pages/TeacherDiary';
 import TeacherDiaryEntry from '@/pages/TeacherDiaryEntry';
+import LessonPlans from '@/pages/LessonPlans';
+import LessonPlan from '@/pages/LessonPlan';
 import Auth from '@/pages/Auth';
 import Account from '@/pages/Account';
 import NotFound from '@/pages/NotFound';
@@ -47,6 +49,8 @@ export const LocalizedRoutes = () => {
       <Route path="/services" element={<RouteWrapper><Services /></RouteWrapper>} />
       <Route path="/blog" element={<RouteWrapper><Blog /></RouteWrapper>} />
       <Route path="/blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
+      <Route path="/lesson-plans" element={<RouteWrapper><LessonPlans /></RouteWrapper>} />
+      <Route path="/lesson-plans/:slug" element={<RouteWrapper><LessonPlan /></RouteWrapper>} />
       <Route path="/events" element={<RouteWrapper><Events /></RouteWrapper>} />
       <Route path="/events/:slug" element={<RouteWrapper><EventDetail /></RouteWrapper>} />
       <Route path="/contact" element={<RouteWrapper><Contact /></RouteWrapper>} />
@@ -65,6 +69,8 @@ export const LocalizedRoutes = () => {
         <Route path="services" element={<RouteWrapper><Services /></RouteWrapper>} />
         <Route path="blog" element={<RouteWrapper><Blog /></RouteWrapper>} />
         <Route path="blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
+        <Route path="lesson-plans" element={<RouteWrapper><LessonPlans /></RouteWrapper>} />
+        <Route path="lesson-plans/:slug" element={<RouteWrapper><LessonPlan /></RouteWrapper>} />
         <Route path="events" element={<RouteWrapper><Events /></RouteWrapper>} />
         <Route path="events/:slug" element={<RouteWrapper><EventDetail /></RouteWrapper>} />
         <Route path="contact" element={<RouteWrapper><Contact /></RouteWrapper>} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -40,6 +40,7 @@ const Navigation = () => {
   const navItems = [
     { name: t.nav.home, path: "/" },
     { name: t.nav.blog, path: "/blog" },
+    { name: t.nav.lessonPlans, path: "/lesson-plans" },
     { name: t.nav.events, path: "/events" },
     { name: t.nav.services, path: "/services" },
     { name: t.nav.about, path: "/about" },

--- a/src/components/lesson-plans/EmptyState.tsx
+++ b/src/components/lesson-plans/EmptyState.tsx
@@ -1,0 +1,25 @@
+import { BookOpenCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  resetLabel: string;
+  onReset: () => void;
+}
+
+export function EmptyState({ title, description, resetLabel, onReset }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl border bg-card/40 p-12 text-center shadow-sm">
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <BookOpenCheck className="h-8 w-8" aria-hidden="true" />
+      </div>
+      <h3 className="text-xl font-semibold">{title}</h3>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">{description}</p>
+      <Button type="button" className="mt-6" onClick={onReset}>
+        {resetLabel}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/lesson-plans/LessonCard.tsx
+++ b/src/components/lesson-plans/LessonCard.tsx
@@ -1,0 +1,91 @@
+import { ArrowRight, Clock } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import type { LessonPlanListItem } from "@/types/lesson-plans";
+
+interface LessonCardProps {
+  lesson: LessonPlanListItem;
+  onSelect: (lesson: LessonPlanListItem) => void;
+  openLabel: string;
+  durationFormatter?: (minutes: number) => string;
+}
+
+const MAX_TAGS = 3;
+
+function formatDuration(minutes: number, formatter?: (minutes: number) => string): string {
+  if (formatter) {
+    return formatter(minutes);
+  }
+  return `${minutes} min`;
+}
+
+export function LessonCard({ lesson, onSelect, openLabel, durationFormatter }: LessonCardProps) {
+  const subjectBadges = lesson.subjects.slice(0, MAX_TAGS);
+  const deliveryBadges = lesson.deliveryMethods.slice(0, MAX_TAGS);
+  const techBadges = lesson.technologyTags.slice(0, MAX_TAGS);
+
+  return (
+    <Card className="group relative h-full overflow-hidden border border-border/60">
+      <button
+        type="button"
+        onClick={() => onSelect(lesson)}
+        aria-label={`${openLabel}: ${lesson.title}`}
+        className="flex h-full w-full flex-col gap-4 p-6 text-left transition hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      >
+        <div className="flex flex-wrap gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+          {lesson.stage ? <Badge variant="secondary">{lesson.stage}</Badge> : null}
+          {subjectBadges.map((subject) => (
+            <Badge key={subject} variant="outline">
+              {subject}
+            </Badge>
+          ))}
+        </div>
+
+        <div className="space-y-3">
+          <h3 className="text-xl font-semibold leading-tight group-hover:text-primary">
+            {lesson.title}
+          </h3>
+          {lesson.summary ? (
+            <p className="line-clamp-3 text-sm text-muted-foreground">{lesson.summary}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-3 text-sm text-muted-foreground">
+          {deliveryBadges.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {deliveryBadges.map((mode) => (
+                <Badge key={mode} variant="secondary" className="bg-primary/5 text-primary">
+                  {mode}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+
+          {techBadges.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {techBadges.map((tag) => (
+                <Badge key={tag} variant="outline" className="border-dashed">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="mt-auto flex items-center justify-between text-sm font-medium text-muted-foreground">
+          {lesson.durationMinutes != null ? (
+            <span className="inline-flex items-center gap-1">
+              <Clock className="h-4 w-4" aria-hidden="true" />
+              {formatDuration(lesson.durationMinutes, durationFormatter)}
+            </span>
+          ) : <span />}
+          <span className="inline-flex items-center gap-2 text-primary">
+            {openLabel}
+            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden="true" />
+          </span>
+        </div>
+      </button>
+    </Card>
+  );
+}

--- a/src/components/lesson-plans/LessonFilters.tsx
+++ b/src/components/lesson-plans/LessonFilters.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useMemo, useState } from "react";
+import type { CheckedState } from "@radix-ui/react-checkbox";
+import { Filter, SlidersHorizontal } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@/components/ui/toggle-group";
+import type { DeliveryMode, Stage } from "@/types/lesson-plans";
+
+type FilterValue = string;
+
+interface LessonFiltersProps {
+  stages: Stage[];
+  deliveryModes: DeliveryMode[];
+  technologyOptions: { value: string; label: string }[];
+  selectedStages: FilterValue[];
+  selectedDeliveryModes: FilterValue[];
+  selectedTechnologies: FilterValue[];
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  onStagesChange: (values: FilterValue[]) => void;
+  onDeliveryChange: (values: FilterValue[]) => void;
+  onTechnologyChange: (values: FilterValue[]) => void;
+  onClearFilters: () => void;
+  searchPlaceholder: string;
+  title: string;
+  stageLabel: string;
+  deliveryLabel: string;
+  technologyLabel: string;
+  clearLabel: string;
+  closeLabel: string;
+}
+
+const MOBILE_BREAKPOINT = 1024;
+
+export function LessonFilters({
+  stages,
+  deliveryModes,
+  technologyOptions,
+  selectedStages,
+  selectedDeliveryModes,
+  selectedTechnologies,
+  searchTerm,
+  onSearchChange,
+  onStagesChange,
+  onDeliveryChange,
+  onTechnologyChange,
+  onClearFilters,
+  searchPlaceholder,
+  title,
+  stageLabel,
+  deliveryLabel,
+  technologyLabel,
+  clearLabel,
+  closeLabel,
+}: LessonFiltersProps) {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [currentSearch, setCurrentSearch] = useState(searchTerm);
+
+  useEffect(() => {
+    setCurrentSearch(searchTerm);
+  }, [searchTerm]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= MOBILE_BREAKPOINT) {
+        setIsSheetOpen(false);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+
+  const selectedCount = useMemo(
+    () =>
+      selectedStages.length +
+      selectedDeliveryModes.length +
+      selectedTechnologies.length,
+    [selectedStages.length, selectedDeliveryModes.length, selectedTechnologies.length],
+  );
+
+  const renderStageOption = (stage: Stage) => (
+    <label
+      key={stage.value}
+      className="flex items-start space-x-3 rounded-lg border border-transparent px-3 py-2 transition hover:border-border"
+    >
+      <Checkbox
+        checked={selectedStages.includes(stage.value)}
+        onCheckedChange={(checked: CheckedState) => {
+          const value = stage.value;
+          if (checked === true) {
+            if (!selectedStages.includes(value)) {
+              onStagesChange([...selectedStages, value]);
+            }
+          } else {
+            onStagesChange(selectedStages.filter((item) => item !== value));
+          }
+        }}
+        aria-label={stage.label}
+      />
+      <span className="flex flex-1 flex-col text-sm">
+        <span className="font-medium">{stage.label}</span>
+        {stage.description ? (
+          <span className="text-muted-foreground">{stage.description}</span>
+        ) : null}
+        {stage.gradeRange ? (
+          <span className="text-xs text-muted-foreground">{stage.gradeRange}</span>
+        ) : null}
+      </span>
+    </label>
+  );
+
+  const renderDeliveryOption = (delivery: DeliveryMode) => (
+    <label
+      key={delivery.value}
+      className="flex items-start space-x-3 rounded-lg border border-transparent px-3 py-2 transition hover:border-border"
+    >
+      <Checkbox
+        checked={selectedDeliveryModes.includes(delivery.value)}
+        onCheckedChange={(checked: CheckedState) => {
+          const value = delivery.value;
+          if (checked === true) {
+            if (!selectedDeliveryModes.includes(value)) {
+              onDeliveryChange([...selectedDeliveryModes, value]);
+            }
+          } else {
+            onDeliveryChange(selectedDeliveryModes.filter((item) => item !== value));
+          }
+        }}
+        aria-label={delivery.label}
+      />
+      <span className="flex flex-1 flex-col text-sm">
+        <span className="font-medium">{delivery.label}</span>
+        {delivery.description ? (
+          <span className="text-muted-foreground">{delivery.description}</span>
+        ) : null}
+        {delivery.durationHint ? (
+          <span className="text-xs text-muted-foreground">{delivery.durationHint}</span>
+        ) : null}
+      </span>
+    </label>
+  );
+
+  const content = (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <label className="text-sm font-medium" htmlFor="lesson-search">
+          {searchPlaceholder}
+        </label>
+        <Input
+          id="lesson-search"
+          type="search"
+          placeholder={searchPlaceholder}
+          value={currentSearch}
+          onChange={(event) => {
+            const value = event.target.value;
+            setCurrentSearch(value);
+            onSearchChange(value);
+          }}
+          aria-label={searchPlaceholder}
+        />
+      </div>
+
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <span className="text-sm font-semibold">{stageLabel}</span>
+        </div>
+        <div className="space-y-2">
+          {stages.map(renderStageOption)}
+        </div>
+      </div>
+
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <span className="text-sm font-semibold">{deliveryLabel}</span>
+        </div>
+        <div className="space-y-2">
+          {deliveryModes.map(renderDeliveryOption)}
+        </div>
+      </div>
+
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <span className="text-sm font-semibold">{technologyLabel}</span>
+        </div>
+        <ToggleGroup
+          type="multiple"
+          value={selectedTechnologies}
+          onValueChange={onTechnologyChange}
+          className="flex flex-wrap gap-2"
+          aria-label={technologyLabel}
+        >
+          {technologyOptions.map((option) => (
+            <ToggleGroupItem
+              key={option.value}
+              value={option.value}
+              className="rounded-full border px-4 py-2 text-sm font-medium"
+              aria-pressed={selectedTechnologies.includes(option.value)}
+            >
+              {option.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => {
+            onClearFilters();
+            setCurrentSearch("");
+            onSearchChange("");
+          }}
+        >
+          {clearLabel}
+        </Button>
+        {selectedCount > 0 ? (
+          <Badge variant="secondary" aria-live="polite">
+            {selectedCount}
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  return (
+    <aside>
+      <div className="mb-4 flex items-center justify-between lg:hidden">
+        <div className="flex items-center gap-2">
+          <Filter className="h-4 w-4" aria-hidden="true" />
+          <span className="text-sm font-medium">{title}</span>
+          {selectedCount > 0 ? (
+            <Badge variant="secondary" aria-live="polite">
+              {selectedCount}
+            </Badge>
+          ) : null}
+        </div>
+        <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
+          <SheetTrigger asChild>
+            <Button variant="outline" size="sm" aria-label={title}>
+              <SlidersHorizontal className="mr-2 h-4 w-4" />
+              {title}
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="right" className="w-full sm:max-w-md">
+            <SheetHeader>
+              <SheetTitle>{title}</SheetTitle>
+            </SheetHeader>
+            <div className="mt-6 max-h-[70vh] overflow-y-auto pr-2">
+              {content}
+            </div>
+            <SheetFooter className="mt-6">
+              <Button
+                type="button"
+                className="w-full"
+                onClick={() => setIsSheetOpen(false)}
+              >
+                {closeLabel}
+              </Button>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      <div className="hidden lg:block">
+        <div className="rounded-2xl border bg-card p-6 shadow-sm">
+          <div className="mb-4 flex items-center gap-2">
+            <Filter className="h-4 w-4" aria-hidden="true" />
+            <h2 className="text-lg font-semibold">{title}</h2>
+            {selectedCount > 0 ? (
+              <Badge variant="secondary" aria-live="polite">
+                {selectedCount}
+              </Badge>
+            ) : null}
+          </div>
+          {content}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/lesson-plans/LessonModal.tsx
+++ b/src/components/lesson-plans/LessonModal.tsx
@@ -1,0 +1,356 @@
+import { useEffect, useMemo } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type {
+  LessonPlan,
+  LessonPlanContentBlock,
+  LessonPlanListItem,
+} from "@/types/lesson-plans";
+
+export interface LessonDetailCopy {
+  stageLabel: string;
+  subjectsLabel: string;
+  deliveryLabel: string;
+  technologyLabel: string;
+  durationLabel: string;
+  summaryLabel: string;
+  overviewTitle: string;
+  objectivesLabel: string;
+  materialsLabel: string;
+  assessmentLabel: string;
+  technologyOverviewLabel: string;
+  deliveryOverviewLabel: string;
+  durationOverviewLabel: string;
+  structureTitle: string;
+  resourcesTitle: string;
+  resourceLinkLabel: string;
+  noResourcesLabel: string;
+  errorLabel: string;
+  downloadLabel: string;
+  openFullLabel: string;
+  closeLabel: string;
+  loadingLabel: string;
+  minutesFormatter: (minutes: number) => string;
+}
+
+interface LessonDetailContentProps {
+  lesson?: LessonPlan | null;
+  initialLesson?: LessonPlanListItem | null;
+  copy: LessonDetailCopy;
+  isLoading?: boolean;
+  errorMessage?: string | null;
+}
+
+interface LessonModalProps extends LessonDetailContentProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onDownloadPdf?: () => void;
+  onOpenFullPage?: () => void;
+}
+
+function useLockBodyScroll(isLocked: boolean) {
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+
+    if (isLocked) {
+      body.style.overflow = "hidden";
+    } else {
+      body.style.overflow = previousOverflow;
+    }
+
+    return () => {
+      body.style.overflow = previousOverflow;
+    };
+  }, [isLocked]);
+}
+
+function renderBlock(block: LessonPlanContentBlock, index: number) {
+  switch (block.type) {
+    case "heading": {
+      const level = Math.min(Math.max(block.level ?? 3, 2), 5);
+      const Tag = `h${level}` as keyof JSX.IntrinsicElements;
+      return (
+        <Tag key={index} className="text-lg font-semibold">
+          {block.text}
+        </Tag>
+      );
+    }
+    case "list": {
+      const ListComponent = block.ordered ? "ol" : "ul";
+      return (
+        <ListComponent key={index} className="ml-6 list-disc space-y-1 text-sm text-muted-foreground">
+          {block.items.map((item, itemIndex) => (
+            <li key={itemIndex}>{item}</li>
+          ))}
+        </ListComponent>
+      );
+    }
+    case "quote": {
+      return (
+        <blockquote
+          key={index}
+          className="border-l-4 border-primary/40 pl-4 italic text-muted-foreground"
+        >
+          {block.text}
+          {block.attribution ? <footer className="mt-2 text-xs">— {block.attribution}</footer> : null}
+        </blockquote>
+      );
+    }
+    case "paragraph":
+    default:
+      return (
+        <p key={index} className="text-sm leading-relaxed text-muted-foreground">
+          {"text" in block ? block.text : null}
+        </p>
+      );
+  }
+}
+
+export function LessonDetailContent({
+  lesson,
+  initialLesson,
+  copy,
+  isLoading = false,
+  errorMessage = null,
+}: LessonDetailContentProps) {
+  const activeLesson = lesson ?? initialLesson ?? null;
+
+  const metaBadges = useMemo(() => {
+    if (!activeLesson) {
+      return [];
+    }
+
+    const badges: Array<{ label: string; values: string[] }> = [
+      { label: copy.stageLabel, values: activeLesson.stage ? [activeLesson.stage] : [] },
+      { label: copy.subjectsLabel, values: activeLesson.subjects },
+      { label: copy.deliveryLabel, values: activeLesson.deliveryMethods },
+      { label: copy.technologyLabel, values: activeLesson.technologyTags },
+    ];
+
+    return badges.filter((badge) => badge.values.length > 0);
+  }, [activeLesson, copy.deliveryLabel, copy.stageLabel, copy.subjectsLabel, copy.technologyLabel]);
+
+  return (
+    <div className="space-y-6">
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">{copy.loadingLabel}</p>
+      ) : errorMessage ? (
+        <p className="text-sm text-destructive">{errorMessage}</p>
+      ) : null}
+
+      {metaBadges.length > 0 ? (
+        <div className="space-y-2">
+          {metaBadges.map((badge) => (
+            <div key={badge.label}>
+              <p className="text-xs font-semibold uppercase text-muted-foreground">{badge.label}</p>
+              <div className="mt-1 flex flex-wrap gap-2">
+                {badge.values.map((value) => (
+                  <Badge key={value} variant="secondary">
+                    {value}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {activeLesson?.durationMinutes != null ? (
+        <div>
+          <p className="text-xs font-semibold uppercase text-muted-foreground">{copy.durationLabel}</p>
+          <p className="text-sm text-muted-foreground">
+            {copy.minutesFormatter(activeLesson.durationMinutes)}
+          </p>
+        </div>
+      ) : null}
+
+      {lesson?.overview ? (
+        <section className="space-y-4">
+          <h3 className="text-lg font-semibold">{copy.overviewTitle}</h3>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {lesson.overview.objectives?.length ? (
+              <div>
+                <h4 className="text-sm font-semibold">{copy.objectivesLabel}</h4>
+                <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+                  {lesson.overview.objectives.map((objective, index) => (
+                    <li key={index}>{objective}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {lesson.overview.materials?.length ? (
+              <div>
+                <h4 className="text-sm font-semibold">{copy.materialsLabel}</h4>
+                <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+                  {lesson.overview.materials.map((material, index) => (
+                    <li key={index}>{material}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {lesson.overview.assessment?.length ? (
+              <div>
+                <h4 className="text-sm font-semibold">{copy.assessmentLabel}</h4>
+                <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+                  {lesson.overview.assessment.map((item, index) => (
+                    <li key={index}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {lesson.overview.technology?.length ? (
+              <div>
+                <h4 className="text-sm font-semibold">{copy.technologyOverviewLabel}</h4>
+                <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+                  {lesson.overview.technology.map((tech, index) => (
+                    <li key={index}>{tech}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {lesson.overview.delivery?.length ? (
+              <div>
+                <h4 className="text-sm font-semibold">{copy.deliveryOverviewLabel}</h4>
+                <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+                  {lesson.overview.delivery.map((delivery, index) => (
+                    <li key={index}>{delivery}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {lesson.overview.durationMinutes != null ? (
+              <div>
+                <h4 className="text-sm font-semibold">{copy.durationOverviewLabel}</h4>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {copy.minutesFormatter(lesson.overview.durationMinutes)}
+                </p>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
+      {lesson?.content?.length ? (
+        <section className="space-y-4">
+          <h3 className="text-lg font-semibold">{copy.structureTitle}</h3>
+          <div className="space-y-6">
+            {lesson.content.map((section, sectionIndex) => (
+              <article key={section.id ?? sectionIndex} className="space-y-3">
+                {section.title ? (
+                  <h4 className="text-base font-semibold">{section.title}</h4>
+                ) : null}
+                {section.description ? (
+                  <p className="text-sm text-muted-foreground">{section.description}</p>
+                ) : null}
+                <div className="space-y-3">
+                  {section.blocks.map((block, blockIndex) => renderBlock(block, blockIndex))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {lesson?.resources?.length ? (
+        <section className="space-y-4">
+          <h3 className="text-lg font-semibold">{copy.resourcesTitle}</h3>
+          <ul className="space-y-3 text-sm text-muted-foreground">
+            {lesson.resources.map((resource, index) => (
+              <li key={`${resource.title}-${index}`} className="rounded-lg border p-4">
+                <p className="font-medium text-foreground">{resource.title}</p>
+                {resource.description ? (
+                  <p className="mt-1 text-sm text-muted-foreground">{resource.description}</p>
+                ) : null}
+                {resource.url ? (
+                  <a
+                    href={resource.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2 inline-flex items-center text-primary hover:underline"
+                  >
+                    {copy.resourceLinkLabel}
+                  </a>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {!isLoading && lesson && !lesson.content.length && !lesson.resources.length ? (
+        <p className="text-sm text-muted-foreground">{copy.noResourcesLabel}</p>
+      ) : null}
+    </div>
+  );
+}
+
+export function LessonModal({
+  isOpen,
+  onClose,
+  lesson,
+  initialLesson,
+  onDownloadPdf,
+  onOpenFullPage,
+  copy,
+  isLoading = false,
+  errorMessage = null,
+}: LessonModalProps) {
+  useLockBodyScroll(isOpen);
+
+  const activeLesson = lesson ?? initialLesson ?? null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(value) => !value && onClose()}>
+      <DialogContent className="flex max-h-[90vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
+        <DialogHeader className="border-b p-6">
+          <DialogTitle className="text-2xl font-bold">
+            {activeLesson?.title ?? copy.loadingLabel}
+          </DialogTitle>
+          <DialogDescription>
+            {activeLesson?.summary ?? copy.summaryLabel}
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="flex-1">
+          <div className="p-6">
+            <LessonDetailContent
+              lesson={lesson}
+              initialLesson={initialLesson}
+              copy={copy}
+              isLoading={isLoading}
+              errorMessage={errorMessage}
+            />
+          </div>
+        </ScrollArea>
+        <DialogFooter className="border-t bg-muted/30 p-4 sm:px-6">
+          <div className="flex w-full flex-col gap-3 sm:flex-row sm:justify-end">
+            {onOpenFullPage ? (
+              <Button variant="outline" onClick={onOpenFullPage}>
+                {copy.openFullLabel}
+              </Button>
+            ) : null}
+            {onDownloadPdf ? (
+              <Button onClick={onDownloadPdf}>{copy.downloadLabel}</Button>
+            ) : null}
+            <Button variant="ghost" onClick={onClose}>
+              {copy.closeLabel}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/lesson-plans/Skeletons.tsx
+++ b/src/components/lesson-plans/Skeletons.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface LessonSkeletonsProps {
+  count?: number;
+}
+
+export function LessonSkeletons({ count = 6 }: LessonSkeletonsProps) {
+  return (
+    <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+      {Array.from({ length: count }).map((_, index) => (
+        <div key={index} className="flex h-full flex-col gap-4 rounded-2xl border p-6">
+          <Skeleton className="h-4 w-32" />
+          <div className="space-y-2">
+            <Skeleton className="h-6 w-3/4" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+          </div>
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+          <div className="mt-auto flex items-center justify-between">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/LessonPlan.tsx
+++ b/src/pages/LessonPlan.tsx
@@ -1,0 +1,179 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, Download } from "lucide-react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { SEO } from "@/components/SEO";
+import { LessonDetailContent, LessonDetailCopy } from "@/components/lesson-plans/LessonModal";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+import type { LessonPlan } from "@/types/lesson-plans";
+
+async function fetchLessonPlanDetail(slug: string): Promise<LessonPlan> {
+  const response = await fetch(`/api/lesson-plans/${slug}`);
+  if (!response.ok) {
+    throw new Error("Failed to load lesson plan");
+  }
+  return response.json() as Promise<LessonPlan>;
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <Skeleton className="h-10 w-3/4" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} className="h-24" />
+        ))}
+      </div>
+      <div className="space-y-3">
+        <Skeleton className="h-6 w-1/3" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+      </div>
+    </div>
+  );
+}
+
+const LessonPlanPage = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+  const { t, language } = useLanguage();
+
+  const lessonCopy = useMemo<LessonDetailCopy>(
+    () => ({
+      stageLabel: t.lessonPlans.modal.stage,
+      subjectsLabel: t.lessonPlans.modal.subjects,
+      deliveryLabel: t.lessonPlans.modal.delivery,
+      technologyLabel: t.lessonPlans.modal.technology,
+      durationLabel: t.lessonPlans.modal.duration,
+      summaryLabel: t.lessonPlans.modal.summary,
+      overviewTitle: t.lessonPlans.modal.overview,
+      objectivesLabel: t.lessonPlans.modal.objectives,
+      materialsLabel: t.lessonPlans.modal.materials,
+      assessmentLabel: t.lessonPlans.modal.assessment,
+      technologyOverviewLabel: t.lessonPlans.modal.technologyOverview,
+      deliveryOverviewLabel: t.lessonPlans.modal.deliveryOverview,
+      durationOverviewLabel: t.lessonPlans.modal.durationOverview,
+      structureTitle: t.lessonPlans.modal.structure,
+      resourcesTitle: t.lessonPlans.modal.resources,
+      resourceLinkLabel: t.lessonPlans.modal.resourceLink,
+      noResourcesLabel: t.lessonPlans.modal.empty,
+      errorLabel: t.lessonPlans.states.error,
+      downloadLabel: t.lessonPlans.modal.download,
+      openFullLabel: t.lessonPlans.modal.openFull,
+      closeLabel: t.lessonPlans.modal.close,
+      loadingLabel: t.lessonPlans.states.loading,
+      minutesFormatter: (minutes: number) =>
+        t.lessonPlans.card.durationLabel.replace("{minutes}", String(minutes)),
+    }),
+    [t],
+  );
+
+  const lessonQuery = useQuery({
+    queryKey: ["lesson-plan", slug],
+    enabled: Boolean(slug),
+    queryFn: () => fetchLessonPlanDetail(slug as string),
+  });
+
+  const lesson = lessonQuery.data ?? null;
+
+  const pageTitle = lesson
+    ? `${lesson.title} | ${t.lessonPlans.seo.title}`
+    : t.lessonPlans.seo.title;
+  const pageDescription = lesson?.summary ?? t.lessonPlans.seo.description;
+
+  const handleBack = () => {
+    navigate(getLocalizedPath("/lesson-plans", language));
+  };
+
+  const handleDownload = () => {
+    if (!lesson) {
+      return;
+    }
+    window.open(`/api/lesson-plans/${lesson.id}/pdf`, "_blank", "noopener,noreferrer");
+  };
+
+  const canonicalUrl = lesson
+    ? `https://schooltechhub.com${getLocalizedPath(`/lesson-plans/${lesson.slug}`, language)}`
+    : `https://schooltechhub.com${getLocalizedPath("/lesson-plans", language)}`;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <SEO
+        title={pageTitle}
+        description={pageDescription}
+        canonicalUrl={canonicalUrl}
+        type="article"
+        lang={language}
+      />
+
+      <main className="container py-12">
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" onClick={handleBack} className="inline-flex items-center gap-2">
+              <ArrowLeft className="h-4 w-4" />
+              {t.lessonPlans.detail.backToList}
+            </Button>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <Button
+              type="button"
+              onClick={handleDownload}
+              disabled={!lesson}
+              className="inline-flex items-center gap-2"
+            >
+              <Download className="h-4 w-4" />
+              {t.lessonPlans.modal.download}
+            </Button>
+          </div>
+        </div>
+
+        {lessonQuery.isLoading ? (
+          <DetailSkeleton />
+        ) : lessonQuery.isError ? (
+          <div className="rounded-2xl border bg-card/40 p-10 text-center">
+            <p className="text-lg font-semibold text-destructive">{t.lessonPlans.states.error}</p>
+            <p className="mt-2 text-sm text-muted-foreground">{t.lessonPlans.detail.errorDescription}</p>
+            <Button type="button" className="mt-6" onClick={handleBack}>
+              {t.lessonPlans.detail.backToList}
+            </Button>
+          </div>
+        ) : lesson ? (
+          <article className="space-y-8">
+            <header className="space-y-3">
+              <h1 className="text-4xl font-bold tracking-tight">{lesson.title}</h1>
+              {lesson.summary ? (
+                <p className="text-lg text-muted-foreground">{lesson.summary}</p>
+              ) : null}
+            </header>
+
+            <LessonDetailContent
+              lesson={lesson}
+              copy={lessonCopy}
+              isLoading={false}
+              errorMessage={null}
+            />
+          </article>
+        ) : (
+          <div className="rounded-2xl border bg-card/40 p-10 text-center">
+            <p className="text-lg font-semibold">{t.lessonPlans.detail.notFoundTitle}</p>
+            <p className="mt-2 text-sm text-muted-foreground">{t.lessonPlans.detail.notFoundDescription}</p>
+            <Button type="button" className="mt-6" onClick={handleBack}>
+              {t.lessonPlans.detail.backToList}
+            </Button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default LessonPlanPage;

--- a/src/pages/LessonPlans.tsx
+++ b/src/pages/LessonPlans.tsx
@@ -1,0 +1,488 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+
+import { SEO } from "@/components/SEO";
+import { EmptyState } from "@/components/lesson-plans/EmptyState";
+import { LessonCard } from "@/components/lesson-plans/LessonCard";
+import { LessonFilters } from "@/components/lesson-plans/LessonFilters";
+import { LessonModal } from "@/components/lesson-plans/LessonModal";
+import { LessonSkeletons } from "@/components/lesson-plans/Skeletons";
+import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+import type {
+  DeliveryMode,
+  LessonPlan,
+  LessonPlanListItem,
+  LessonPlanListResponse,
+  Stage,
+} from "@/types/lesson-plans";
+
+const LESSON_PARAM = "lesson";
+
+function getListParam(params: URLSearchParams, key: string): string[] {
+  const values = params.getAll(key);
+  if (values.length === 0) {
+    const raw = params.get(key);
+    if (raw) {
+      values.push(raw);
+    }
+  }
+
+  return Array.from(
+    new Set(
+      values
+        .flatMap((value) =>
+          value
+            .split(",")
+            .map((part) => part.trim())
+            .filter(Boolean),
+        )
+        .map((value) => value.toLowerCase()),
+    ),
+  );
+}
+
+function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setDebounced(value);
+    }, delay);
+
+    return () => clearTimeout(timeout);
+  }, [value, delay]);
+
+  return debounced;
+}
+
+async function fetchLessonPlans(
+  filters: {
+    search: string | null;
+    stages: string[];
+    delivery: string[];
+    tech: string[];
+  },
+  cursor: string | null,
+): Promise<LessonPlanListResponse> {
+  const params = new URLSearchParams();
+  if (filters.search) {
+    params.set("q", filters.search);
+  }
+  filters.stages.forEach((value) => params.append("stage", value));
+  filters.delivery.forEach((value) => params.append("delivery", value));
+  filters.tech.forEach((value) => params.append("tech", value));
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+
+  const response = await fetch(`/api/lesson-plans?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error("Failed to load lesson plans");
+  }
+  return response.json() as Promise<LessonPlanListResponse>;
+}
+
+async function fetchLessonPlanDetail(slug: string): Promise<LessonPlan> {
+  const response = await fetch(`/api/lesson-plans/${slug}`);
+  if (!response.ok) {
+    throw new Error("Failed to load lesson plan");
+  }
+  return response.json() as Promise<LessonPlan>;
+}
+
+const stageConfigs = [
+  {
+    value: "early childhood",
+    translationKey: "earlyChildhood",
+    label: "Early Childhood",
+    description: "Play-based foundations",
+    gradeRange: "PreK-1",
+  },
+  {
+    value: "elementary",
+    translationKey: "elementary",
+    label: "Elementary",
+    description: "Building core skills",
+    gradeRange: "Grades 2-5",
+  },
+  {
+    value: "middle school",
+    translationKey: "middleSchool",
+    label: "Middle School",
+    description: "Exploration and inquiry",
+    gradeRange: "Grades 6-8",
+  },
+  {
+    value: "high school",
+    translationKey: "highSchool",
+    label: "High School",
+    description: "College and career ready",
+    gradeRange: "Grades 9-12",
+  },
+  {
+    value: "adult learners",
+    translationKey: "adultLearners",
+    label: "Adult Learners",
+    description: "Professional and higher ed",
+    gradeRange: "Post-secondary",
+  },
+] as const;
+
+const deliveryConfigs = [
+  { value: "in-person", translationKey: "inPerson", label: "In-person", description: "Face-to-face classroom" },
+  { value: "blended", translationKey: "blended", label: "Blended", description: "Mix of online and in-class" },
+  { value: "online", translationKey: "online", label: "Online", description: "Live or asynchronous remote" },
+  { value: "project-based", translationKey: "projectBased", label: "Project-based", description: "Student-led projects" },
+  { value: "flipped", translationKey: "flipped", label: "Flipped", description: "Learn at home, apply in class" },
+] as const;
+
+const technologyConfigs = [
+  { value: "ai", translationKey: "ai", label: "AI" },
+  { value: "robotics", translationKey: "robotics", label: "Robotics" },
+  { value: "coding", translationKey: "coding", label: "Coding" },
+  { value: "vr", translationKey: "vr", label: "VR" },
+  { value: "steam", translationKey: "steam", label: "STEAM" },
+] as const;
+
+const DEBOUNCE_DELAY = 350;
+
+const LessonPlans = () => {
+  const { t, language } = useLanguage();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const [searchTerm, setSearchTerm] = useState(searchParams.get("q") || "");
+  const [selectedStages, setSelectedStages] = useState<string[]>(() => getListParam(searchParams, "stage"));
+  const [selectedDelivery, setSelectedDelivery] = useState<string[]>(() => getListParam(searchParams, "delivery"));
+  const [selectedTech, setSelectedTech] = useState<string[]>(() => getListParam(searchParams, "tech"));
+
+  const debouncedSearch = useDebouncedValue(searchTerm, DEBOUNCE_DELAY);
+
+  const updateSearchParams = useCallback(
+    (mutator: (params: URLSearchParams) => void, options?: { replace?: boolean }) => {
+      const current = searchParams.toString();
+      const params = new URLSearchParams(searchParams);
+      mutator(params);
+      const next = params.toString();
+      if (next !== current) {
+        setSearchParams(params, options);
+      }
+    },
+    [searchParams, setSearchParams],
+  );
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    setSearchTerm(params.get("q") || "");
+    setSelectedStages(getListParam(params, "stage"));
+    setSelectedDelivery(getListParam(params, "delivery"));
+    setSelectedTech(getListParam(params, "tech"));
+  }, [location.search]);
+
+  useEffect(() => {
+    updateSearchParams((params) => {
+      if (debouncedSearch) {
+        params.set("q", debouncedSearch);
+      } else {
+        params.delete("q");
+      }
+      params.delete("cursor");
+      params.delete("page");
+    }, { replace: true });
+  }, [debouncedSearch, updateSearchParams]);
+
+  const stageKey = useMemo(() => selectedStages.slice().sort().join("|"), [selectedStages]);
+  const deliveryKey = useMemo(() => selectedDelivery.slice().sort().join("|"), [selectedDelivery]);
+  const techKey = useMemo(() => selectedTech.slice().sort().join("|"), [selectedTech]);
+
+  const filters = useMemo(
+    () => ({
+      search: debouncedSearch || null,
+      stages: selectedStages,
+      delivery: selectedDelivery,
+      tech: selectedTech,
+    }),
+    [debouncedSearch, selectedStages, selectedDelivery, selectedTech],
+  );
+
+  const lessonPlansQuery = useInfiniteQuery({
+    queryKey: ["lesson-plans", language, filters.search, stageKey, deliveryKey, techKey],
+    initialPageParam: null as string | null,
+    queryFn: ({ pageParam }) => fetchLessonPlans(filters, (pageParam as string | null) ?? null),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+
+  const lessonItems = useMemo(
+    () => lessonPlansQuery.data?.pages.flatMap((page) => page.items) ?? [],
+    [lessonPlansQuery.data],
+  );
+
+  const [selectedLessonSlug, setSelectedLessonSlug] = useState<string | null>(
+    searchParams.get(LESSON_PARAM),
+  );
+  const [selectedLessonPreview, setSelectedLessonPreview] = useState<LessonPlanListItem | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const slug = params.get(LESSON_PARAM);
+    setSelectedLessonSlug(slug);
+  }, [location.search]);
+
+  useEffect(() => {
+    if (!selectedLessonSlug) {
+      setSelectedLessonPreview(null);
+      return;
+    }
+    const match = lessonItems.find((item) => item.slug === selectedLessonSlug) ?? null;
+    setSelectedLessonPreview(match);
+  }, [lessonItems, selectedLessonSlug]);
+
+  const lessonDetailQuery = useQuery({
+    queryKey: ["lesson-plan", selectedLessonSlug],
+    enabled: Boolean(selectedLessonSlug),
+    queryFn: () => fetchLessonPlanDetail(selectedLessonSlug as string),
+  });
+
+  const stageOptions = useMemo<Stage[]>(() => {
+    const stageTranslations = t.lessonPlans.filters.stages;
+    return stageConfigs.map((config) => {
+      const translation = stageTranslations[config.translationKey] ?? {};
+      return {
+        value: config.value,
+        label: translation.label ?? config.label,
+        description: translation.description ?? config.description,
+        gradeRange: translation.gradeRange ?? config.gradeRange,
+      } satisfies Stage;
+    });
+  }, [t.lessonPlans.filters.stages]);
+
+  const deliveryOptions = useMemo<DeliveryMode[]>(() => {
+    const deliveryTranslations = t.lessonPlans.filters.deliveries;
+    return deliveryConfigs.map((config) => {
+      const translation = deliveryTranslations[config.translationKey] ?? {};
+      return {
+        value: config.value,
+        label: translation.label ?? config.label,
+        description: translation.description ?? config.description,
+      } satisfies DeliveryMode;
+    });
+  }, [t.lessonPlans.filters.deliveries]);
+
+  const technologyOptions = useMemo(
+    () => {
+      const techTranslations = t.lessonPlans.filters.technologyOptions;
+      return technologyConfigs.map((config) => ({
+        value: config.value,
+        label: techTranslations[config.translationKey] ?? config.label,
+      }));
+    },
+    [t.lessonPlans.filters.technologyOptions],
+  );
+
+  const handleStagesChange = (values: string[]) => {
+    const unique = Array.from(new Set(values.map((value) => value.toLowerCase())));
+    setSelectedStages(unique);
+    updateSearchParams((params) => {
+      params.delete("stage");
+      unique.forEach((value) => params.append("stage", value));
+      params.delete("cursor");
+    });
+  };
+
+  const handleDeliveryChange = (values: string[]) => {
+    const unique = Array.from(new Set(values.map((value) => value.toLowerCase())));
+    setSelectedDelivery(unique);
+    updateSearchParams((params) => {
+      params.delete("delivery");
+      unique.forEach((value) => params.append("delivery", value));
+      params.delete("cursor");
+    });
+  };
+
+  const handleTechChange = (values: string[]) => {
+    const unique = Array.from(new Set(values.map((value) => value.toLowerCase())));
+    setSelectedTech(unique);
+    updateSearchParams((params) => {
+      params.delete("tech");
+      unique.forEach((value) => params.append("tech", value));
+      params.delete("cursor");
+    });
+  };
+
+  const handleClearFilters = () => {
+    setSelectedStages([]);
+    setSelectedDelivery([]);
+    setSelectedTech([]);
+    setSearchTerm("");
+    updateSearchParams((params) => {
+      params.delete("stage");
+      params.delete("delivery");
+      params.delete("tech");
+      params.delete("q");
+      params.delete("cursor");
+      params.delete("page");
+    });
+  };
+
+  const handleSelectLesson = (lesson: LessonPlanListItem) => {
+    updateSearchParams((params) => {
+      params.set(LESSON_PARAM, lesson.slug);
+    });
+  };
+
+  const handleCloseModal = () => {
+    updateSearchParams((params) => {
+      params.delete(LESSON_PARAM);
+    }, { replace: true });
+  };
+
+  const handleOpenFullPage = () => {
+    if (!selectedLessonSlug) {
+      return;
+    }
+    navigate(getLocalizedPath(`/lesson-plans/${selectedLessonSlug}`, language));
+  };
+
+  const handleDownloadPdf = () => {
+    const lesson = lessonDetailQuery.data ?? selectedLessonPreview;
+    if (!lesson) {
+      return;
+    }
+    window.open(`/api/lesson-plans/${lesson.id}/pdf`, "_blank", "noopener,noreferrer");
+  };
+
+  const isInitialLoading = lessonPlansQuery.isLoading && !lessonPlansQuery.data;
+  const hasResults = lessonItems.length > 0;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <SEO
+        title={t.lessonPlans.seo.title}
+        description={t.lessonPlans.seo.description}
+        canonicalUrl={`https://schooltechhub.com${getLocalizedPath("/lesson-plans", language)}`}
+        type="website"
+        lang={language}
+      />
+      <main className="container py-12">
+        <div className="mb-12 space-y-3 text-center">
+          <h1 className="text-4xl font-bold tracking-tight">{t.lessonPlans.hero.title}</h1>
+          <p className="text-muted-foreground">{t.lessonPlans.hero.subtitle}</p>
+        </div>
+
+        <div className="grid gap-10 lg:grid-cols-[320px,1fr]">
+          <LessonFilters
+            stages={stageOptions}
+            deliveryModes={deliveryOptions}
+            technologyOptions={technologyOptions}
+            selectedStages={selectedStages}
+            selectedDeliveryModes={selectedDelivery}
+            selectedTechnologies={selectedTech}
+            searchTerm={searchTerm}
+            onSearchChange={setSearchTerm}
+            onStagesChange={handleStagesChange}
+            onDeliveryChange={handleDeliveryChange}
+            onTechnologyChange={handleTechChange}
+            onClearFilters={handleClearFilters}
+            searchPlaceholder={t.lessonPlans.filters.searchPlaceholder}
+            title={t.lessonPlans.filters.title}
+            stageLabel={t.lessonPlans.filters.stageLabel}
+            deliveryLabel={t.lessonPlans.filters.deliveryLabel}
+            technologyLabel={t.lessonPlans.filters.technologyLabel}
+            clearLabel={t.lessonPlans.filters.clear}
+            closeLabel={t.common.close}
+          />
+
+          <section className="space-y-8">
+            {isInitialLoading ? (
+              <LessonSkeletons />
+            ) : hasResults ? (
+              <>
+                <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+                  {lessonItems.map((lesson) => (
+                    <LessonCard
+                      key={lesson.id}
+                      lesson={lesson}
+                      onSelect={handleSelectLesson}
+                      openLabel={t.lessonPlans.card.openLabel}
+                      durationFormatter={(minutes) =>
+                        t.lessonPlans.card.durationLabel.replace("{minutes}", String(minutes))
+                      }
+                    />
+                  ))}
+                </div>
+                {lessonPlansQuery.hasNextPage ? (
+                  <div className="flex justify-center">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => lessonPlansQuery.fetchNextPage()}
+                      disabled={lessonPlansQuery.isFetchingNextPage}
+                    >
+                      {lessonPlansQuery.isFetchingNextPage
+                        ? t.common.loading
+                        : t.lessonPlans.states.loadMore}
+                    </Button>
+                  </div>
+                ) : null}
+              </>
+            ) : (
+              <EmptyState
+                title={t.lessonPlans.states.emptyTitle}
+                description={t.lessonPlans.states.emptyDescription}
+                resetLabel={t.lessonPlans.states.resetFilters}
+                onReset={handleClearFilters}
+              />
+            )}
+
+            {lessonPlansQuery.isError ? (
+              <p className="text-sm text-destructive">{t.lessonPlans.states.error}</p>
+            ) : null}
+          </section>
+        </div>
+      </main>
+
+      <LessonModal
+        isOpen={Boolean(selectedLessonSlug)}
+        onClose={handleCloseModal}
+        lesson={lessonDetailQuery.data ?? null}
+        initialLesson={selectedLessonPreview}
+        onDownloadPdf={handleDownloadPdf}
+        onOpenFullPage={handleOpenFullPage}
+        isLoading={lessonDetailQuery.isLoading || lessonDetailQuery.isFetching}
+        errorMessage={lessonDetailQuery.isError ? t.lessonPlans.states.error : null}
+        copy={{
+          stageLabel: t.lessonPlans.modal.stage,
+          subjectsLabel: t.lessonPlans.modal.subjects,
+          deliveryLabel: t.lessonPlans.modal.delivery,
+          technologyLabel: t.lessonPlans.modal.technology,
+          durationLabel: t.lessonPlans.modal.duration,
+          summaryLabel: t.lessonPlans.modal.summary,
+          overviewTitle: t.lessonPlans.modal.overview,
+          objectivesLabel: t.lessonPlans.modal.objectives,
+          materialsLabel: t.lessonPlans.modal.materials,
+          assessmentLabel: t.lessonPlans.modal.assessment,
+          technologyOverviewLabel: t.lessonPlans.modal.technologyOverview,
+          deliveryOverviewLabel: t.lessonPlans.modal.deliveryOverview,
+          durationOverviewLabel: t.lessonPlans.modal.durationOverview,
+          structureTitle: t.lessonPlans.modal.structure,
+          resourcesTitle: t.lessonPlans.modal.resources,
+          resourceLinkLabel: t.lessonPlans.modal.resourceLink,
+          noResourcesLabel: t.lessonPlans.modal.empty,
+          errorLabel: t.lessonPlans.states.error,
+          downloadLabel: t.lessonPlans.modal.download,
+          openFullLabel: t.lessonPlans.modal.openFull,
+          closeLabel: t.lessonPlans.modal.close,
+          loadingLabel: t.lessonPlans.states.loading,
+          minutesFormatter: (minutes) =>
+            t.lessonPlans.card.durationLabel.replace("{minutes}", String(minutes)),
+        }}
+      />
+    </div>
+  );
+};
+
+export default LessonPlans;

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -4,6 +4,7 @@ export const en = {
     about: "About",
     services: "Services",
     blog: "Blog",
+    lessonPlans: "Lesson Plans",
     events: "Events",
     contact: "Contact",
     edutech: "Edu Tech",
@@ -492,6 +493,121 @@ export const en = {
         errorDescription: "Failed to subscribe. Please try again."
       }
     }
+  },
+  lessonPlans: {
+    seo: {
+      title: "Lesson Plans Library",
+      description:
+        "Browse ready-to-teach lesson plans filtered by grade level, delivery style, and classroom technology.",
+    },
+    hero: {
+      title: "Lesson Plans",
+      subtitle: "Find practical, tech-ready lessons for every classroom stage.",
+    },
+    filters: {
+      title: "Filters",
+      searchPlaceholder: "Search lesson plans",
+      stageLabel: "Stage",
+      deliveryLabel: "Delivery mode",
+      technologyLabel: "Technology focus",
+      clear: "Clear filters",
+      stages: {
+        earlyChildhood: {
+          label: "Early Childhood",
+          description: "Play-based foundations",
+          gradeRange: "PreK-1",
+        },
+        elementary: {
+          label: "Elementary",
+          description: "Building core skills",
+          gradeRange: "Grades 2-5",
+        },
+        middleSchool: {
+          label: "Middle School",
+          description: "Exploration and inquiry",
+          gradeRange: "Grades 6-8",
+        },
+        highSchool: {
+          label: "High School",
+          description: "College and career ready",
+          gradeRange: "Grades 9-12",
+        },
+        adultLearners: {
+          label: "Adult Learners",
+          description: "Professional and higher ed",
+          gradeRange: "Post-secondary",
+        },
+      },
+      deliveries: {
+        inPerson: {
+          label: "In-person",
+          description: "Face-to-face classroom",
+        },
+        blended: {
+          label: "Blended",
+          description: "Mix of online and in-class",
+        },
+        online: {
+          label: "Online",
+          description: "Live or asynchronous remote",
+        },
+        projectBased: {
+          label: "Project-based",
+          description: "Student-led projects",
+        },
+        flipped: {
+          label: "Flipped",
+          description: "Learn at home, apply in class",
+        },
+      },
+      technologyOptions: {
+        ai: "AI & automation",
+        robotics: "Robotics",
+        coding: "Coding",
+        vr: "Virtual reality",
+        steam: "STEAM",
+      },
+    },
+    states: {
+      loading: "Loading lesson plans...",
+      emptyTitle: "No lesson plans found",
+      emptyDescription: "Try adjusting your filters or search keywords.",
+      resetFilters: "Reset filters",
+      error: "We couldn't load lesson plans right now. Please try again soon.",
+      loadMore: "Load more plans",
+    },
+    card: {
+      openLabel: "View lesson plan",
+      durationLabel: "{minutes} minutes",
+    },
+    modal: {
+      stage: "Stage",
+      subjects: "Subjects",
+      delivery: "Delivery",
+      technology: "Technology",
+      duration: "Duration",
+      summary: "Summary",
+      overview: "Lesson overview",
+      objectives: "Objectives",
+      materials: "Materials",
+      assessment: "Assessment",
+      technologyOverview: "Technology tools",
+      deliveryOverview: "Delivery modes",
+      durationOverview: "Suggested duration",
+      structure: "Lesson structure",
+      resources: "Resources",
+      resourceLink: "Open resource",
+      empty: "Lesson details will be added soon.",
+      download: "Download PDF",
+      openFull: "Open full page",
+      close: "Close",
+    },
+    detail: {
+      backToList: "Back to lesson plans",
+      errorDescription: "We couldn't load this lesson plan. Please return to the library and try again.",
+      notFoundTitle: "Lesson plan not found",
+      notFoundDescription: "This lesson plan may have been unpublished or removed.",
+    },
   },
   blogPost: {
     backToBlog: "Back to Blog",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -4,6 +4,7 @@ export const sq = {
     about: "Rreth Nesh",
     services: "Shërbimet",
     blog: "Blog",
+    lessonPlans: "Planet e mësimit",
     events: "Evente",
     contact: "Kontakt",
     edutech: "Teknologji Edukative",
@@ -496,6 +497,121 @@ export const sq = {
         errorDescription: "Abonimi dështoi. Ju lutemi provoni përsëri."
       }
     }
+  },
+  lessonPlans: {
+    seo: {
+      title: "Biblioteka e planeve mësimore",
+      description:
+        "Shfleto plane mësimore gati për zbatim sipas nivelit, mënyrës së dorëzimit dhe teknologjisë në klasë.",
+    },
+    hero: {
+      title: "Planet e mësimit",
+      subtitle: "Gjej plane praktike dhe të gatshme për çdo klasë.",
+    },
+    filters: {
+      title: "Filtra",
+      searchPlaceholder: "Kërko plane mësimore",
+      stageLabel: "Nivel",
+      deliveryLabel: "Mënyra e dorëzimit",
+      technologyLabel: "Fokusi teknologjik",
+      clear: "Fshi filtrat",
+      stages: {
+        earlyChildhood: {
+          label: "Fëmijëria e hershme",
+          description: "Bazat përmes lojës",
+          gradeRange: "Kopsht-1",
+        },
+        elementary: {
+          label: "Cikli fillor",
+          description: "Zhvillimi i aftësive bazë",
+          gradeRange: "Klasat 2-5",
+        },
+        middleSchool: {
+          label: "Cikli i mesëm",
+          description: "Eksplorim dhe hetim",
+          gradeRange: "Klasat 6-8",
+        },
+        highSchool: {
+          label: "Shkolla e mesme",
+          description: "Gati për universitet dhe karrierë",
+          gradeRange: "Klasat 9-12",
+        },
+        adultLearners: {
+          label: "Nxënës të rritur",
+          description: "Arsim profesional dhe i lartë",
+          gradeRange: "Pas-parauniversitar",
+        },
+      },
+      deliveries: {
+        inPerson: {
+          label: "Në klasë",
+          description: "Mësim ballë për ballë",
+        },
+        blended: {
+          label: "I kombinuar",
+          description: "Kombinim online dhe në klasë",
+        },
+        online: {
+          label: "Online",
+          description: "Mësim i drejtpërdrejtë ose i pavarur",
+        },
+        projectBased: {
+          label: "Bazuar në projekt",
+          description: "Projektet e udhëhequra nga nxënësit",
+        },
+        flipped: {
+          label: "Klasa e përmbysur",
+          description: "Mëso në shtëpi, zbato në klasë",
+        },
+      },
+      technologyOptions: {
+        ai: "Inteligjenca artificiale",
+        robotics: "Robotikë",
+        coding: "Programim",
+        vr: "Realitet virtual",
+        steam: "STEAM",
+      },
+    },
+    states: {
+      loading: "Duke ngarkuar planet e mësimit...",
+      emptyTitle: "Nuk u gjetën plane",
+      emptyDescription: "Provo të ndryshosh filtrat ose fjalët e kërkimit.",
+      resetFilters: "Rivendos filtrat",
+      error: "Nuk mundëm të ngarkojmë planet e mësimit. Provo përsëri.",
+      loadMore: "Shfaq më shumë plane",
+    },
+    card: {
+      openLabel: "Shiko planin",
+      durationLabel: "{minutes} minuta",
+    },
+    modal: {
+      stage: "Nivel",
+      subjects: "Lëndë",
+      delivery: "Dorëzim",
+      technology: "Teknologji",
+      duration: "Kohëzgjatja",
+      summary: "Përmbledhje",
+      overview: "Përmbledhje e mësimit",
+      objectives: "Objektivat",
+      materials: "Materialet",
+      assessment: "Vlerësimi",
+      technologyOverview: "Mjetet teknologjike",
+      deliveryOverview: "Mënyrat e dorëzimit",
+      durationOverview: "Kohëzgjatja e sugjeruar",
+      structure: "Struktura e mësimit",
+      resources: "Burimet",
+      resourceLink: "Hap burimin",
+      empty: "Detajet e planit do të shtohen së shpejti.",
+      download: "Shkarko PDF",
+      openFull: "Hap faqen e plotë",
+      close: "Mbyll",
+    },
+    detail: {
+      backToList: "Kthehu te planet",
+      errorDescription: "Nuk mundëm të ngarkojmë këtë plan. Kthehu në listë dhe provo përsëri.",
+      notFoundTitle: "Plani nuk u gjet",
+      notFoundDescription: "Ky plan mund të jetë hequr ose i pa publikuar më.",
+    },
   },
   blogPost: {
     backToBlog: "Kthehu te Blogu",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -4,6 +4,7 @@ export const vi = {
     about: "Về chúng tôi",
     services: "Dịch vụ",
     blog: "Blog",
+    lessonPlans: "Kế hoạch bài học",
     events: "Sự kiện",
     contact: "Liên hệ",
     edutech: "Công nghệ giáo dục",
@@ -496,6 +497,121 @@ export const vi = {
         errorDescription: "Đăng ký không thành công. Vui lòng thử lại."
       }
     }
+  },
+  lessonPlans: {
+    seo: {
+      title: "Thư viện kế hoạch bài học",
+      description:
+        "Duyệt các kế hoạch bài học sẵn sàng áp dụng theo cấp lớp, hình thức triển khai và công nghệ lớp học.",
+    },
+    hero: {
+      title: "Kế hoạch bài học",
+      subtitle: "Tìm những bài học thực tế, sẵn sàng cho mọi lớp học.",
+    },
+    filters: {
+      title: "Bộ lọc",
+      searchPlaceholder: "Tìm kiếm kế hoạch bài học",
+      stageLabel: "Cấp học",
+      deliveryLabel: "Hình thức triển khai",
+      technologyLabel: "Trọng tâm công nghệ",
+      clear: "Xóa bộ lọc",
+      stages: {
+        earlyChildhood: {
+          label: "Mầm non",
+          description: "Nền tảng qua vui chơi",
+          gradeRange: "Mẫu giáo-1",
+        },
+        elementary: {
+          label: "Tiểu học",
+          description: "Phát triển kỹ năng nền tảng",
+          gradeRange: "Lớp 2-5",
+        },
+        middleSchool: {
+          label: "THCS",
+          description: "Khám phá và tìm hiểu",
+          gradeRange: "Lớp 6-8",
+        },
+        highSchool: {
+          label: "THPT",
+          description: "Sẵn sàng cho đại học và nghề nghiệp",
+          gradeRange: "Lớp 9-12",
+        },
+        adultLearners: {
+          label: "Học viên trưởng thành",
+          description: "Giáo dục nghề nghiệp và cao hơn",
+          gradeRange: "Sau trung học",
+        },
+      },
+      deliveries: {
+        inPerson: {
+          label: "Trực tiếp",
+          description: "Giảng dạy tại lớp",
+        },
+        blended: {
+          label: "Kết hợp",
+          description: "Kết hợp online và tại lớp",
+        },
+        online: {
+          label: "Trực tuyến",
+          description: "Học đồng bộ hoặc không đồng bộ",
+        },
+        projectBased: {
+          label: "Dựa trên dự án",
+          description: "Dự án do học sinh dẫn dắt",
+        },
+        flipped: {
+          label: "Lớp học đảo ngược",
+          description: "Học ở nhà, thực hành tại lớp",
+        },
+      },
+      technologyOptions: {
+        ai: "Trí tuệ nhân tạo",
+        robotics: "Người máy",
+        coding: "Lập trình",
+        vr: "Thực tế ảo",
+        steam: "STEAM",
+      },
+    },
+    states: {
+      loading: "Đang tải kế hoạch bài học...",
+      emptyTitle: "Không tìm thấy kế hoạch phù hợp",
+      emptyDescription: "Hãy thử điều chỉnh bộ lọc hoặc từ khóa tìm kiếm.",
+      resetFilters: "Đặt lại bộ lọc",
+      error: "Không thể tải kế hoạch bài học. Vui lòng thử lại.",
+      loadMore: "Xem thêm kế hoạch",
+    },
+    card: {
+      openLabel: "Xem kế hoạch",
+      durationLabel: "{minutes} phút",
+    },
+    modal: {
+      stage: "Cấp học",
+      subjects: "Môn học",
+      delivery: "Hình thức",
+      technology: "Công nghệ",
+      duration: "Thời lượng",
+      summary: "Tóm tắt",
+      overview: "Tổng quan bài học",
+      objectives: "Mục tiêu",
+      materials: "Tài liệu",
+      assessment: "Đánh giá",
+      technologyOverview: "Công cụ công nghệ",
+      deliveryOverview: "Hình thức triển khai",
+      durationOverview: "Thời lượng gợi ý",
+      structure: "Cấu trúc bài học",
+      resources: "Tài nguyên",
+      resourceLink: "Mở tài nguyên",
+      empty: "Chi tiết bài học sẽ được cập nhật sớm.",
+      download: "Tải PDF",
+      openFull: "Mở trang đầy đủ",
+      close: "Đóng",
+    },
+    detail: {
+      backToList: "Quay lại danh sách",
+      errorDescription: "Không thể tải kế hoạch này. Hãy quay lại thư viện và thử lại.",
+      notFoundTitle: "Không tìm thấy kế hoạch",
+      notFoundDescription: "Kế hoạch này có thể đã bị gỡ xuống hoặc chưa công bố.",
+    },
   },
   blogPost: {
     backToBlog: "Quay lại Blog",

--- a/src/types/lesson-plans.ts
+++ b/src/types/lesson-plans.ts
@@ -1,0 +1,35 @@
+import type {
+  LessonPlanContentBlock as ApiLessonPlanContentBlock,
+  LessonPlanContentSection as ApiLessonPlanContentSection,
+  LessonPlanListItem as ApiLessonPlanListItem,
+  LessonPlanListResponse as ApiLessonPlanListResponse,
+  LessonPlanOverview as ApiLessonPlanOverview,
+  LessonPlanResource as ApiLessonPlanResource,
+} from "../../types/lesson-plans";
+
+export interface Stage {
+  value: string;
+  label: string;
+  description?: string;
+  gradeRange?: string;
+}
+
+export interface DeliveryMode {
+  value: string;
+  label: string;
+  description?: string;
+  durationHint?: string;
+}
+
+export interface LessonPlan extends ApiLessonPlanListItem {
+  overview: ApiLessonPlanOverview | null;
+  content: ApiLessonPlanContentSection[];
+  resources: ApiLessonPlanResource[];
+}
+
+export type LessonPlanListItem = ApiLessonPlanListItem;
+export type LessonPlanOverview = ApiLessonPlanOverview;
+export type LessonPlanContentBlock = ApiLessonPlanContentBlock;
+export type LessonPlanContentSection = ApiLessonPlanContentSection;
+export type LessonPlanResource = ApiLessonPlanResource;
+export type LessonPlanListResponse = ApiLessonPlanListResponse;


### PR DESCRIPTION
## Summary
- add shared lesson plan types and modular components for filters, cards, modal, and empty/skeleton states
- implement lesson plan listing and detail pages with debounced filters, infinite pagination, modal deep links, and PDF downloads
- register new routes/navigation links and localize strings for English, Albanian, and Vietnamese

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d022b5a21483319d9f9a9e935c6a02