### PR TITLE
Make worksheet and lesson filters collapsible

### DIFF
--- a/src/components/filters/FilterSection.tsx
+++ b/src/components/filters/FilterSection.tsx
@@ -1,0 +1,51 @@
+import { useState, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+interface FilterSectionProps {
+  title: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+  className?: string;
+  contentClassName?: string;
+}
+
+export function FilterSection({
+  title,
+  children,
+  defaultOpen = true,
+  className,
+  contentClassName,
+}: FilterSectionProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className={cn("space-y-3", className)}
+    >
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center justify-between gap-2 text-left text-sm font-semibold"
+          aria-expanded={isOpen}
+        >
+          <span>{title}</span>
+          <ChevronDown
+            className={cn(
+              "h-4 w-4 shrink-0 transition-transform duration-200",
+              isOpen ? "rotate-180" : "rotate-0",
+            )}
+            aria-hidden="true"
+          />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className={cn("mt-3", contentClassName ?? "space-y-2")}>
+        {children}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/components/lesson-plans/LessonFilters.tsx
+++ b/src/components/lesson-plans/LessonFilters.tsx
@@ -19,6 +19,7 @@ import {
   ToggleGroupItem,
 } from "@/components/ui/toggle-group";
 import type { DeliveryMode, Stage } from "@/types/lesson-plans";
+import { FilterSection } from "@/components/filters/FilterSection";
 
 type FilterValue = string;
 
@@ -176,28 +177,15 @@ export function LessonFilters({
         />
       </div>
 
-      <div>
-        <div className="mb-3 flex items-center justify-between">
-          <span className="text-sm font-semibold">{stageLabel}</span>
-        </div>
-        <div className="space-y-2">
-          {stages.map(renderStageOption)}
-        </div>
-      </div>
+      <FilterSection title={stageLabel}>
+        {stages.map(renderStageOption)}
+      </FilterSection>
 
-      <div>
-        <div className="mb-3 flex items-center justify-between">
-          <span className="text-sm font-semibold">{deliveryLabel}</span>
-        </div>
-        <div className="space-y-2">
-          {deliveryModes.map(renderDeliveryOption)}
-        </div>
-      </div>
+      <FilterSection title={deliveryLabel}>
+        {deliveryModes.map(renderDeliveryOption)}
+      </FilterSection>
 
-      <div>
-        <div className="mb-3 flex items-center justify-between">
-          <span className="text-sm font-semibold">{technologyLabel}</span>
-        </div>
+      <FilterSection title={technologyLabel}>
         <ToggleGroup
           type="multiple"
           value={selectedTechnologies}
@@ -216,7 +204,7 @@ export function LessonFilters({
             </ToggleGroupItem>
           ))}
         </ToggleGroup>
-      </div>
+      </FilterSection>
 
       <div className="flex items-center justify-between">
         <Button

--- a/src/components/worksheets/WorksheetFilters.tsx
+++ b/src/components/worksheets/WorksheetFilters.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import type { WorksheetFiltersState } from "@/types/worksheets";
+import { FilterSection } from "@/components/filters/FilterSection";
 
 const MOBILE_BREAKPOINT = 1024;
 
@@ -160,99 +161,69 @@ export function WorksheetFilters({
         />
       </div>
 
-      <div>
-        <div className="mb-3 flex items-center justify-between">
-          <span className="text-sm font-semibold">{copy.stageLabel}</span>
-        </div>
-        <div className="space-y-2">
-          {stageOptions.map((option) =>
-            renderCheckboxOption(option, value.stages.includes(option.value), (checked) =>
-              updateFilters({
-                stages: toggleListValue(value.stages, option.value, checked),
-              }),
-            ),
-          )}
-        </div>
-      </div>
+      <FilterSection title={copy.stageLabel}>
+        {stageOptions.map((option) =>
+          renderCheckboxOption(option, value.stages.includes(option.value), (checked) =>
+            updateFilters({
+              stages: toggleListValue(value.stages, option.value, checked),
+            }),
+          ),
+        )}
+      </FilterSection>
 
-      <div>
-        <div className="mb-3 flex items-center justify-between">
-          <span className="text-sm font-semibold">{copy.subjectLabel}</span>
-        </div>
-        <div className="space-y-2">
-          {subjectOptions.map((option) =>
-            renderCheckboxOption(option, value.subjects.includes(option.value), (checked) =>
-              updateFilters({
-                subjects: toggleListValue(value.subjects, option.value, checked),
-              }),
-            ),
-          )}
-        </div>
-      </div>
+      <FilterSection title={copy.subjectLabel}>
+        {subjectOptions.map((option) =>
+          renderCheckboxOption(option, value.subjects.includes(option.value), (checked) =>
+            updateFilters({
+              subjects: toggleListValue(value.subjects, option.value, checked),
+            }),
+          ),
+        )}
+      </FilterSection>
 
-      <div>
-        <div className="mb-3 flex items-center justify-between">
-          <span className="text-sm font-semibold">{copy.skillLabel}</span>
-        </div>
-        <div className="space-y-2">
-          {skillOptions.map((option) =>
-            renderCheckboxOption(option, value.skills.includes(option.value), (checked) =>
-              updateFilters({
-                skills: toggleListValue(value.skills, option.value, checked),
-              }),
-            ),
-          )}
-        </div>
-      </div>
+      <FilterSection title={copy.skillLabel}>
+        {skillOptions.map((option) =>
+          renderCheckboxOption(option, value.skills.includes(option.value), (checked) =>
+            updateFilters({
+              skills: toggleListValue(value.skills, option.value, checked),
+            }),
+          ),
+        )}
+      </FilterSection>
 
-      <div>
-        <div className="mb-3 flex items-center justify-between">
-          <span className="text-sm font-semibold">{copy.typeLabel}</span>
-        </div>
-        <div className="space-y-2">
-          {typeOptions.map((option) =>
-            renderCheckboxOption(option, value.worksheetTypes.includes(option.value), (checked) =>
-              updateFilters({
-                worksheetTypes: toggleListValue(
-                  value.worksheetTypes,
-                  option.value,
-                  checked,
-                ),
-              }),
-            ),
-          )}
-        </div>
-      </div>
+      <FilterSection title={copy.typeLabel}>
+        {typeOptions.map((option) =>
+          renderCheckboxOption(option, value.worksheetTypes.includes(option.value), (checked) =>
+            updateFilters({
+              worksheetTypes: toggleListValue(
+                value.worksheetTypes,
+                option.value,
+                checked,
+              ),
+            }),
+          ),
+        )}
+      </FilterSection>
 
-      <div>
-        <div className="mb-3 flex items-center justify-between">
-          <span className="text-sm font-semibold">{copy.difficultyLabel}</span>
-        </div>
-        <div className="space-y-2">
-          {difficultyOptions.map((option) =>
-            renderCheckboxOption(option, value.difficulties.includes(option.value), (checked) =>
-              updateFilters({
-                difficulties: toggleListValue(value.difficulties, option.value, checked),
-              }),
-            ),
-          )}
-        </div>
-      </div>
+      <FilterSection title={copy.difficultyLabel}>
+        {difficultyOptions.map((option) =>
+          renderCheckboxOption(option, value.difficulties.includes(option.value), (checked) =>
+            updateFilters({
+              difficulties: toggleListValue(value.difficulties, option.value, checked),
+            }),
+          ),
+        )}
+      </FilterSection>
 
-      <div>
-        <div className="mb-3 flex items-center justify-between">
-          <span className="text-sm font-semibold">{copy.formatLabel}</span>
-        </div>
-        <div className="space-y-2">
-          {formatOptions.map((option) =>
-            renderCheckboxOption(option, value.formats.includes(option.value), (checked) =>
-              updateFilters({
-                formats: toggleListValue(value.formats, option.value, checked),
-              }),
-            ),
-          )}
-        </div>
-      </div>
+      <FilterSection title={copy.formatLabel}>
+        {formatOptions.map((option) =>
+          renderCheckboxOption(option, value.formats.includes(option.value), (checked) =>
+            updateFilters({
+              formats: toggleListValue(value.formats, option.value, checked),
+            }),
+          ),
+        )}
+      </FilterSection>
 
       <div className="space-y-4 rounded-xl border border-dashed p-4">
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- add a reusable `FilterSection` component to show filter groups in a collapsible shell
- update worksheet filters to use collapsible sections while preserving existing filter behavior
- update lesson plan filters to use the same collapsible sections for consistency across resources

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0374688988331a490be9f9bd02c5d