### PR TITLE
Add lesson plan builder pages and API integrations

### DIFF
--- a/api/_lib/lesson-builder-helpers.ts
+++ b/api/_lib/lesson-builder-helpers.ts
@@ -1,0 +1,308 @@
+import type {
+  LessonBuilderPlan,
+  LessonBuilderPart,
+  LessonBuilderStandard,
+  LessonBuilderVersionEntry,
+} from "../../types/lesson-builder";
+import {
+  builderStepsToContent,
+  mergeActivityValues,
+  mergeStandardValues,
+  mergeStepValues,
+  cryptoRandomId,
+} from "../../types/lesson-builder";
+import type {
+  LessonPlanContentSection,
+  LessonPlanDetail,
+  LessonPlanRecord,
+} from "../../types/lesson-plans";
+import { mapRecordToDetail } from "./lesson-plan-helpers";
+
+interface BuilderMetadata {
+  version?: number;
+  steps?: unknown;
+  standards?: unknown;
+  availableStandards?: unknown;
+  parts?: unknown;
+  lastSavedAt?: unknown;
+  history?: unknown;
+}
+
+const DEFAULT_PARTS: Array<{ id: string; label: string; description: string | null }> = [
+  { id: "overview", label: "Overview", description: null },
+  { id: "activities", label: "Learning Activities", description: null },
+  { id: "assessment", label: "Assessment", description: null },
+  { id: "resources", label: "Resources", description: null },
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeMetadata(value: unknown): BuilderMetadata {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const builderRaw = isRecord(value.builder) ? value.builder : value;
+  return {
+    version: builderRaw.version,
+    steps: builderRaw.steps,
+    standards: builderRaw.standards,
+    availableStandards: builderRaw.availableStandards ?? builderRaw.available_standards,
+    parts: builderRaw.parts,
+    lastSavedAt: builderRaw.lastSavedAt ?? builderRaw.last_saved_at,
+    history: builderRaw.history,
+  } as BuilderMetadata;
+}
+
+function ensureParts(
+  parts: unknown,
+  detail: LessonPlanDetail,
+  steps: LessonBuilderPlan["steps"]
+): LessonBuilderPart[] {
+  if (Array.isArray(parts)) {
+    const normalized = parts
+      .map((part) => normalizePart(part))
+      .filter((part): part is LessonBuilderPart => part !== null);
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+
+  return DEFAULT_PARTS.map((part) => ({
+    id: part.id,
+    label: part.label,
+    description:
+      part.id === "overview"
+        ? detail.summary ?? null
+        : part.id === "activities"
+          ? `${steps.length} ${steps.length === 1 ? "step" : "steps"}`
+          : part.description,
+    completed: part.id === "overview" ? Boolean(detail.summary) : steps.length > 0,
+  }));
+}
+
+function normalizePart(input: unknown): LessonBuilderPart | null {
+  if (!isRecord(input)) {
+    return null;
+  }
+  const id = typeof input.id === "string" && input.id ? input.id : cryptoRandomId("part");
+  const label = typeof input.label === "string" && input.label ? input.label : null;
+  return {
+    id,
+    label: label ?? "Part",
+    description: typeof input.description === "string" ? input.description : null,
+    completed: Boolean(input.completed),
+  };
+}
+
+function normalizeHistory(history: unknown): LessonBuilderVersionEntry[] {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+  return history
+    .map((entry) => {
+      if (!isRecord(entry)) {
+        return null;
+      }
+      const id = typeof entry.id === "string" && entry.id.length > 0
+        ? entry.id
+        : cryptoRandomId("ver");
+      const createdAt = typeof entry.createdAt === "string"
+        ? entry.createdAt
+        : typeof entry.created_at === "string"
+          ? entry.created_at
+          : null;
+      if (!createdAt) {
+        return null;
+      }
+      const label = typeof entry.label === "string" && entry.label.length > 0
+        ? entry.label
+        : "Revision";
+      const author = typeof entry.author === "string" ? entry.author : null;
+      const summary = typeof entry.summary === "string" ? entry.summary : null;
+      return {
+        id,
+        label,
+        createdAt,
+        author,
+        summary,
+      } satisfies LessonBuilderVersionEntry;
+    })
+    .filter((entry): entry is LessonBuilderVersionEntry => entry !== null);
+}
+
+function stepsFromSections(sections: LessonPlanContentSection[]): LessonBuilderPlan["steps"] {
+  return sections.map((section, index) =>
+    mergeStepValues({
+      id: section.id ?? cryptoRandomId("step"),
+      title: section.title ?? `Step ${index + 1}`,
+      description: section.description ?? extractFirstParagraph(section),
+      activities:
+        section.blocks?.filter((block) => block.type === "list").flatMap((block) =>
+          "items" in block && Array.isArray(block.items)
+            ? block.items.map((item) =>
+                mergeActivityValues({
+                  title: typeof item === "string" ? item : "Activity",
+                })
+              )
+            : []
+        ) ?? [],
+    })
+  );
+}
+
+function extractFirstParagraph(section: LessonPlanContentSection): string | null {
+  if (!Array.isArray(section.blocks)) {
+    return null;
+  }
+  const paragraph = section.blocks.find((block) => block.type === "paragraph");
+  if (paragraph && "text" in paragraph && typeof paragraph.text === "string") {
+    return paragraph.text;
+  }
+  return null;
+}
+
+function normalizeSteps(raw: unknown, fallback: LessonPlanContentSection[]): LessonBuilderPlan["steps"] {
+  if (Array.isArray(raw)) {
+    const normalized = raw
+      .map((step) => mergeStepValues(step as Record<string, unknown>))
+      .filter((step) => step !== null);
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+  return stepsFromSections(fallback);
+}
+
+function normalizeStandards(raw: unknown): LessonBuilderStandard[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .map((standard) => mergeStandardValues(standard as Record<string, unknown>))
+    .filter((standard) => standard !== null);
+}
+
+export function mapRecordToBuilderPlan(record: LessonPlanRecord): LessonBuilderPlan {
+  const detail = mapRecordToDetail(record);
+  const metadata = normalizeMetadata(record.metadata ?? null);
+  const steps = normalizeSteps(metadata.steps, detail.content);
+  const standards = normalizeStandards(metadata.standards);
+  const availableStandards = normalizeStandards(metadata.availableStandards ?? standards);
+  const history = normalizeHistory(metadata.history);
+
+  const parts = ensureParts(metadata.parts, detail, steps);
+
+  return {
+    id: detail.id,
+    slug: detail.slug,
+    title: detail.title,
+    summary: detail.summary,
+    status: detail.status,
+    stage: detail.stage,
+    stages: detail.stages,
+    subjects: detail.subjects,
+    deliveryMethods: detail.deliveryMethods,
+    technologyTags: detail.technologyTags,
+    durationMinutes: detail.durationMinutes,
+    overview: detail.overview,
+    steps,
+    standards,
+    availableStandards,
+    resources: detail.resources,
+    lastSavedAt: typeof metadata.lastSavedAt === "string" ? metadata.lastSavedAt : detail.updatedAt,
+    version: typeof metadata.version === "number" ? metadata.version : detail.updatedAt ? 1 : 0,
+    parts,
+    history,
+    createdAt: detail.createdAt ?? null,
+    updatedAt: detail.updatedAt ?? null,
+  };
+}
+
+export function buildMetadataFromPlan(plan: LessonBuilderPlan): Record<string, unknown> {
+  return {
+    builder: {
+      version: plan.version,
+      steps: plan.steps,
+      standards: plan.standards,
+      availableStandards: plan.availableStandards,
+      parts: plan.parts,
+      lastSavedAt: plan.lastSavedAt,
+      history: plan.history,
+    },
+  };
+}
+
+export function buildUpdatePayload(plan: LessonBuilderPlan): Partial<LessonPlanRecord> {
+  return {
+    title: plan.title,
+    summary: plan.summary,
+    stage: plan.stage,
+    stages: plan.stages,
+    subjects: plan.subjects,
+    delivery_methods: plan.deliveryMethods,
+    technology_tags: plan.technologyTags,
+    duration_minutes: plan.durationMinutes,
+    overview: plan.overview,
+    content: builderStepsToContent(plan.steps),
+    resources: plan.resources,
+    metadata: buildMetadataFromPlan(plan),
+  } as Partial<LessonPlanRecord>;
+}
+
+export function createDraftInsert(
+  plan: Pick<LessonBuilderPlan, "id" | "slug" | "title" | "summary" | "stage" | "stages" | "subjects" | "deliveryMethods" | "technologyTags" | "durationMinutes"> & {
+    status: LessonPlanRecord["status"];
+    overview: LessonBuilderPlan["overview"];
+    steps: LessonBuilderPlan["steps"];
+    standards: LessonBuilderPlan["standards"];
+    availableStandards: LessonBuilderPlan["availableStandards"];
+    resources: LessonBuilderPlan["resources"];
+    version: number;
+    parts: LessonBuilderPlan["parts"];
+    history: LessonBuilderPlan["history"];
+  }
+): Partial<LessonPlanRecord> {
+  return {
+    id: plan.id,
+    slug: plan.slug,
+    title: plan.title,
+    summary: plan.summary,
+    stage: plan.stage,
+    stages: plan.stages,
+    subjects: plan.subjects,
+    delivery_methods: plan.deliveryMethods,
+    technology_tags: plan.technologyTags,
+    duration_minutes: plan.durationMinutes,
+    status: plan.status,
+    overview: plan.overview,
+    content: builderStepsToContent(plan.steps),
+    resources: plan.resources,
+    metadata: {
+      builder: {
+        version: plan.version,
+        steps: plan.steps,
+        standards: plan.standards,
+        availableStandards: plan.availableStandards,
+        parts: plan.parts,
+        lastSavedAt: null,
+        history: plan.history,
+      },
+    },
+  } as Partial<LessonPlanRecord>;
+}
+
+export function nextVersionEntry(
+  plan: LessonBuilderPlan,
+  timestamp: string
+): LessonBuilderVersionEntry {
+  const label = `Draft v${plan.version + 1}`;
+  return {
+    id: cryptoRandomId("ver"),
+    label,
+    createdAt: timestamp,
+    author: plan.history[0]?.author ?? null,
+    summary: plan.summary,
+  };
+}

--- a/api/builder/lesson-plans.ts
+++ b/api/builder/lesson-plans.ts
@@ -1,0 +1,128 @@
+import { mapRecordToBuilderPlan, createDraftInsert } from "../_lib/lesson-builder-helpers";
+import { getSupabaseClient } from "../_lib/supabase";
+import type { LessonBuilderDraftRequest, LessonBuilderPlanResponse } from "../../types/lesson-builder";
+import type { LessonPlanRecord } from "../../types/lesson-plans";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+function errorResponse(status: number, message: string): Response {
+  return jsonResponse({ error: message }, status);
+}
+
+function generateId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `plan_${Math.random().toString(36).slice(2, 12)}`;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+}
+
+function buildSlug(title: string, id: string): string {
+  const base = slugify(title || "lesson-plan");
+  const suffix = id.replace(/[^a-z0-9]+/gi, "").slice(0, 6) || "draft";
+  return `${base}-${suffix}`;
+}
+
+function parseRequestBody(body: unknown): LessonBuilderDraftRequest {
+  if (!body || typeof body !== "object") {
+    return {};
+  }
+  const record = body as Record<string, unknown>;
+  return {
+    title: typeof record.title === "string" ? record.title : null,
+    stage: typeof record.stage === "string" ? record.stage : null,
+    subjects: Array.isArray(record.subjects)
+      ? record.subjects.filter((subject): subject is string => typeof subject === "string")
+      : [],
+  };
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  if (request.method && request.method.toUpperCase() !== "POST") {
+    return new Response(null, {
+      status: 405,
+      headers: {
+        Allow: "POST",
+      },
+    });
+  }
+
+  let payload: LessonBuilderDraftRequest = {};
+  try {
+    payload = parseRequestBody(await request.json());
+  } catch {
+    payload = {};
+  }
+
+  const id = generateId();
+  const title = payload.title?.trim() && payload.title.length > 0 ? payload.title.trim() : "Untitled Lesson";
+  const slug = buildSlug(title, id);
+  const now = new Date().toISOString();
+
+  const draft = createDraftInsert({
+    id,
+    slug,
+    title,
+    summary: null,
+    stage: payload.stage ?? null,
+    stages: payload.stage ? [payload.stage] : [],
+    subjects: payload.subjects ?? [],
+    deliveryMethods: [],
+    technologyTags: [],
+    durationMinutes: null,
+    status: "draft",
+    overview: null,
+    steps: [],
+    standards: [],
+    availableStandards: [],
+    resources: [],
+    version: 1,
+    parts: [
+      { id: "overview", label: "Overview", description: null, completed: false },
+      { id: "activities", label: "Learning Activities", description: null, completed: false },
+      { id: "assessment", label: "Assessment", description: null, completed: false },
+      { id: "resources", label: "Resources", description: null, completed: false },
+    ],
+    history: [
+      {
+        id: `ver_${id.slice(0, 6)}`,
+        label: "Draft v1",
+        createdAt: now,
+        author: null,
+        summary: null,
+      },
+    ],
+  });
+
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from<LessonPlanRecord>("lesson_plans")
+    .insert(draft)
+    .select("*")
+    .maybeSingle();
+
+  if (error || !data) {
+    return errorResponse(500, "Failed to create draft");
+  }
+
+  const plan = mapRecordToBuilderPlan(data);
+
+  const response: LessonBuilderPlanResponse = { plan };
+  return jsonResponse(response, 201);
+}

--- a/api/builder/lesson-plans/[id].ts
+++ b/api/builder/lesson-plans/[id].ts
@@ -1,0 +1,138 @@
+import { mapRecordToBuilderPlan, buildUpdatePayload, nextVersionEntry, buildMetadataFromPlan } from "../../_lib/lesson-builder-helpers";
+import { getSupabaseClient } from "../../_lib/supabase";
+import type {
+  LessonBuilderPlan,
+  LessonBuilderPlanResponse,
+  LessonBuilderUpdateRequest,
+} from "../../../types/lesson-builder";
+import type { LessonPlanRecord } from "../../../types/lesson-plans";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+function errorResponse(status: number, message: string): Response {
+  return jsonResponse({ error: message }, status);
+}
+
+function parseLookup(url: URL): "id" | "slug" {
+  const lookup = url.searchParams.get("lookup");
+  return lookup === "slug" ? "slug" : "id";
+}
+
+async function loadPlan(id: string, lookup: "id" | "slug") {
+  const supabase = getSupabaseClient();
+  let query = supabase.from<LessonPlanRecord>("lesson_plans").select("*");
+  if (lookup === "slug") {
+    query = query.eq("slug", id).eq("status", "published");
+  } else {
+    query = query.eq("id", id);
+  }
+
+  const { data, error } = await query.maybeSingle();
+  if (error) {
+    return { error: errorResponse(500, "Failed to load lesson plan") };
+  }
+  if (!data) {
+    return { error: errorResponse(404, "Lesson plan not found") };
+  }
+  return { plan: mapRecordToBuilderPlan(data) };
+}
+
+function parseUpdate(body: unknown): LessonBuilderUpdateRequest | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+  if (!("plan" in body)) {
+    return null;
+  }
+  return body as LessonBuilderUpdateRequest;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const segments = url.pathname.split("/").filter(Boolean);
+  const id = segments.pop();
+
+  if (!id) {
+    return errorResponse(404, "Lesson plan not found");
+  }
+
+  if (!request.method) {
+    return errorResponse(405, "Method not allowed");
+  }
+
+  const method = request.method.toUpperCase();
+  const lookup = parseLookup(url);
+
+  if (method === "GET") {
+    const result = await loadPlan(id, lookup);
+    if ("error" in result) {
+      return result.error;
+    }
+    const response: LessonBuilderPlanResponse = { plan: result.plan };
+    return jsonResponse(response);
+  }
+
+  if (method !== "PATCH") {
+    return new Response(null, {
+      status: 405,
+      headers: {
+        Allow: "GET, PATCH",
+      },
+    });
+  }
+
+  if (lookup === "slug") {
+    return errorResponse(400, "Updates must use plan id");
+  }
+
+  let payload: LessonBuilderUpdateRequest | null = null;
+  try {
+    payload = parseUpdate(await request.json());
+  } catch {
+    payload = null;
+  }
+
+  if (!payload || !payload.plan) {
+    return errorResponse(400, "Invalid payload");
+  }
+
+  const incomingPlan = payload.plan;
+  const timestamp = new Date().toISOString();
+  const history = [nextVersionEntry(incomingPlan, timestamp), ...incomingPlan.history].slice(0, 25);
+
+  const updatedPlan: LessonBuilderPlan = {
+    ...incomingPlan,
+    lastSavedAt: timestamp,
+    version: incomingPlan.version + 1,
+    history,
+  };
+
+  const update = buildUpdatePayload(updatedPlan);
+  // Ensure metadata keeps version + history updates
+  update.metadata = buildMetadataFromPlan(updatedPlan);
+
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from<LessonPlanRecord>("lesson_plans")
+    .update(update)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+
+  if (error || !data) {
+    return errorResponse(500, "Failed to save lesson plan");
+  }
+
+  const plan = mapRecordToBuilderPlan(data);
+  const response: LessonBuilderPlanResponse = { plan };
+  return jsonResponse(response);
+}

--- a/api/builder/lesson-plans/[id]/activities.ts
+++ b/api/builder/lesson-plans/[id]/activities.ts
@@ -1,0 +1,98 @@
+import { getSupabaseClient } from "../../../_lib/supabase";
+import { mergeActivityValues, cryptoRandomId } from "../../../../types/lesson-builder";
+import type { LessonBuilderActivitySearchResponse } from "../../../../types/lesson-builder";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+function errorResponse(status: number, message: string): Response {
+  return jsonResponse({ error: message }, status);
+}
+
+function ensureArray(input: unknown): string[] {
+  if (Array.isArray(input)) {
+    return input.filter((value): value is string => typeof value === "string");
+  }
+  if (typeof input === "string") {
+    return input
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function mapActivity(record: Record<string, unknown>) {
+  const title = typeof record.title === "string" && record.title.length > 0 ? record.title : "Activity";
+  const summary = typeof record.excerpt === "string" ? record.excerpt : null;
+  const subjects = ensureArray(record.subjects);
+  const gradeLevels = ensureArray(record.grade_levels ?? record.gradeLevels);
+  const durationMinutes = typeof record.read_time === "number" ? record.read_time : null;
+  const tags = ensureArray(record.activity_type ?? record.activityTypes ?? record.tags);
+  const slug = typeof record.slug === "string" ? record.slug : null;
+  const sourceUrl = slug ? `/edutech/${slug}` : null;
+
+  return mergeActivityValues({
+    id: typeof record.id === "string" ? record.id : cryptoRandomId("activity"),
+    title,
+    summary,
+    subjects,
+    gradeLevels,
+    durationMinutes,
+    sourceUrl,
+    tags,
+  });
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  if (request.method && request.method.toUpperCase() !== "GET") {
+    return new Response(null, {
+      status: 405,
+      headers: {
+        Allow: "GET",
+      },
+    });
+  }
+
+  const url = new URL(request.url);
+  const query = url.searchParams.get("q");
+  const supabase = getSupabaseClient();
+
+  let builder = supabase
+    .from("content_master")
+    .select("id,title,excerpt,subjects,grade_levels,activity_type,slug,read_time")
+    .eq("content_type", "activity")
+    .limit(12);
+
+  if (query && query.trim().length > 0) {
+    const term = `%${query.trim()}%`;
+    builder = builder.or(
+      [
+        `title.ilike.${term}`,
+        `excerpt.ilike.${term}`,
+      ].join(",")
+    );
+  }
+
+  const { data, error } = await builder;
+
+  if (error) {
+    return errorResponse(500, "Failed to search activities");
+  }
+
+  const records = Array.isArray(data) ? data : [];
+  const results = records
+    .map((record) => mapActivity(record as Record<string, unknown>))
+    .filter((activity) => activity.title.length > 0);
+
+  const response: LessonBuilderActivitySearchResponse = { results };
+  return jsonResponse(response);
+}

--- a/api/builder/lesson-plans/[id]/history.ts
+++ b/api/builder/lesson-plans/[id]/history.ts
@@ -1,0 +1,57 @@
+import { mapRecordToBuilderPlan } from "../../../_lib/lesson-builder-helpers";
+import { getSupabaseClient } from "../../../_lib/supabase";
+import type { LessonBuilderHistoryResponse } from "../../../../types/lesson-builder";
+import type { LessonPlanRecord } from "../../../../types/lesson-plans";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+function errorResponse(status: number, message: string): Response {
+  return jsonResponse({ error: message }, status);
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  if (request.method && request.method.toUpperCase() !== "GET") {
+    return new Response(null, {
+      status: 405,
+      headers: {
+        Allow: "GET",
+      },
+    });
+  }
+
+  const url = new URL(request.url);
+  const segments = url.pathname.split("/").filter(Boolean);
+  const id = segments[segments.length - 2];
+
+  if (!id) {
+    return errorResponse(404, "Lesson plan not found");
+  }
+
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from<LessonPlanRecord>("lesson_plans")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    return errorResponse(500, "Failed to load version history");
+  }
+
+  if (!data) {
+    return errorResponse(404, "Lesson plan not found");
+  }
+
+  const plan = mapRecordToBuilderPlan(data);
+  const response: LessonBuilderHistoryResponse = { versions: plan.history };
+  return jsonResponse(response);
+}

--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -17,6 +17,8 @@ import LessonPlans from '@/pages/LessonPlans';
 import LessonPlan from '@/pages/LessonPlan';
 import Worksheets from '@/pages/Worksheets';
 import Worksheet from '@/pages/Worksheet';
+import BuilderLessonPlan from '@/pages/BuilderLessonPlan';
+import BuilderLessonPlanDetail from '@/pages/BuilderLessonPlanDetail';
 import Auth from '@/pages/Auth';
 import Account from '@/pages/Account';
 import NotFound from '@/pages/NotFound';
@@ -42,6 +44,16 @@ const RouteWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => 
   );
 };
 
+const LegacyBuilderRedirect: React.FC<{ includeLanguage?: boolean }> = ({ includeLanguage = false }) => {
+  const params = useParams<{ lang?: string; id?: string }>();
+  const langPrefix = includeLanguage && params.lang ? `/${params.lang}` : '';
+  const destination = params.id
+    ? `${langPrefix}/builder/lesson-plans/${params.id}`
+    : `${langPrefix}/builder/lesson-plans`;
+
+  return <Navigate to={destination} replace />;
+};
+
 export const LocalizedRoutes = () => {
   return (
     <Routes>
@@ -53,6 +65,10 @@ export const LocalizedRoutes = () => {
       <Route path="/blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
       <Route path="/lesson-plans" element={<RouteWrapper><LessonPlans /></RouteWrapper>} />
       <Route path="/lesson-plans/:slug" element={<RouteWrapper><LessonPlan /></RouteWrapper>} />
+      <Route path="/builder/lesson-plans" element={<RouteWrapper><BuilderLessonPlan /></RouteWrapper>} />
+      <Route path="/builder/lesson-plans/:id" element={<RouteWrapper><BuilderLessonPlanDetail /></RouteWrapper>} />
+      <Route path="/lesson-plans/builder" element={<LegacyBuilderRedirect />} />
+      <Route path="/lesson-plans/builder/:id" element={<LegacyBuilderRedirect />} />
       <Route path="/worksheets" element={<RouteWrapper><Worksheets /></RouteWrapper>} />
       <Route path="/worksheets/:slug" element={<RouteWrapper><Worksheet /></RouteWrapper>} />
       <Route path="/events" element={<RouteWrapper><Events /></RouteWrapper>} />
@@ -75,6 +91,10 @@ export const LocalizedRoutes = () => {
         <Route path="blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
         <Route path="lesson-plans" element={<RouteWrapper><LessonPlans /></RouteWrapper>} />
         <Route path="lesson-plans/:slug" element={<RouteWrapper><LessonPlan /></RouteWrapper>} />
+        <Route path="builder/lesson-plans" element={<RouteWrapper><BuilderLessonPlan /></RouteWrapper>} />
+        <Route path="builder/lesson-plans/:id" element={<RouteWrapper><BuilderLessonPlanDetail /></RouteWrapper>} />
+        <Route path="lesson-plans/builder" element={<LegacyBuilderRedirect includeLanguage />} />
+        <Route path="lesson-plans/builder/:id" element={<LegacyBuilderRedirect includeLanguage />} />
         <Route path="worksheets" element={<RouteWrapper><Worksheets /></RouteWrapper>} />
         <Route path="worksheets/:slug" element={<RouteWrapper><Worksheet /></RouteWrapper>} />
         <Route path="events" element={<RouteWrapper><Events /></RouteWrapper>} />

--- a/src/components/builder/lesson/ActivitySearchPanel.tsx
+++ b/src/components/builder/lesson/ActivitySearchPanel.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { LessonBuilderActivity } from "@/types/lesson-builder";
+
+interface ActivitySearchCopy {
+  title: string;
+  placeholder: string;
+  helper: string;
+  addLabel: string;
+  empty: string;
+}
+
+interface ActivitySearchPanelProps {
+  query: string;
+  onQueryChange: (value: string) => void;
+  results: LessonBuilderActivity[];
+  onAdd: (activity: LessonBuilderActivity) => void;
+  isLoading: boolean;
+  copy: ActivitySearchCopy;
+}
+
+export const ActivitySearchPanel = ({
+  query,
+  onQueryChange,
+  results,
+  onAdd,
+  isLoading,
+  copy,
+}: ActivitySearchPanelProps) => {
+  const hasResults = results.length > 0;
+  const helperText = useMemo(() => copy.helper.replace("{min}", "3"), [copy.helper]);
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold text-foreground">{copy.title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Input
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder={copy.placeholder}
+          />
+          <p className="text-xs text-muted-foreground">{helperText}</p>
+        </div>
+        <ScrollArea className="h-[240px]">
+          {isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="space-y-2">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-3 w-full" />
+                </div>
+              ))}
+            </div>
+          ) : hasResults ? (
+            <div className="space-y-4">
+              {results.map((activity) => (
+                <div key={activity.id} className="space-y-2 rounded-lg border border-border p-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <p className="font-medium text-foreground">{activity.title}</p>
+                      {activity.summary ? (
+                        <p className="text-sm text-muted-foreground">{activity.summary}</p>
+                      ) : null}
+                    </div>
+                    <Button size="sm" onClick={() => onAdd(activity)}>
+                      {copy.addLabel}
+                    </Button>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {activity.subjects.map((subject) => (
+                      <Badge key={subject} variant="secondary">
+                        {subject}
+                      </Badge>
+                    ))}
+                    {activity.tags.map((tag) => (
+                      <Badge key={tag} variant="outline">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">{copy.empty}</p>
+          )}
+        </ScrollArea>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/builder/lesson/MetaBar.tsx
+++ b/src/components/builder/lesson/MetaBar.tsx
@@ -1,0 +1,87 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { LessonBuilderPlan } from "@/types/lesson-builder";
+
+interface MetaBarCopy {
+  titleLabel: string;
+  summaryLabel: string;
+  stageLabel: string;
+  subjectsLabel: string;
+  durationLabel: string;
+  technologyLabel: string;
+}
+
+interface MetaBarProps {
+  plan: LessonBuilderPlan;
+  copy: MetaBarCopy;
+  onUpdate: (updater: (plan: LessonBuilderPlan) => LessonBuilderPlan) => void;
+}
+
+export const MetaBar = ({ plan, copy, onUpdate }: MetaBarProps) => {
+  const handleTitleChange = (value: string) => {
+    onUpdate((current) => ({ ...current, title: value }));
+  };
+
+  const handleSummaryChange = (value: string) => {
+    onUpdate((current) => ({ ...current, summary: value.length > 0 ? value : null }));
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg font-semibold text-foreground">{copy.titleLabel}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2">
+          <Input
+            value={plan.title}
+            onChange={(event) => handleTitleChange(event.target.value)}
+            placeholder={copy.titleLabel}
+          />
+        </div>
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-muted-foreground">{copy.summaryLabel}</p>
+          <Textarea
+            value={plan.summary ?? ""}
+            onChange={(event) => handleSummaryChange(event.target.value)}
+            placeholder={copy.summaryLabel}
+            className="min-h-[120px]"
+          />
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <MetaGroup label={copy.stageLabel} values={plan.stage ? [plan.stage] : []} />
+          <MetaGroup label={copy.subjectsLabel} values={plan.subjects} />
+          <MetaGroup
+            label={copy.durationLabel}
+            values={plan.durationMinutes != null ? [`${plan.durationMinutes} min`] : []}
+          />
+          <MetaGroup label={copy.technologyLabel} values={plan.technologyTags} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+interface MetaGroupProps {
+  label: string;
+  values: string[];
+}
+
+const MetaGroup = ({ label, values }: MetaGroupProps) => (
+  <div className="space-y-2">
+    <p className="text-xs font-semibold uppercase text-muted-foreground">{label}</p>
+    {values.length > 0 ? (
+      <div className="flex flex-wrap gap-2">
+        {values.map((value) => (
+          <Badge key={value} variant="secondary">
+            {value}
+          </Badge>
+        ))}
+      </div>
+    ) : (
+      <p className="text-sm text-muted-foreground">—</p>
+    )}
+  </div>
+);

--- a/src/components/builder/lesson/PartsSidebar.tsx
+++ b/src/components/builder/lesson/PartsSidebar.tsx
@@ -1,0 +1,98 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type {
+  LessonBuilderPart,
+  LessonBuilderVersionEntry,
+} from "@/types/lesson-builder";
+
+interface PartsSidebarCopy {
+  title: string;
+  empty: string;
+}
+
+interface HistoryCopy {
+  title: string;
+  empty: string;
+}
+
+interface PartsSidebarProps {
+  parts: LessonBuilderPart[];
+  selectedPart: string | null;
+  onSelect: (id: string) => void;
+  copy: PartsSidebarCopy;
+  history: LessonBuilderVersionEntry[];
+  historyCopy: HistoryCopy;
+}
+
+export const PartsSidebar = ({
+  parts,
+  selectedPart,
+  onSelect,
+  copy,
+  history,
+  historyCopy,
+}: PartsSidebarProps) => {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base font-semibold text-foreground">{copy.title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {parts.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{copy.empty}</p>
+          ) : (
+            <div className="space-y-2">
+              {parts.map((part) => (
+                <Button
+                  key={part.id}
+                  variant={part.id === selectedPart ? "secondary" : "ghost"}
+                  className="w-full justify-start text-left"
+                  onClick={() => onSelect(part.id)}
+                >
+                  <div className="flex w-full flex-col">
+                    <span className="font-medium text-foreground">{part.label}</span>
+                    {part.description ? (
+                      <span className="text-xs text-muted-foreground">{part.description}</span>
+                    ) : null}
+                  </div>
+                  {part.completed ? (
+                    <Badge className="ml-2" variant="outline">
+                      ✓
+                    </Badge>
+                  ) : null}
+                </Button>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base font-semibold text-foreground">{historyCopy.title}</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {history.length === 0 ? (
+            <p className="px-6 py-4 text-sm text-muted-foreground">{historyCopy.empty}</p>
+          ) : (
+            <ScrollArea className="h-48">
+              <div className="space-y-4 px-6 py-4">
+                {history.map((entry) => (
+                  <div key={entry.id} className="space-y-1">
+                    <p className="text-sm font-medium text-foreground">{entry.label}</p>
+                    <p className="text-xs text-muted-foreground">{new Date(entry.createdAt).toLocaleString()}</p>
+                    {entry.summary ? (
+                      <p className="text-xs text-muted-foreground">{entry.summary}</p>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/builder/lesson/PlanCanvas.tsx
+++ b/src/components/builder/lesson/PlanCanvas.tsx
@@ -1,0 +1,72 @@
+import { Fragment } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import type { LessonBuilderStep } from "@/types/lesson-builder";
+import { StepCard } from "./StepCard";
+
+interface PlanCanvasCopy {
+  title: string;
+  addStep: string;
+  empty: string;
+  stepCopy: {
+    titlePlaceholder: string;
+    descriptionPlaceholder: string;
+    notesPlaceholder: string;
+    activitiesTitle: string;
+    removeActivity: string;
+  };
+}
+
+interface PlanCanvasProps {
+  steps: LessonBuilderStep[];
+  selectedStepId: string | null;
+  onSelectStep: (id: string) => void;
+  onAddStep: () => void;
+  onRemoveStep: (id: string) => void;
+  onStepChange: (id: string, updater: (step: LessonBuilderStep) => LessonBuilderStep) => void;
+  copy: PlanCanvasCopy;
+}
+
+export const PlanCanvas = ({
+  steps,
+  selectedStepId,
+  onSelectStep,
+  onAddStep,
+  onRemoveStep,
+  onStepChange,
+  copy,
+}: PlanCanvasProps) => {
+  return (
+    <Card className="h-full">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-lg font-semibold text-foreground">{copy.title}</CardTitle>
+        <Button size="sm" onClick={onAddStep}>
+          {copy.addStep}
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {steps.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{copy.empty}</p>
+        ) : (
+          <div className="space-y-4">
+            {steps.map((step, index) => (
+              <Fragment key={step.id}>
+                <StepCard
+                  step={step}
+                  index={index}
+                  isActive={step.id === selectedStepId}
+                  onSelect={() => onSelectStep(step.id)}
+                  onRemove={() => onRemoveStep(step.id)}
+                  onChange={(updater) => onStepChange(step.id, updater)}
+                  copy={copy.stepCopy}
+                />
+                {index < steps.length - 1 ? <Separator /> : null}
+              </Fragment>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/builder/lesson/PreviewModal.tsx
+++ b/src/components/builder/lesson/PreviewModal.tsx
@@ -1,0 +1,39 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { LessonBuilderPlan } from "@/types/lesson-builder";
+import { builderPlanToLessonPlan } from "@/types/lesson-builder";
+import { LessonDetailContent, type LessonDetailCopy } from "@/components/lesson-plans/LessonModal";
+
+interface PreviewModalCopy {
+  title: string;
+}
+
+interface PreviewModalProps {
+  plan: LessonBuilderPlan | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  copy: PreviewModalCopy;
+  lessonCopy: LessonDetailCopy;
+}
+
+export const PreviewModal = ({ plan, open, onOpenChange, copy, lessonCopy }: PreviewModalProps) => {
+  const lesson = plan ? builderPlanToLessonPlan(plan) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>{copy.title}</DialogTitle>
+        </DialogHeader>
+        <ScrollArea className="max-h-[70vh] pr-4">
+          <LessonDetailContent lesson={lesson} copy={lessonCopy} />
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/builder/lesson/StandardsPicker.tsx
+++ b/src/components/builder/lesson/StandardsPicker.tsx
@@ -1,0 +1,51 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { LessonBuilderStandard } from "@/types/lesson-builder";
+
+interface StandardsCopy {
+  title: string;
+  empty: string;
+  selectedLabel: string;
+}
+
+interface StandardsPickerProps {
+  available: LessonBuilderStandard[];
+  selected: LessonBuilderStandard[];
+  onToggle: (standard: LessonBuilderStandard) => void;
+  copy: StandardsCopy;
+}
+
+export const StandardsPicker = ({ available, selected, onToggle, copy }: StandardsPickerProps) => {
+  const selectedIds = new Set(selected.map((standard) => standard.id));
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold text-foreground">{copy.title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {available.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{copy.empty}</p>
+        ) : (
+          <div className="space-y-3">
+            {available.map((standard) => (
+              <label key={standard.id} className="flex cursor-pointer items-start gap-3 rounded-lg border border-border p-3">
+                <Checkbox
+                  checked={selectedIds.has(standard.id)}
+                  onCheckedChange={() => onToggle(standard)}
+                />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-foreground">{standard.code}</p>
+                  <p className="text-xs text-muted-foreground">{standard.description}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {standard.subject ? `${standard.subject}` : copy.selectedLabel}
+                  </p>
+                </div>
+              </label>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/builder/lesson/StepCard.tsx
+++ b/src/components/builder/lesson/StepCard.tsx
@@ -1,0 +1,129 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import type { LessonBuilderActivity, LessonBuilderStep } from "@/types/lesson-builder";
+
+interface StepCardCopy {
+  titlePlaceholder: string;
+  descriptionPlaceholder: string;
+  notesPlaceholder: string;
+  activitiesTitle: string;
+  removeActivity: string;
+}
+
+interface StepCardProps {
+  step: LessonBuilderStep;
+  index: number;
+  isActive: boolean;
+  onSelect: () => void;
+  onChange: (updater: (step: LessonBuilderStep) => LessonBuilderStep) => void;
+  onRemove?: () => void;
+  copy: StepCardCopy;
+}
+
+export const StepCard = ({
+  step,
+  index,
+  isActive,
+  onSelect,
+  onChange,
+  onRemove,
+  copy,
+}: StepCardProps) => {
+  const handleTitleChange = (value: string) => {
+    onChange((current) => ({ ...current, title: value }));
+  };
+
+  const handleDescriptionChange = (value: string) => {
+    onChange((current) => ({ ...current, description: value.length > 0 ? value : null }));
+  };
+
+  const handleNotesChange = (value: string) => {
+    onChange((current) => ({ ...current, notes: value.length > 0 ? value : null }));
+  };
+
+  const handleRemoveActivity = (activity: LessonBuilderActivity) => {
+    onChange((current) => ({
+      ...current,
+      activities: current.activities.filter((item) => item.id !== activity.id),
+    }));
+  };
+
+  return (
+    <Card
+      className={`border ${isActive ? "border-primary" : "border-border"} transition-colors`}
+      onClick={onSelect}
+    >
+      <CardContent className="space-y-4 p-4">
+        <div className="flex items-center justify-between">
+          <Badge variant={isActive ? "default" : "outline"}>{index + 1}</Badge>
+          {onRemove ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-xs text-muted-foreground"
+              onClick={(event) => {
+                event.stopPropagation();
+                onRemove();
+              }}
+            >
+              ×
+            </Button>
+          ) : null}
+        </div>
+        <Input
+          value={step.title}
+          onChange={(event) => handleTitleChange(event.target.value)}
+          placeholder={copy.titlePlaceholder}
+        />
+        <Textarea
+          value={step.description ?? ""}
+          onChange={(event) => handleDescriptionChange(event.target.value)}
+          placeholder={copy.descriptionPlaceholder}
+          className="min-h-[100px]"
+        />
+        <Textarea
+          value={step.notes ?? ""}
+          onChange={(event) => handleNotesChange(event.target.value)}
+          placeholder={copy.notesPlaceholder}
+          className="min-h-[80px]"
+        />
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-muted-foreground">{copy.activitiesTitle}</p>
+          {step.activities.length === 0 ? (
+            <p className="text-xs text-muted-foreground">—</p>
+          ) : (
+            <div className="space-y-2">
+              {step.activities.map((activity) => (
+                <div
+                  key={activity.id}
+                  className="flex items-start justify-between gap-2 rounded-md border border-border p-2"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-foreground">{activity.title}</p>
+                    {activity.summary ? (
+                      <p className="text-xs text-muted-foreground">{activity.summary}</p>
+                    ) : null}
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs text-muted-foreground"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleRemoveActivity(activity);
+                    }}
+                  >
+                    {copy.removeActivity}
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/builder/lesson/Toolbar.tsx
+++ b/src/components/builder/lesson/Toolbar.tsx
@@ -1,0 +1,89 @@
+import { format } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Loader2, MoreHorizontal, Play } from "lucide-react";
+import type { LessonBuilderPlan, LessonBuilderVersionEntry } from "@/types/lesson-builder";
+
+interface ToolbarCopy {
+  draftStatus: string;
+  publishedStatus: string;
+  previewLabel: string;
+  savingLabel: string;
+  historyLabel: string;
+  lastSavedPrefix: string;
+  noHistory: string;
+}
+
+interface ToolbarProps {
+  plan: LessonBuilderPlan | null;
+  history: LessonBuilderVersionEntry[];
+  isSaving: boolean;
+  onPreview: () => void;
+  copy: ToolbarCopy;
+}
+
+function formatLastSaved(date: string | null, prefix: string): string {
+  if (!date) {
+    return prefix;
+  }
+  try {
+    return `${prefix} ${format(new Date(date), "PPpp")}`;
+  } catch {
+    return prefix;
+  }
+}
+
+export const Toolbar = ({ plan, history, isSaving, onPreview, copy }: ToolbarProps) => {
+  const statusLabel = plan?.status === "published" ? copy.publishedStatus : copy.draftStatus;
+  const lastSavedLabel = formatLastSaved(plan?.lastSavedAt ?? plan?.updatedAt ?? null, copy.lastSavedPrefix);
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-border bg-card/50 px-4 py-3">
+      <div className="flex items-center gap-3">
+        <Badge variant={plan?.status === "published" ? "default" : "outline"}>{statusLabel}</Badge>
+        <span className="text-sm text-muted-foreground">{lastSavedLabel}</span>
+        {isSaving ? (
+          <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {copy.savingLabel}
+          </span>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm">
+              <MoreHorizontal className="mr-2 h-4 w-4" />
+              {copy.historyLabel}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-64">
+            {history.length === 0 ? (
+              <DropdownMenuItem disabled>{copy.noHistory}</DropdownMenuItem>
+            ) : (
+              history.map((entry) => (
+                <DropdownMenuItem key={entry.id} className="flex-col items-start gap-1">
+                  <span className="text-sm font-medium">{entry.label}</span>
+                  <span className="text-xs text-muted-foreground">{format(new Date(entry.createdAt), "PPpp")}</span>
+                  {entry.summary ? (
+                    <span className="text-xs text-muted-foreground">{entry.summary}</span>
+                  ) : null}
+                </DropdownMenuItem>
+              ))
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button size="sm" onClick={onPreview}>
+          <Play className="mr-2 h-4 w-4" />
+          {copy.previewLabel}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/lib/builder-api.ts
+++ b/src/lib/builder-api.ts
@@ -1,0 +1,76 @@
+import type {
+  LessonBuilderActivity,
+  LessonBuilderPlan,
+  LessonBuilderPlanResponse,
+  LessonBuilderHistoryResponse,
+  LessonBuilderActivitySearchResponse,
+  LessonBuilderDraftRequest,
+} from "@/types/lesson-builder";
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Request failed with status ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function createLessonBuilderDraft(
+  payload: LessonBuilderDraftRequest = {}
+): Promise<LessonBuilderPlan> {
+  const response = await fetch("/api/builder/lesson-plans", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  const result = await handleResponse<LessonBuilderPlanResponse>(response);
+  return result.plan;
+}
+
+export async function fetchLessonBuilderPlan(
+  identifier: string,
+  options: { lookup?: "id" | "slug" } = {}
+): Promise<LessonBuilderPlan> {
+  const lookup = options.lookup ?? "id";
+  const response = await fetch(`/api/builder/lesson-plans/${identifier}?lookup=${lookup}`);
+  const result = await handleResponse<LessonBuilderPlanResponse>(response);
+  return result.plan;
+}
+
+export async function autosaveLessonBuilderPlan(
+  id: string,
+  plan: LessonBuilderPlan
+): Promise<LessonBuilderPlan> {
+  const response = await fetch(`/api/builder/lesson-plans/${id}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ plan }),
+  });
+  const result = await handleResponse<LessonBuilderPlanResponse>(response);
+  return result.plan;
+}
+
+export async function fetchLessonBuilderHistory(id: string): Promise<LessonBuilderHistoryResponse["versions"]> {
+  const response = await fetch(`/api/builder/lesson-plans/${id}/history`);
+  const result = await handleResponse<LessonBuilderHistoryResponse>(response);
+  return result.versions;
+}
+
+export async function searchLessonBuilderActivities(
+  id: string,
+  query: string
+): Promise<LessonBuilderActivity[]> {
+  const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost";
+  const url = new URL(`/api/builder/lesson-plans/${id}/activities`, origin);
+  if (query.trim()) {
+    url.searchParams.set("q", query.trim());
+  }
+  const path = `${url.pathname}${url.search}`;
+  const response = await fetch(path);
+  const result = await handleResponse<LessonBuilderActivitySearchResponse>(response);
+  return result.results;
+}

--- a/src/pages/BuilderLessonPlan.tsx
+++ b/src/pages/BuilderLessonPlan.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { Loader2, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+import { createLessonBuilderDraft } from "@/lib/builder-api";
+
+const BuilderLessonPlan = () => {
+  const navigate = useNavigate();
+  const { language, t } = useLanguage();
+
+  const mutation = useMutation({
+    mutationFn: createLessonBuilderDraft,
+    onSuccess: (plan) => {
+      const path = getLocalizedPath(`/builder/lesson-plans/${plan.id}`, language);
+      navigate(path, { replace: true });
+    },
+  });
+
+  useEffect(() => {
+    if (!mutation.isPending && !mutation.isSuccess) {
+      mutation.mutate({});
+    }
+  }, [mutation]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-6">
+      <Card className="max-w-md">
+        <CardContent className="space-y-4 p-6 text-center">
+          {mutation.isError ? (
+            <>
+              <div className="flex justify-center">
+                <RefreshCw className="h-10 w-10 text-destructive" />
+              </div>
+              <p className="text-base font-medium text-foreground">{t.lessonBuilder.states.error}</p>
+              <p className="text-sm text-muted-foreground">
+                {t.lessonBuilder.states.errorDescription}
+              </p>
+              <Button onClick={() => mutation.mutate({})} variant="default">
+                {t.lessonBuilder.states.retry}
+              </Button>
+            </>
+          ) : (
+            <>
+              <div className="flex justify-center">
+                <Loader2 className="h-10 w-10 animate-spin text-primary" />
+              </div>
+              <p className="text-base font-medium text-foreground">
+                {t.lessonBuilder.states.creating}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {t.lessonBuilder.states.creatingDescription}
+              </p>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default BuilderLessonPlan;

--- a/src/pages/BuilderLessonPlanDetail.tsx
+++ b/src/pages/BuilderLessonPlanDetail.tsx
@@ -1,0 +1,313 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+import { Loader2, RefreshCw } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  ActivitySearchPanel,
+} from "@/components/builder/lesson/ActivitySearchPanel";
+import { MetaBar } from "@/components/builder/lesson/MetaBar";
+import { PartsSidebar } from "@/components/builder/lesson/PartsSidebar";
+import { PlanCanvas } from "@/components/builder/lesson/PlanCanvas";
+import { StandardsPicker } from "@/components/builder/lesson/StandardsPicker";
+import { Toolbar } from "@/components/builder/lesson/Toolbar";
+import { PreviewModal } from "@/components/builder/lesson/PreviewModal";
+import type { LessonDetailCopy } from "@/components/lesson-plans/LessonModal";
+import {
+  autosaveLessonBuilderPlan,
+  fetchLessonBuilderHistory,
+  fetchLessonBuilderPlan,
+  searchLessonBuilderActivities,
+} from "@/lib/builder-api";
+import type {
+  LessonBuilderActivity,
+  LessonBuilderPlan,
+  LessonBuilderVersionEntry,
+} from "@/types/lesson-builder";
+import { mergeStepValues } from "@/types/lesson-builder";
+
+const AUTOSAVE_DELAY = 1500;
+
+const BuilderLessonPlanDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const { t } = useLanguage();
+  const queryClient = useQueryClient();
+
+  const planQuery = useQuery({
+    queryKey: ["builder-plan", id],
+    enabled: Boolean(id),
+    queryFn: () => fetchLessonBuilderPlan(id as string),
+  });
+
+  const historyQuery = useQuery({
+    queryKey: ["builder-plan-history", id],
+    enabled: Boolean(id),
+    queryFn: () => fetchLessonBuilderHistory(id as string),
+  });
+
+  const [plan, setPlan] = useState<LessonBuilderPlan | null>(null);
+  const [selectedPart, setSelectedPart] = useState<string | null>(null);
+  const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
+  const [activityQuery, setActivityQuery] = useState("");
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
+  const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestPlan = useRef<LessonBuilderPlan | null>(null);
+
+  useEffect(() => {
+    if (planQuery.data) {
+      setPlan(planQuery.data);
+      latestPlan.current = planQuery.data;
+      if (!selectedPart && planQuery.data.parts.length > 0) {
+        setSelectedPart(planQuery.data.parts[0].id);
+      }
+      if (!selectedStepId && planQuery.data.steps.length > 0) {
+        setSelectedStepId(planQuery.data.steps[0].id);
+      }
+    }
+  }, [planQuery.data, selectedPart, selectedStepId]);
+
+  useEffect(() => () => {
+    if (autosaveTimer.current) {
+      clearTimeout(autosaveTimer.current);
+    }
+  }, []);
+
+  const autosaveMutation = useMutation({
+    mutationFn: (updatedPlan: LessonBuilderPlan) => autosaveLessonBuilderPlan(id as string, updatedPlan),
+    onSuccess: (updated) => {
+      latestPlan.current = updated;
+      setPlan(updated);
+      queryClient.setQueryData(["builder-plan", id], updated);
+      queryClient.setQueryData(["builder-plan-history", id], updated.history);
+    },
+  });
+
+  const isSaving = autosaveMutation.isPending;
+
+  const scheduleAutosave = useCallback(
+    (nextPlan: LessonBuilderPlan) => {
+      latestPlan.current = nextPlan;
+      if (autosaveTimer.current) {
+        clearTimeout(autosaveTimer.current);
+      }
+      autosaveTimer.current = setTimeout(() => {
+        if (latestPlan.current) {
+          autosaveMutation.mutate(latestPlan.current);
+        }
+      }, AUTOSAVE_DELAY);
+    },
+    [autosaveMutation]
+  );
+
+  const updatePlan = useCallback(
+    (updater: (plan: LessonBuilderPlan) => LessonBuilderPlan) => {
+      setPlan((current) => {
+        if (!current) {
+          return current;
+        }
+        const next = updater(current);
+        scheduleAutosave(next);
+        return next;
+      });
+    },
+    [scheduleAutosave]
+  );
+
+  const handleAddStep = () => {
+    const newStep = mergeStepValues({ title: "" });
+    updatePlan((current) => ({
+      ...current,
+      steps: [...current.steps, newStep],
+    }));
+    setSelectedStepId(newStep.id);
+  };
+
+  const handleRemoveStep = (stepId: string) => {
+    updatePlan((current) => {
+      const remaining = current.steps.filter((step) => step.id !== stepId);
+      setSelectedStepId((prev) => {
+        if (prev === stepId) {
+          return remaining[0]?.id ?? null;
+        }
+        return prev;
+      });
+      return {
+        ...current,
+        steps: remaining,
+      };
+    });
+  };
+
+  const handleStepChange = (stepId: string, updater: (step: LessonBuilderPlan["steps"][number]) => LessonBuilderPlan["steps"][number]) => {
+    updatePlan((current) => ({
+      ...current,
+      steps: current.steps.map((step) => (step.id === stepId ? updater(step) : step)),
+    }));
+  };
+
+  const handleAddActivity = (activity: LessonBuilderActivity) => {
+    if (!selectedStepId) {
+      return;
+    }
+    updatePlan((current) => ({
+      ...current,
+      steps: current.steps.map((step) => {
+        if (step.id !== selectedStepId) {
+          return step;
+        }
+        const exists = step.activities.some((item) => item.id === activity.id);
+        return exists
+          ? step
+          : { ...step, activities: [...step.activities, activity] };
+      }),
+    }));
+  };
+
+  const handleToggleStandard = (standard: LessonBuilderPlan["standards"][number]) => {
+    updatePlan((current) => {
+      const exists = current.standards.some((item) => item.id === standard.id);
+      const standards = exists
+        ? current.standards.filter((item) => item.id !== standard.id)
+        : [...current.standards, standard];
+      const available = current.availableStandards.some((item) => item.id === standard.id)
+        ? current.availableStandards
+        : [...current.availableStandards, standard];
+      return {
+        ...current,
+        standards,
+        availableStandards: available,
+      };
+    });
+  };
+
+  const activitiesQuery = useQuery({
+    queryKey: ["builder-plan-activities", id, activityQuery],
+    enabled: Boolean(id) && activityQuery.trim().length >= 3,
+    queryFn: () => searchLessonBuilderActivities(id as string, activityQuery),
+  });
+
+  const activityResults = activityQuery.trim().length >= 3 ? activitiesQuery.data ?? [] : [];
+  const history = historyQuery.data ?? plan?.history ?? [];
+
+  const lessonCopy = useMemo<LessonDetailCopy>(() => ({
+    stageLabel: t.lessonPlans.modal.stage,
+    subjectsLabel: t.lessonPlans.modal.subjects,
+    deliveryLabel: t.lessonPlans.modal.delivery,
+    technologyLabel: t.lessonPlans.modal.technology,
+    durationLabel: t.lessonPlans.modal.duration,
+    summaryLabel: t.lessonPlans.modal.summary,
+    overviewTitle: t.lessonPlans.modal.overview,
+    objectivesLabel: t.lessonPlans.modal.objectives,
+    materialsLabel: t.lessonPlans.modal.materials,
+    assessmentLabel: t.lessonPlans.modal.assessment,
+    technologyOverviewLabel: t.lessonPlans.modal.technologyOverview,
+    deliveryOverviewLabel: t.lessonPlans.modal.deliveryOverview,
+    durationOverviewLabel: t.lessonPlans.modal.durationOverview,
+    structureTitle: t.lessonPlans.modal.structure,
+    resourcesTitle: t.lessonPlans.modal.resources,
+    resourceLinkLabel: t.lessonPlans.modal.resourceLink,
+    noResourcesLabel: t.lessonPlans.modal.empty,
+    errorLabel: t.lessonPlans.states.error,
+    downloadLabel: t.lessonPlans.modal.download,
+    openFullLabel: t.lessonPlans.modal.openFull,
+    closeLabel: t.lessonPlans.modal.close,
+    loadingLabel: t.lessonPlans.states.loading,
+    minutesFormatter: (minutes: number) =>
+      t.lessonPlans.card.durationLabel.replace("{minutes}", String(minutes)),
+  }), [t]);
+
+  if (planQuery.isLoading) {
+    return (
+      <div className="space-y-6 p-6">
+        <Toolbar plan={plan ?? null} history={history} isSaving={false} onPreview={() => undefined} copy={t.lessonBuilder.toolbar} />
+        <Card>
+          <CardContent className="flex items-center gap-3 p-6 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            {t.lessonBuilder.states.loading}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (planQuery.isError || !plan) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center p-6">
+        <Card className="max-w-md">
+          <CardContent className="space-y-4 p-6 text-center">
+            <div className="flex justify-center">
+              <RefreshCw className="h-10 w-10 text-destructive" />
+            </div>
+            <p className="text-base font-medium text-foreground">{t.lessonBuilder.states.error}</p>
+            <p className="text-sm text-muted-foreground">{t.lessonBuilder.states.errorDescription}</p>
+            <Button onClick={() => planQuery.refetch()}>{t.lessonBuilder.states.retry}</Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <Toolbar
+        plan={plan}
+        history={history as LessonBuilderVersionEntry[]}
+        isSaving={isSaving}
+        onPreview={() => setIsPreviewOpen(true)}
+        copy={t.lessonBuilder.toolbar}
+      />
+      <div className="grid gap-6 lg:grid-cols-[280px,1fr,320px]">
+        <div className="space-y-6">
+          <PartsSidebar
+            parts={plan.parts}
+            selectedPart={selectedPart}
+            onSelect={setSelectedPart}
+            copy={t.lessonBuilder.parts}
+            history={history as LessonBuilderVersionEntry[]}
+            historyCopy={t.lessonBuilder.history}
+          />
+        </div>
+        <div className="space-y-6">
+          <MetaBar plan={plan} copy={t.lessonBuilder.meta} onUpdate={updatePlan} />
+          <PlanCanvas
+            steps={plan.steps}
+            selectedStepId={selectedStepId}
+            onSelectStep={setSelectedStepId}
+            onAddStep={handleAddStep}
+            onRemoveStep={handleRemoveStep}
+            onStepChange={handleStepChange}
+            copy={t.lessonBuilder.canvas}
+          />
+        </div>
+        <div className="space-y-6">
+          <ActivitySearchPanel
+            query={activityQuery}
+            onQueryChange={setActivityQuery}
+            results={activityResults}
+            onAdd={handleAddActivity}
+            isLoading={activitiesQuery.isFetching}
+            copy={t.lessonBuilder.activities}
+          />
+          <StandardsPicker
+            available={plan.availableStandards}
+            selected={plan.standards}
+            onToggle={handleToggleStandard}
+            copy={t.lessonBuilder.standards}
+          />
+        </div>
+      </div>
+      <PreviewModal
+        plan={plan}
+        open={isPreviewOpen}
+        onOpenChange={setIsPreviewOpen}
+        copy={t.lessonBuilder.preview}
+        lessonCopy={lessonCopy}
+      />
+    </div>
+  );
+};
+
+export default BuilderLessonPlanDetail;

--- a/src/pages/LessonPlan.tsx
+++ b/src/pages/LessonPlan.tsx
@@ -10,13 +10,16 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 import type { LessonPlan } from "@/types/lesson-plans";
+import { builderPlanToLessonPlan } from "@/types/lesson-builder";
+import type { LessonBuilderPlanResponse } from "@/types/lesson-builder";
 
 async function fetchLessonPlanDetail(slug: string): Promise<LessonPlan> {
-  const response = await fetch(`/api/lesson-plans/${slug}`);
+  const response = await fetch(`/api/builder/lesson-plans/${slug}?lookup=slug`);
   if (!response.ok) {
     throw new Error("Failed to load lesson plan");
   }
-  return response.json() as Promise<LessonPlan>;
+  const payload = (await response.json()) as LessonBuilderPlanResponse;
+  return builderPlanToLessonPlan(payload.plan);
 }
 
 function DetailSkeleton() {

--- a/src/pages/LessonPlans.tsx
+++ b/src/pages/LessonPlans.tsx
@@ -18,6 +18,8 @@ import type {
   LessonPlanListResponse,
   Stage,
 } from "@/types/lesson-plans";
+import { builderPlanToLessonPlan } from "@/types/lesson-builder";
+import type { LessonBuilderPlanResponse } from "@/types/lesson-builder";
 
 const LESSON_PARAM = "lesson";
 
@@ -86,11 +88,12 @@ async function fetchLessonPlans(
 }
 
 async function fetchLessonPlanDetail(slug: string): Promise<LessonPlan> {
-  const response = await fetch(`/api/lesson-plans/${slug}`);
+  const response = await fetch(`/api/builder/lesson-plans/${slug}?lookup=slug`);
   if (!response.ok) {
     throw new Error("Failed to load lesson plan");
   }
-  return response.json() as Promise<LessonPlan>;
+  const payload = (await response.json()) as LessonBuilderPlanResponse;
+  return builderPlanToLessonPlan(payload.plan);
 }
 
 const stageConfigs = [

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1160,6 +1160,68 @@ export const en = {
       vi: "Vietnamese"
     }
   },
+  lessonBuilder: {
+    states: {
+      creating: "Preparing your new lesson plan...",
+      creatingDescription: "Setting up a fresh workspace for your ideas.",
+      error: "We couldn't open the builder",
+      errorDescription: "Please retry or refresh the page.",
+      retry: "Try again",
+      loading: "Loading lesson plan...",
+    },
+    toolbar: {
+      draftStatus: "Draft",
+      publishedStatus: "Published",
+      previewLabel: "Preview",
+      savingLabel: "Saving...",
+      historyLabel: "Version history",
+      lastSavedPrefix: "Last saved",
+      noHistory: "No versions yet",
+    },
+    parts: {
+      title: "Plan structure",
+      empty: "Add parts to organise your plan.",
+    },
+    history: {
+      title: "Recent versions",
+      empty: "No saved versions yet.",
+    },
+    meta: {
+      titleLabel: "Lesson title",
+      summaryLabel: "Lesson summary",
+      stageLabel: "Stage",
+      subjectsLabel: "Subjects",
+      durationLabel: "Duration",
+      technologyLabel: "Technology",
+    },
+    canvas: {
+      title: "Learning sequence",
+      addStep: "Add step",
+      empty: "Start by adding your first learning step.",
+      stepCopy: {
+        titlePlaceholder: "Name this learning step",
+        descriptionPlaceholder: "Describe what happens during this step...",
+        notesPlaceholder: "Add facilitator notes or differentiation ideas",
+        activitiesTitle: "Linked activities",
+        removeActivity: "Remove",
+      },
+    },
+    activities: {
+      title: "Find activities",
+      placeholder: "Search by topic, tool, or outcome",
+      helper: "Type at least {min} characters to search our activity library.",
+      addLabel: "Add to step",
+      empty: "No activities match your search yet.",
+    },
+    standards: {
+      title: "Standards & objectives",
+      empty: "No standards available yet.",
+      selectedLabel: "General objective",
+    },
+    preview: {
+      title: "Lesson preview",
+    },
+  },
   account: {
     seo: {
       title: "My Account | SchoolTech Hub",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -1160,6 +1160,68 @@ export const sq = {
       vi: "Vietnamisht"
     }
   },
+  lessonBuilder: {
+    states: {
+      creating: "Po përgatisim planin tuaj të ri...",
+      creatingDescription: "Po krijojmë një hapësirë të re për idetë tuaja.",
+      error: "Nuk mundëm të hapim ndërtuesin",
+      errorDescription: "Ju lutemi provoni përsëri ose rifreskoni faqen.",
+      retry: "Provo përsëri",
+      loading: "Duke ngarkuar planin e mësimit...",
+    },
+    toolbar: {
+      draftStatus: "Draft",
+      publishedStatus: "I publikuar",
+      previewLabel: "Pamje paraprake",
+      savingLabel: "Duke ruajtur...",
+      historyLabel: "Historiku i versioneve",
+      lastSavedPrefix: "Ruajtur së fundmi",
+      noHistory: "Ende nuk ka versione",
+    },
+    parts: {
+      title: "Struktura e planit",
+      empty: "Shto pjesë për të organizuar planin.",
+    },
+    history: {
+      title: "Versionet e fundit",
+      empty: "Ende nuk ka versione të ruajtura.",
+    },
+    meta: {
+      titleLabel: "Titulli i mësimit",
+      summaryLabel: "Përmbledhja e mësimit",
+      stageLabel: "Niveli",
+      subjectsLabel: "Lëndët",
+      durationLabel: "Kohëzgjatja",
+      technologyLabel: "Teknologjia",
+    },
+    canvas: {
+      title: "Rrjedha e të nxënit",
+      addStep: "Shto hap",
+      empty: "Filloni duke shtuar hapin e parë të mësimit.",
+      stepCopy: {
+        titlePlaceholder: "Emërto këtë hap të të nxënit",
+        descriptionPlaceholder: "Përshkruani çfarë ndodh gjatë këtij hapi...",
+        notesPlaceholder: "Shto shënime ose ide diferencimi",
+        activitiesTitle: "Aktivitete të lidhura",
+        removeActivity: "Hiq",
+      },
+    },
+    activities: {
+      title: "Gjej aktivitete",
+      placeholder: "Kërko sipas temës, mjetit ose rezultatit",
+      helper: "Shkruani të paktën {min} karaktere për të kërkuar në bibliotekën e aktiviteteve.",
+      addLabel: "Shto te hapi",
+      empty: "Asnjë aktivitet nuk përputhet me kërkimin tuaj.",
+    },
+    standards: {
+      title: "Standardet & objektivat",
+      empty: "Ende nuk ka standarde.",
+      selectedLabel: "Objektiv i përgjithshëm",
+    },
+    preview: {
+      title: "Pamje paraprake e planit",
+    },
+  },
   account: {
     seo: {
       title: "Llogaria Ime | SchoolTech Hub",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -1160,6 +1160,68 @@ export const vi = {
       vi: "Tiếng Việt"
     }
   },
+  lessonBuilder: {
+    states: {
+      creating: "Đang chuẩn bị kế hoạch học tập mới của bạn...",
+      creatingDescription: "Đang thiết lập không gian làm việc mới cho ý tưởng của bạn.",
+      error: "Không thể mở trình xây dựng",
+      errorDescription: "Vui lòng thử lại hoặc tải lại trang.",
+      retry: "Thử lại",
+      loading: "Đang tải kế hoạch học tập...",
+    },
+    toolbar: {
+      draftStatus: "Bản nháp",
+      publishedStatus: "Đã xuất bản",
+      previewLabel: "Xem trước",
+      savingLabel: "Đang lưu...",
+      historyLabel: "Lịch sử phiên bản",
+      lastSavedPrefix: "Lưu gần nhất",
+      noHistory: "Chưa có phiên bản nào",
+    },
+    parts: {
+      title: "Cấu trúc kế hoạch",
+      empty: "Thêm các phần để tổ chức kế hoạch của bạn.",
+    },
+    history: {
+      title: "Phiên bản gần đây",
+      empty: "Chưa có phiên bản được lưu.",
+    },
+    meta: {
+      titleLabel: "Tiêu đề bài học",
+      summaryLabel: "Tóm tắt bài học",
+      stageLabel: "Cấp học",
+      subjectsLabel: "Môn học",
+      durationLabel: "Thời lượng",
+      technologyLabel: "Công nghệ",
+    },
+    canvas: {
+      title: "Chuỗi hoạt động học tập",
+      addStep: "Thêm bước",
+      empty: "Bắt đầu bằng cách thêm bước học tập đầu tiên.",
+      stepCopy: {
+        titlePlaceholder: "Đặt tên cho bước học tập này",
+        descriptionPlaceholder: "Mô tả những gì diễn ra trong bước này...",
+        notesPlaceholder: "Thêm ghi chú hoặc ý tưởng phân hóa",
+        activitiesTitle: "Hoạt động đính kèm",
+        removeActivity: "Xóa",
+      },
+    },
+    activities: {
+      title: "Tìm hoạt động",
+      placeholder: "Tìm theo chủ đề, công cụ hoặc kết quả",
+      helper: "Nhập ít nhất {min} ký tự để tìm kiếm trong thư viện hoạt động.",
+      addLabel: "Thêm vào bước",
+      empty: "Chưa có hoạt động phù hợp với tìm kiếm.",
+    },
+    standards: {
+      title: "Chuẩn & mục tiêu",
+      empty: "Chưa có chuẩn nào.",
+      selectedLabel: "Mục tiêu chung",
+    },
+    preview: {
+      title: "Xem trước kế hoạch",
+    },
+  },
   account: {
     seo: {
       title: "Tài khoản của tôi | SchoolTech Hub",

--- a/src/types/lesson-builder.ts
+++ b/src/types/lesson-builder.ts
@@ -1,0 +1,36 @@
+import type {
+  LessonBuilderPlan,
+  LessonBuilderPlanResponse,
+  LessonBuilderHistoryResponse,
+  LessonBuilderActivity,
+  LessonBuilderActivitySearchResponse,
+  LessonBuilderDraftRequest,
+  LessonBuilderUpdateRequest,
+  LessonBuilderPart,
+  LessonBuilderStandard,
+  LessonBuilderStep,
+  LessonBuilderVersionEntry,
+} from "../../types/lesson-builder";
+
+export type {
+  LessonBuilderPlan,
+  LessonBuilderPlanResponse,
+  LessonBuilderHistoryResponse,
+  LessonBuilderActivity,
+  LessonBuilderActivitySearchResponse,
+  LessonBuilderDraftRequest,
+  LessonBuilderUpdateRequest,
+  LessonBuilderPart,
+  LessonBuilderStandard,
+  LessonBuilderStep,
+  LessonBuilderVersionEntry,
+};
+
+export {
+  builderPlanToLessonPlan,
+  builderStepsToContent,
+  mergeActivityValues,
+  mergeStandardValues,
+  mergeStepValues,
+  cryptoRandomId,
+} from "../../types/lesson-builder";

--- a/types/lesson-builder.ts
+++ b/types/lesson-builder.ts
@@ -1,0 +1,249 @@
+import type {
+  LessonPlanContentBlock,
+  LessonPlanContentSection,
+  LessonPlanOverview,
+  LessonPlanResource,
+  LessonPlanStatus,
+  LessonPlan,
+  LessonPlanListItem,
+} from "./lesson-plans";
+
+export interface LessonBuilderActivity {
+  id: string;
+  title: string;
+  summary: string | null;
+  subjects: string[];
+  gradeLevels: string[];
+  durationMinutes: number | null;
+  sourceUrl: string | null;
+  tags: string[];
+}
+
+export interface LessonBuilderStep {
+  id: string;
+  title: string;
+  description: string | null;
+  durationMinutes: number | null;
+  notes: string | null;
+  activities: LessonBuilderActivity[];
+}
+
+export interface LessonBuilderStandard {
+  id: string;
+  code: string;
+  description: string;
+  domain: string | null;
+  subject: string | null;
+  gradeLevels: string[];
+}
+
+export interface LessonBuilderPart {
+  id: string;
+  label: string;
+  description: string | null;
+  completed: boolean;
+}
+
+export interface LessonBuilderVersionEntry {
+  id: string;
+  label: string;
+  createdAt: string;
+  author: string | null;
+  summary: string | null;
+}
+
+export interface LessonBuilderPlan {
+  id: string;
+  slug: string;
+  title: string;
+  summary: string | null;
+  status: LessonPlanStatus;
+  stage: string | null;
+  stages: string[];
+  subjects: string[];
+  deliveryMethods: string[];
+  technologyTags: string[];
+  durationMinutes: number | null;
+  overview: LessonPlanOverview | null;
+  steps: LessonBuilderStep[];
+  standards: LessonBuilderStandard[];
+  availableStandards: LessonBuilderStandard[];
+  resources: LessonPlanResource[];
+  lastSavedAt: string | null;
+  version: number;
+  parts: LessonBuilderPart[];
+  history: LessonBuilderVersionEntry[];
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface LessonBuilderPlanResponse {
+  plan: LessonBuilderPlan;
+}
+
+export interface LessonBuilderHistoryResponse {
+  versions: LessonBuilderVersionEntry[];
+}
+
+export interface LessonBuilderActivitySearchResponse {
+  results: LessonBuilderActivity[];
+}
+
+export interface LessonBuilderDraftRequest {
+  title?: string | null;
+  stage?: string | null;
+  subjects?: string[];
+}
+
+export interface LessonBuilderUpdateRequest {
+  plan: LessonBuilderPlan;
+}
+
+function ensureString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : null;
+}
+
+function ensureStringArray(values: unknown): string[] {
+  if (!values) {
+    return [];
+  }
+  if (Array.isArray(values)) {
+    return values
+      .map((value) => ensureString(value))
+      .filter((value): value is string => Boolean(value));
+  }
+  if (typeof values === "string") {
+    return values
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+export function builderStepsToContent(
+  steps: LessonBuilderStep[]
+): LessonPlanContentSection[] {
+  return steps.map((step, index) => {
+    const blocks: LessonPlanContentBlock[] = [];
+
+    if (step.description) {
+      blocks.push({
+        type: "paragraph",
+        text: step.description,
+      });
+    }
+
+    if (step.activities.length > 0) {
+      blocks.push({
+        type: "list",
+        items: step.activities.map((activity) =>
+          activity.summary
+            ? `${activity.title} — ${activity.summary}`
+            : activity.title
+        ),
+      });
+    }
+
+    if (step.notes) {
+      blocks.push({
+        type: "quote",
+        text: step.notes,
+      });
+    }
+
+    return {
+      id: step.id,
+      title: step.title || `Step ${index + 1}`,
+      description: step.description,
+      blocks,
+    };
+  });
+}
+
+function createListItemFromPlan(plan: LessonBuilderPlan): LessonPlanListItem {
+  return {
+    id: plan.id,
+    slug: plan.slug,
+    title: plan.title,
+    summary: plan.summary,
+    stage: plan.stage,
+    stages: plan.stages,
+    subjects: plan.subjects,
+    deliveryMethods: plan.deliveryMethods,
+    technologyTags: plan.technologyTags,
+    durationMinutes: plan.durationMinutes,
+    pdfUrl: null,
+    status: plan.status,
+    createdAt: plan.createdAt,
+    updatedAt: plan.updatedAt,
+  };
+}
+
+export function builderPlanToLessonPlan(plan: LessonBuilderPlan): LessonPlan {
+  return {
+    ...createListItemFromPlan(plan),
+    overview: plan.overview,
+    content: builderStepsToContent(plan.steps),
+    resources: plan.resources,
+  };
+}
+
+export function mergeStandardValues(
+  values: Partial<LessonBuilderStandard>
+): LessonBuilderStandard {
+  return {
+    id: values.id ?? cryptoRandomId("std"),
+    code: ensureString(values.code) ?? "STD",
+    description: ensureString(values.description) ?? "Standard",
+    domain: ensureString(values.domain),
+    subject: ensureString(values.subject),
+    gradeLevels: ensureStringArray(values.gradeLevels),
+  };
+}
+
+export function mergeActivityValues(
+  values: Partial<LessonBuilderActivity>
+): LessonBuilderActivity {
+  return {
+    id: values.id ?? cryptoRandomId("act"),
+    title: ensureString(values.title) ?? "Untitled Activity",
+    summary: ensureString(values.summary),
+    subjects: ensureStringArray(values.subjects),
+    gradeLevels: ensureStringArray(values.gradeLevels),
+    durationMinutes:
+      typeof values.durationMinutes === "number" && Number.isFinite(values.durationMinutes)
+        ? Math.max(0, Math.trunc(values.durationMinutes))
+        : null,
+    sourceUrl: ensureString(values.sourceUrl),
+    tags: ensureStringArray(values.tags),
+  };
+}
+
+export function mergeStepValues(
+  values: Partial<LessonBuilderStep>
+): LessonBuilderStep {
+  return {
+    id: values.id ?? cryptoRandomId("step"),
+    title: ensureString(values.title) ?? "",
+    description: ensureString(values.description),
+    durationMinutes:
+      typeof values.durationMinutes === "number" && Number.isFinite(values.durationMinutes)
+        ? Math.max(0, Math.trunc(values.durationMinutes))
+        : null,
+    notes: ensureString(values.notes),
+    activities: Array.isArray(values.activities)
+      ? values.activities.map((activity) => mergeActivityValues(activity))
+      : [],
+  };
+}
+
+export function cryptoRandomId(prefix: string): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `${prefix}_${crypto.randomUUID()}`;
+  }
+  const random = Math.random().toString(36).slice(2, 10);
+  return `${prefix}_${random}`;
+}


### PR DESCRIPTION
## Summary
- add lesson builder API helpers and endpoints plus client utilities
- scaffold lesson builder UI with React Query autosave, activity search, and localized copy
- update routing and lesson detail pages to use the new builder data shape with redirects

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d098cf32e483319c2674de2fa34946