### PR TITLE
Add lesson plan builder endpoints and activity metadata scraping

### DIFF
--- a/api/__tests__/builder/activities.test.ts
+++ b/api/__tests__/builder/activities.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import listHandler from "../../activities";
+import createHandler from "../../activities/create";
+import ogHandler from "../../og-scrape";
+import { SupabaseStub } from "./supabase-stub";
+
+const stub = new SupabaseStub();
+
+vi.mock("../../_lib/supabase", () => ({
+  getSupabaseClient: () => stub,
+}));
+
+beforeEach(() => {
+  stub.reset();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("activities list", () => {
+  it("applies filters and pagination", async () => {
+    stub.setResponses([
+      {
+        data: [{ id: "activity-1", title: "Robotics Warmup" }],
+        count: 30,
+      },
+    ]);
+
+    const response = await listHandler(
+      new Request(
+        "http://localhost/api/activities?q=robot&subjects=STEM&types=warmup&page=2&limit=5"
+      )
+    );
+
+    const body = await response.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.nextCursor).toBe(10);
+
+    expect(stub.calls.find((call) => call.method === "ilike")).toBeDefined();
+    expect(stub.calls.find((call) => call.method === "overlaps")).toBeDefined();
+    expect(stub.calls.find((call) => call.method === "range")).toBeDefined();
+  });
+});
+
+describe("activity creation", () => {
+  it("creates activity records", async () => {
+    stub.setResponses([{ data: { id: "activity-1", title: "Robotics" } }]);
+
+    const response = await createHandler(
+      new Request("http://localhost/api/activities/create", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "teacher-1",
+          title: "Robotics",
+          url: "https://example.com",
+        }),
+      })
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(201);
+    expect(body.activity.id).toBe("activity-1");
+
+    const insertCall = stub.calls.find((call) => call.method === "insert");
+    expect(insertCall?.args[0]).toMatchObject({
+      title: "Robotics",
+      created_by: "teacher-1",
+    });
+  });
+
+  it("requires a title", async () => {
+    const response = await createHandler(
+      new Request("http://localhost/api/activities/create", {
+        method: "POST",
+        body: JSON.stringify({ userId: "teacher-1" }),
+      })
+    );
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("og scrape", () => {
+  it("normalizes url, loads metadata, and sanitizes embed", async () => {
+    const html = `
+      <html>
+        <head>
+          <title>Sample</title>
+          <meta property="og:title" content="OG Title" />
+          <meta property="og:description" content="OG Description" />
+          <meta property="og:image" content="https://cdn.example/image.jpg" />
+          <link rel="alternate" type="application/json+oembed" href="https://example.com/oembed.json" />
+        </head>
+      </html>
+    `;
+    const oEmbed = {
+      title: "Embed Title",
+      provider_name: "Provider",
+      thumbnail_url: "https://cdn.example/thumb.jpg",
+      html: '<iframe src="https://player.example/embed"></iframe>',
+    };
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(html, { status: 200, headers: { "Content-Type": "text/html" } })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(oEmbed), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await ogHandler(
+      new Request("http://localhost/api/og-scrape", {
+        method: "POST",
+        body: JSON.stringify({ url: "example.com/watch" }),
+      })
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.url).toBe("https://example.com/watch");
+    expect(body.metadata.embedHtml).toContain("iframe");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://example.com/watch");
+  });
+
+  it("rejects unsupported embed markup", async () => {
+    const html = `
+      <html>
+        <head>
+          <link rel="alternate" type="application/json+oembed" href="https://example.com/oembed.json" />
+        </head>
+      </html>
+    `;
+    const oEmbed = {
+      html: "<div>Not allowed</div>",
+    };
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(html, { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(oEmbed), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await ogHandler(
+      new Request("http://localhost/api/og-scrape", {
+        method: "POST",
+        body: JSON.stringify({ url: "https://example.com/watch" }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+  });
+});

--- a/api/__tests__/builder/lesson-plans.test.ts
+++ b/api/__tests__/builder/lesson-plans.test.ts
@@ -1,0 +1,294 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import listHandler from "../../lesson-plans";
+import detailHandler from "../../lesson-plans/[id]";
+import duplicateHandler from "../../lesson-plans/[id]/duplicate";
+import versionsHandler from "../../lesson-plans/[id]/versions";
+import exportHandler from "../../lesson-plans/[id]/export";
+import { SupabaseStub, type SupabaseResponse } from "./supabase-stub";
+
+const stub = new SupabaseStub();
+
+vi.mock("../../_lib/supabase", () => ({
+  getSupabaseClient: () => stub,
+}));
+
+beforeAll(() => {
+  // ensure fetch is available in tests that rely on it
+  if (!(global as any).fetch) {
+    (global as any).fetch = vi.fn();
+  }
+});
+
+beforeEach(() => {
+  stub.reset();
+});
+
+describe("lesson plan creation", () => {
+  it("creates a plan using teacher profile defaults", async () => {
+    stub.setResponses([
+      {
+        data: {
+          default_stage: "middle",
+          default_duration_minutes: 50,
+          default_subject: "Science",
+          default_summary: "Base summary",
+        },
+      },
+      {
+        data: {
+          id: "plan-123",
+          title: "Untitled lesson plan",
+          share_access: "owner",
+        },
+      },
+    ]);
+
+    const response = await listHandler(
+      new Request("http://localhost/api/lesson-plans", {
+        method: "POST",
+        body: JSON.stringify({ userId: "teacher-1" }),
+      })
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(201);
+    expect(body.plan.title).toBe("Untitled lesson plan");
+    expect(body.plan.shareAccess).toBe("owner");
+
+    const insertCall = stub.calls.find((call) => call.method === "insert");
+    expect(insertCall).toBeDefined();
+    expect(insertCall?.args[0]).toMatchObject({
+      owner_id: "teacher-1",
+      stage: "middle",
+      duration_minutes: 50,
+      subject: "Science",
+    });
+  });
+
+  it("requires a user id", async () => {
+    const response = await listHandler(
+      new Request("http://localhost/api/lesson-plans", { method: "POST" })
+    );
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("lesson plan detail", () => {
+  it("returns read-only plan when share access is viewer", async () => {
+    stub.setResponses([
+      { data: { id: "plan-1", title: "Plan", share_access: "viewer" } },
+      { data: [{ id: "step-1", title: "Intro" }] },
+    ]);
+
+    const response = await detailHandler(
+      new Request("http://localhost/api/lesson-plans/plan-1")
+    );
+
+    const body = await response.json();
+    expect(body.plan.readOnly).toBe(true);
+    expect(body.steps).toHaveLength(1);
+  });
+
+  it("updates plan and snapshots activity resources", async () => {
+    const responses: SupabaseResponse[] = [
+      { data: { id: "plan-1", share_access: "owner" } },
+      { data: { id: "plan-1", title: "Updated title", share_access: "owner" } },
+      { data: [] },
+      { data: { id: "plan-1", title: "Updated title", share_access: "owner" } },
+      {
+        data: [
+          {
+            id: "step-1",
+            title: "Activity Title",
+            position: 0,
+            resources: [
+              {
+                type: "activity",
+                activityId: "activity-1",
+                title: "Activity Title",
+                url: "https://example.com",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    stub.setResponses(responses);
+
+    const response = await detailHandler(
+      new Request("http://localhost/api/lesson-plans/plan-1", {
+        method: "PATCH",
+        body: JSON.stringify({
+          plan: { title: "Updated title" },
+          steps: [
+            {
+              id: "step-1",
+              activity: {
+                id: "activity-1",
+                title: "Activity Title",
+                url: "https://example.com",
+                durationMinutes: 15,
+              },
+            },
+          ],
+        }),
+      })
+    );
+
+    const body = await response.json();
+    expect(body.plan.title).toBe("Updated title");
+    expect(body.steps[0].resources[0]).toMatchObject({
+      activityId: "activity-1",
+      title: "Activity Title",
+    });
+
+    const upsertCall = stub.calls.find((call) => call.method === "upsert");
+    expect(upsertCall).toBeDefined();
+    const stepPayload = (upsertCall?.args[0] as any[])[0];
+    expect(stepPayload.resources[0]).toMatchObject({
+      activityId: "activity-1",
+      title: "Activity Title",
+      url: "https://example.com",
+    });
+    expect(stepPayload.title).toBe("Activity Title");
+    expect(stepPayload.duration_minutes).toBe(15);
+  });
+});
+
+describe("lesson plan duplication", () => {
+  it("duplicates plan and steps", async () => {
+    stub.setResponses([
+      {
+        data: {
+          id: "plan-1",
+          title: "Original",
+          share_access: "owner",
+          summary: "Summary",
+        },
+      },
+      {
+        data: [
+          {
+            id: "step-1",
+            title: "Intro",
+            position: 0,
+            resources: [],
+          },
+        ],
+      },
+      {
+        data: { id: "plan-2", title: "Original (Copy)", share_access: "owner" },
+      },
+      { data: [] },
+    ]);
+
+    const response = await duplicateHandler(
+      new Request("http://localhost/api/lesson-plans/plan-1/duplicate", {
+        method: "POST",
+        body: JSON.stringify({ userId: "teacher-1" }),
+      })
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(201);
+    expect(body.plan.id).toBe("plan-2");
+
+    const stepInsert = stub.calls.filter((call) => call.method === "insert");
+    expect(stepInsert[1]?.args[0][0]).toMatchObject({
+      lesson_plan_id: "plan-2",
+      title: "Intro",
+    });
+  });
+});
+
+describe("lesson plan versions", () => {
+  it("lists versions", async () => {
+    stub.setResponses([
+      { data: [{ id: "version-1", label: "Snapshot" }], count: 1 },
+    ]);
+
+    const response = await versionsHandler(
+      new Request("http://localhost/api/lesson-plans/plan-1/versions")
+    );
+
+    const body = await response.json();
+    expect(body.versions).toHaveLength(1);
+    expect(body.versions[0].id).toBe("version-1");
+  });
+
+  it("creates version snapshot", async () => {
+    stub.setResponses([
+      { data: { id: "plan-1", share_access: "owner" } },
+      { data: { id: "plan-1", title: "Plan" } },
+      { data: [{ id: "step-1" }] },
+      { data: { id: "version-1", label: null } },
+    ]);
+
+    const response = await versionsHandler(
+      new Request("http://localhost/api/lesson-plans/plan-1/versions", {
+        method: "POST",
+        body: JSON.stringify({ userId: "teacher-1" }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.version.id).toBe("version-1");
+
+    const insertCall = stub.calls.find((call) => call.method === "insert");
+    expect(insertCall?.args[0]).toMatchObject({
+      lesson_plan_id: "plan-1",
+    });
+  });
+});
+
+describe("lesson plan export", () => {
+  it("updates export selection and returns signed url", async () => {
+    stub.setResponses([
+      { data: { id: "plan-1", share_access: "owner" } },
+      {
+        data: {
+          id: "plan-1",
+          share_access: "owner",
+          latest_export_path: "exports/plan-1.pdf",
+        },
+      },
+    ]);
+    stub.setStorageResponses([{ data: { signedUrl: "https://signed.example" } }]);
+
+    const response = await exportHandler(
+      new Request("http://localhost/api/lesson-plans/plan-1/export", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "teacher-1",
+          exportType: "pdf",
+          exportPath: "exports/plan-1.pdf",
+          bucket: "lesson-exports",
+          expiresIn: 120,
+        }),
+      })
+    );
+
+    const body = await response.json();
+    expect(body.signedUrl).toBe("https://signed.example");
+    expect(stub.storageCalls[0]).toMatchObject({
+      bucket: "lesson-exports",
+      path: "exports/plan-1.pdf",
+      expiresIn: 120,
+    });
+  });
+
+  it("blocks export when share access is viewer", async () => {
+    stub.setResponses([{ data: { id: "plan-1", share_access: "viewer" } }]);
+
+    const response = await exportHandler(
+      new Request("http://localhost/api/lesson-plans/plan-1/export", {
+        method: "POST",
+        body: JSON.stringify({ userId: "teacher-1" }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/api/__tests__/builder/supabase-stub.ts
+++ b/api/__tests__/builder/supabase-stub.ts
@@ -1,0 +1,170 @@
+export interface SupabaseResponse {
+  data: any;
+  error?: { message: string } | null;
+  count?: number | null;
+}
+
+export interface StorageResponse {
+  data?: { signedUrl?: string | null } | null;
+  error?: { message: string } | null;
+}
+
+interface CallRecord {
+  table: string;
+  method: string;
+  args: unknown[];
+}
+
+class QueryBuilder {
+  public readonly calls: CallRecord[] = [];
+
+  constructor(
+    private readonly parent: SupabaseStub,
+    private readonly table: string,
+    private response: SupabaseResponse
+  ) {}
+
+  private record(method: string, args: unknown[]): this {
+    const entry: CallRecord = { table: this.table, method, args };
+    this.parent.calls.push(entry);
+    this.calls.push(entry);
+    return this;
+  }
+
+  select(field: string, options?: unknown): this {
+    return this.record("select", [field, options]);
+  }
+
+  eq(column: string, value: unknown): this {
+    return this.record("eq", [column, value]);
+  }
+
+  order(column: string, options?: unknown): this {
+    return this.record("order", [column, options]);
+  }
+
+  ilike(column: string, pattern: string): this {
+    return this.record("ilike", [column, pattern]);
+  }
+
+  overlaps(column: string, values: unknown[]): this {
+    return this.record("overlaps", [column, values]);
+  }
+
+  range(from: number, to: number): this {
+    return this.record("range", [from, to]);
+  }
+
+  insert(values: unknown): this {
+    return this.record("insert", [values]);
+  }
+
+  update(values: unknown): this {
+    return this.record("update", [values]);
+  }
+
+  upsert(values: unknown, options?: unknown): this {
+    return this.record("upsert", [values, options]);
+  }
+
+  single() {
+    this.record("single", []);
+    return Promise.resolve({
+      data: this.response.data,
+      error: this.response.error ?? null,
+    });
+  }
+
+  maybeSingle() {
+    this.record("maybeSingle", []);
+    return Promise.resolve({
+      data: this.response.data,
+      error: this.response.error ?? null,
+    });
+  }
+
+  then<TResult1 = any, TResult2 = never>(
+    onfulfilled?:
+      | ((value: {
+          data: unknown;
+          error: { message: string } | null;
+          count?: number | null;
+        }) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
+    this.record("then", []);
+    const result = {
+      data: this.response.data,
+      error: this.response.error ?? null,
+      count: this.response.count ?? null,
+    };
+    if (onfulfilled) {
+      try {
+        return Promise.resolve(onfulfilled(result));
+      } catch (error) {
+        if (onrejected) {
+          return Promise.resolve(onrejected(error));
+        }
+        return Promise.reject(error);
+      }
+    }
+    return Promise.resolve(result as unknown as TResult1);
+  }
+}
+
+export class SupabaseStub {
+  public calls: CallRecord[] = [];
+  public storageCalls: Array<{ bucket: string; path: string; expiresIn: number }> = [];
+  private responses: SupabaseResponse[] = [];
+  private storageResponses: StorageResponse[] = [];
+
+  from(table: string): QueryBuilder {
+    const response = this.responses.shift() ?? { data: null, error: null };
+    this.calls.push({ table, method: "from", args: [] });
+    return new QueryBuilder(this, table, response);
+  }
+
+  rpc(name: string, args?: unknown): Promise<SupabaseResponse> {
+    this.calls.push({ table: "rpc", method: name, args: [args] });
+    const response = this.responses.shift() ?? { data: null, error: null };
+    return Promise.resolve(response);
+  }
+
+  setResponses(responses: SupabaseResponse[]): void {
+    this.responses = responses.map((response) => ({
+      data: response.data,
+      error: response.error ?? null,
+      count: response.count ?? null,
+    }));
+  }
+
+  setStorageResponses(responses: StorageResponse[]): void {
+    this.storageResponses = responses.map((response) => ({
+      data: response.data ?? null,
+      error: response.error ?? null,
+    }));
+  }
+
+  reset(): void {
+    this.calls = [];
+    this.storageCalls = [];
+    this.responses = [];
+    this.storageResponses = [];
+  }
+
+  storage = {
+    from: (bucket: string) => ({
+      createSignedUrl: async (path: string, expiresIn: number) => {
+        this.storageCalls.push({ bucket, path, expiresIn });
+        const response =
+          this.storageResponses.shift() ??
+          ({ data: { signedUrl: null }, error: null } as StorageResponse);
+        return {
+          data: response.data ?? null,
+          error: response.error ?? null,
+        };
+      },
+    }),
+  };
+}

--- a/api/_lib/http.ts
+++ b/api/_lib/http.ts
@@ -1,0 +1,52 @@
+export interface JsonResponseInit extends ResponseInit {
+  headers?: HeadersInit;
+}
+
+const DEFAULT_HEADERS: HeadersInit = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+  "Access-Control-Allow-Origin": "*",
+};
+
+export function jsonResponse(
+  body: unknown,
+  status = 200,
+  init: JsonResponseInit = {}
+): Response {
+  const headers = new Headers(DEFAULT_HEADERS);
+  if (init.headers) {
+    const extra = new Headers(init.headers);
+    extra.forEach((value, key) => headers.set(key, value));
+  }
+
+  return new Response(JSON.stringify(body), {
+    ...init,
+    status,
+    headers,
+  });
+}
+
+export function errorResponse(status: number, message: string): Response {
+  return jsonResponse({ error: message }, status);
+}
+
+export async function parseJsonBody<T = unknown>(request: Request): Promise<T | null> {
+  try {
+    return (await request.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function methodNotAllowed(allowed: string[]): Response {
+  return new Response(null, {
+    status: 405,
+    headers: {
+      Allow: allowed.join(", "),
+    },
+  });
+}
+
+export function normalizeMethod(method: string | undefined | null): string {
+  return (method ?? "GET").toUpperCase();
+}

--- a/api/activities/create.ts
+++ b/api/activities/create.ts
@@ -1,0 +1,60 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+  parseJsonBody,
+} from "../_lib/http";
+import { getSupabaseClient } from "../_lib/supabase";
+
+interface ActivityCreatePayload {
+  userId?: string;
+  title?: string;
+  url?: string | null;
+  description?: string | null;
+  thumbnailUrl?: string | null;
+  subjects?: string[] | null;
+  gradeLevels?: string[] | null;
+  activityTypes?: string[] | null;
+  durationMinutes?: number | null;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+  if (method !== "POST") {
+    return methodNotAllowed(["POST"]);
+  }
+
+  const payload = (await parseJsonBody<ActivityCreatePayload>(request)) ?? {};
+  if (!payload.userId) {
+    return errorResponse(400, "A userId is required to create an activity");
+  }
+
+  if (!payload.title || payload.title.trim().length === 0) {
+    return errorResponse(400, "A title is required to create an activity");
+  }
+
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from("activities")
+    .insert({
+      title: payload.title.trim(),
+      url: payload.url ?? null,
+      description: payload.description ?? null,
+      thumbnail_url: payload.thumbnailUrl ?? null,
+      subjects: payload.subjects ?? null,
+      grade_levels: payload.gradeLevels ?? null,
+      activity_types: payload.activityTypes ?? null,
+      duration_minutes: payload.durationMinutes ?? null,
+      created_by: payload.userId,
+      status: "draft",
+    })
+    .select("*")
+    .single();
+
+  if (error || !data) {
+    return errorResponse(500, "Failed to create activity");
+  }
+
+  return jsonResponse({ activity: data }, 201);
+}

--- a/api/activities/index.ts
+++ b/api/activities/index.ts
@@ -1,0 +1,134 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+} from "../_lib/http";
+import { getSupabaseClient } from "../_lib/supabase";
+
+interface ActivityListFilters {
+  q: string | null;
+  limit: number;
+  offset: number;
+  subjects: string[];
+  gradeLevels: string[];
+  activityTypes: string[];
+}
+
+interface ActivityRecord {
+  id: string;
+  title: string;
+  description?: string | null;
+  url?: string | null;
+  thumbnail_url?: string | null;
+  subject?: string | null;
+  grade_levels?: string[] | null;
+  activity_types?: string[] | null;
+  created_at?: string | null;
+}
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+  if (method !== "GET") {
+    return methodNotAllowed(["GET"]);
+  }
+
+  const url = parseRequestUrl(request);
+  const filters = parseFilters(url);
+  const supabase = getSupabaseClient();
+
+  let query = supabase
+    .from("activities")
+    .select("*", { count: "exact" })
+    .order("created_at", { ascending: false });
+
+  if (filters.q) {
+    const pattern = `%${filters.q.replace(/%/g, "\\%").replace(/_/g, "\\_")}%`;
+    query = query.ilike("title", pattern);
+  }
+
+  if (filters.subjects.length > 0) {
+    query = query.overlaps("subjects", filters.subjects);
+  }
+
+  if (filters.gradeLevels.length > 0) {
+    query = query.overlaps("grade_levels", filters.gradeLevels);
+  }
+
+  if (filters.activityTypes.length > 0) {
+    query = query.overlaps("activity_types", filters.activityTypes);
+  }
+
+  const end = filters.offset + filters.limit - 1;
+  query = query.range(filters.offset, end);
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    return errorResponse(500, "Failed to load activities");
+  }
+
+  const items = Array.isArray(data) ? (data as ActivityRecord[]) : [];
+  const hasMore = count != null ? filters.offset + filters.limit < count : false;
+  const nextCursor = hasMore ? filters.offset + filters.limit : null;
+
+  return jsonResponse({
+    items,
+    nextCursor,
+    total: count ?? items.length,
+  });
+}
+
+function parseRequestUrl(request: Request): URL {
+  try {
+    return new URL(request.url);
+  } catch {
+    return new URL(request.url, "http://localhost");
+  }
+}
+
+function parseFilters(url: URL): ActivityListFilters {
+  const params = url.searchParams;
+  const limit = clampLimit(parseIntSafe(params.get("limit")) ?? DEFAULT_LIMIT);
+  const page = parseIntSafe(params.get("page"));
+  const offset = page && page > 0 ? (page - 1) * limit : parseIntSafe(params.get("offset")) ?? 0;
+  return {
+    q: sanitize(params.get("q")),
+    limit,
+    offset,
+    subjects: parseList(params, "subjects"),
+    gradeLevels: parseList(params, "gradeLevels"),
+    activityTypes: parseList(params, "types"),
+  };
+}
+
+function parseList(params: URLSearchParams, key: string): string[] {
+  const raw = params.getAll(key);
+  const parts = raw
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return Array.from(new Set(parts));
+}
+
+function clampLimit(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(MAX_LIMIT, Math.max(1, Math.trunc(value)));
+}
+
+function parseIntSafe(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function sanitize(value: string | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/api/lesson-plans.ts
+++ b/api/lesson-plans.ts
@@ -5,31 +5,35 @@ import {
   parseListFilters,
   parseRequestUrl,
 } from "./_lib/lesson-plan-helpers";
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+  parseJsonBody,
+} from "./_lib/http";
 import { getSupabaseClient } from "./_lib/supabase";
 
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": "no-store",
-      "Access-Control-Allow-Origin": "*",
-    },
-  });
-}
+const LESSON_PLAN_BUILDER_TABLE = "lesson_plan_builder_plans";
+const TEACHER_PROFILE_TABLE = "teacher_profiles";
 
-function errorResponse(status: number, message: string): Response {
-  return jsonResponse({ error: message }, status);
+interface LessonPlanCreatePayload {
+  userId?: string;
+  title?: string;
+  summary?: string | null;
+  stage?: string | null;
+  durationMinutes?: number | null;
 }
 
 export default async function handler(request: Request): Promise<Response> {
-  if (request.method && request.method.toUpperCase() !== "GET") {
-    return new Response(null, {
-      status: 405,
-      headers: {
-        Allow: "GET",
-      },
-    });
+  const method = normalizeMethod(request.method);
+
+  if (method === "POST") {
+    return handleCreate(request);
+  }
+
+  if (method !== "GET") {
+    return methodNotAllowed(["GET", "POST"]);
   }
 
   const url = parseRequestUrl(request);
@@ -57,4 +61,60 @@ export default async function handler(request: Request): Promise<Response> {
   const records: LessonPlanRecord[] = data ?? [];
   const payload = buildListResponse(records, filters);
   return jsonResponse(payload);
+}
+
+async function handleCreate(request: Request): Promise<Response> {
+  const payload = (await parseJsonBody<LessonPlanCreatePayload>(request)) ?? {};
+
+  if (!payload.userId) {
+    return errorResponse(400, "A userId is required to create a lesson plan");
+  }
+
+  const supabase = getSupabaseClient();
+  const profileResult = await supabase
+    .from(TEACHER_PROFILE_TABLE)
+    .select(
+      "default_stage, default_duration_minutes, default_subject, default_summary"
+    )
+    .eq("user_id", payload.userId)
+    .maybeSingle();
+
+  if (profileResult.error) {
+    return errorResponse(500, "Failed to load teacher profile defaults");
+  }
+
+  const defaults = profileResult.data ?? {};
+  const now = new Date().toISOString();
+  const insertPayload = {
+    owner_id: payload.userId,
+    title: payload.title?.trim() || "Untitled lesson plan",
+    summary: payload.summary ?? defaults.default_summary ?? null,
+    stage: payload.stage ?? defaults.default_stage ?? null,
+    duration_minutes:
+      payload.durationMinutes ?? defaults.default_duration_minutes ?? null,
+    subject: defaults.default_subject ?? null,
+    share_access: "owner" as const,
+    created_at: now,
+    updated_at: now,
+  };
+
+  const insertResult = await supabase
+    .from(LESSON_PLAN_BUILDER_TABLE)
+    .insert(insertPayload)
+    .select("*")
+    .single();
+
+  if (insertResult.error) {
+    return errorResponse(500, "Failed to create lesson plan");
+  }
+
+  return jsonResponse({
+    plan: {
+      ...insertResult.data,
+      shareAccess: insertResult.data?.share_access ?? "owner",
+      readOnly:
+        insertResult.data?.share_access != null &&
+        insertResult.data.share_access !== "owner",
+    },
+  }, 201);
 }

--- a/api/lesson-plans/[id].ts
+++ b/api/lesson-plans/[id].ts
@@ -1,0 +1,269 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+  parseJsonBody,
+} from "../_lib/http";
+import { getSupabaseClient } from "../_lib/supabase";
+
+const LESSON_PLAN_TABLE = "lesson_plan_builder_plans";
+const LESSON_PLAN_STEPS_TABLE = "lesson_plan_steps";
+
+interface ActivityPayload {
+  id: string;
+  title?: string | null;
+  url?: string | null;
+  provider?: string | null;
+  thumbnailUrl?: string | null;
+  durationMinutes?: number | null;
+  summary?: string | null;
+  embedHtml?: string | null;
+}
+
+interface StepPayload {
+  id?: string;
+  position?: number | null;
+  title?: string | null;
+  durationMinutes?: number | null;
+  notes?: string | null;
+  activity?: ActivityPayload | null;
+  resources?: unknown[] | null;
+}
+
+interface UpdatePayload {
+  userId?: string;
+  plan?: Record<string, unknown> | null;
+  steps?: StepPayload[] | null;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+  const id = extractIdFromRequest(request);
+
+  if (!id) {
+    return errorResponse(400, "A lesson plan id is required");
+  }
+
+  if (method === "GET") {
+    return handleGet(id);
+  }
+
+  if (method === "PATCH" || method === "PUT") {
+    return handleUpdate(request, id);
+  }
+
+  return methodNotAllowed(["GET", "PATCH", "PUT"]);
+}
+
+async function handleGet(id: string): Promise<Response> {
+  const supabase = getSupabaseClient();
+  const planResult = await supabase
+    .from(LESSON_PLAN_TABLE)
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (planResult.error) {
+    return errorResponse(500, "Failed to load lesson plan");
+  }
+
+  if (!planResult.data) {
+    return errorResponse(404, "Lesson plan not found");
+  }
+
+  const stepsResult = await supabase
+    .from(LESSON_PLAN_STEPS_TABLE)
+    .select("*")
+    .eq("lesson_plan_id", id)
+    .order("position", { ascending: true, nullsFirst: false });
+
+  if (stepsResult.error) {
+    return errorResponse(500, "Failed to load lesson plan steps");
+  }
+
+  const plan = mapPlan(planResult.data);
+  const steps = Array.isArray(stepsResult.data) ? stepsResult.data : [];
+
+  return jsonResponse({
+    plan,
+    steps,
+  });
+}
+
+async function handleUpdate(request: Request, id: string): Promise<Response> {
+  const payload = (await parseJsonBody<UpdatePayload>(request)) ?? {};
+  const supabase = getSupabaseClient();
+
+  const planResult = await supabase
+    .from(LESSON_PLAN_TABLE)
+    .select("id, share_access")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (planResult.error) {
+    return errorResponse(500, "Failed to verify lesson plan access");
+  }
+
+  if (!planResult.data) {
+    return errorResponse(404, "Lesson plan not found");
+  }
+
+  const shareAccess = planResult.data.share_access ?? "owner";
+  if (!canEdit(shareAccess)) {
+    return errorResponse(403, "You do not have permission to update this plan");
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (payload.plan && typeof payload.plan === "object") {
+    for (const [key, value] of Object.entries(payload.plan)) {
+      if (value === undefined) continue;
+      if (key === "share_access") continue;
+      updates[key] = value;
+    }
+  }
+
+  if (Object.keys(updates).length > 0) {
+    const updateResult = await supabase
+      .from(LESSON_PLAN_TABLE)
+      .update({ ...updates, updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .select("*")
+      .single();
+
+    if (updateResult.error) {
+      return errorResponse(500, "Failed to update lesson plan");
+    }
+  }
+
+  if (Array.isArray(payload.steps) && payload.steps.length > 0) {
+    const normalizedSteps = payload.steps.map((step, index) =>
+      mapStepPayload(id, step, index)
+    );
+
+    const upsertResult = await supabase
+      .from(LESSON_PLAN_STEPS_TABLE)
+      .upsert(normalizedSteps, { onConflict: "id" })
+      .select("id");
+
+    if (upsertResult.error) {
+      return errorResponse(500, "Failed to update lesson plan steps");
+    }
+  }
+
+  const refreshedPlan = await supabase
+    .from(LESSON_PLAN_TABLE)
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (refreshedPlan.error || !refreshedPlan.data) {
+    return errorResponse(500, "Failed to load updated lesson plan");
+  }
+
+  const refreshedSteps = await supabase
+    .from(LESSON_PLAN_STEPS_TABLE)
+    .select("*")
+    .eq("lesson_plan_id", id)
+    .order("position", { ascending: true, nullsFirst: false });
+
+  if (refreshedSteps.error) {
+    return errorResponse(500, "Failed to load updated lesson plan steps");
+  }
+
+  return jsonResponse({
+    plan: mapPlan(refreshedPlan.data),
+    steps: Array.isArray(refreshedSteps.data) ? refreshedSteps.data : [],
+  });
+}
+
+function extractIdFromRequest(request: Request): string | null {
+  try {
+    const url = new URL(request.url);
+    const segments = url.pathname.split("/").filter(Boolean);
+    const id = segments[segments.length - 1];
+    return id ? decodeURIComponent(id) : null;
+  } catch {
+    return null;
+  }
+}
+
+function mapPlan(plan: Record<string, any>): Record<string, unknown> {
+  const shareAccess = plan.share_access ?? "owner";
+  return {
+    ...plan,
+    shareAccess,
+    readOnly: !canEdit(shareAccess),
+  };
+}
+
+function canEdit(shareAccess: string | null | undefined): boolean {
+  return shareAccess === "owner" || shareAccess === "editor";
+}
+
+function mapStepPayload(
+  planId: string,
+  step: StepPayload,
+  index: number
+): Record<string, unknown> {
+  const activity = step.activity ?? null;
+  const title = sanitizeTitle(step.title, activity?.title);
+  const duration =
+    step.durationMinutes ?? activity?.durationMinutes ?? null;
+
+  const resources = buildResourceSnapshot(step, activity);
+
+  return {
+    id: step.id ?? undefined,
+    lesson_plan_id: planId,
+    position: step.position ?? index,
+    title,
+    duration_minutes: duration,
+    notes: step.notes ?? null,
+    resources,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function sanitizeTitle(
+  provided: string | null | undefined,
+  activityTitle: string | null | undefined
+): string {
+  const primary = provided ?? activityTitle ?? "Lesson step";
+  return primary.trim().length > 0 ? primary.trim() : "Lesson step";
+}
+
+function buildResourceSnapshot(
+  step: StepPayload,
+  activity: ActivityPayload | null
+): unknown[] {
+  if (!activity) {
+    return step.resources ?? [];
+  }
+
+  const snapshot = {
+    type: "activity",
+    activityId: activity.id,
+    title: activity.title ?? null,
+    url: activity.url ?? null,
+    provider: activity.provider ?? null,
+    thumbnailUrl: activity.thumbnailUrl ?? null,
+    durationMinutes: activity.durationMinutes ?? null,
+    summary: activity.summary ?? null,
+    embedHtml: sanitizeEmbed(activity.embedHtml ?? null),
+  };
+
+  return [snapshot];
+}
+
+function sanitizeEmbed(embed: string | null): string | null {
+  if (!embed) {
+    return null;
+  }
+
+  const cleaned = embed.replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, "");
+  if (!/(<iframe|<blockquote)/i.test(cleaned)) {
+    return null;
+  }
+  return cleaned.trim();
+}

--- a/api/lesson-plans/[id]/duplicate.ts
+++ b/api/lesson-plans/[id]/duplicate.ts
@@ -1,0 +1,137 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+  parseJsonBody,
+} from "../../_lib/http";
+import { getSupabaseClient } from "../../_lib/supabase";
+
+const LESSON_PLAN_TABLE = "lesson_plan_builder_plans";
+const LESSON_PLAN_STEPS_TABLE = "lesson_plan_steps";
+
+interface DuplicatePayload {
+  userId?: string;
+  title?: string;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+  const id = extractIdFromRequest(request);
+
+  if (!id) {
+    return errorResponse(400, "A lesson plan id is required");
+  }
+
+  if (method !== "POST") {
+    return methodNotAllowed(["POST"]);
+  }
+
+  return handleDuplicate(request, id);
+}
+
+async function handleDuplicate(request: Request, id: string): Promise<Response> {
+  const payload = (await parseJsonBody<DuplicatePayload>(request)) ?? {};
+  if (!payload.userId) {
+    return errorResponse(400, "A userId is required to duplicate a lesson plan");
+  }
+
+  const supabase = getSupabaseClient();
+  const planResult = await supabase
+    .from(LESSON_PLAN_TABLE)
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (planResult.error) {
+    return errorResponse(500, "Failed to load lesson plan");
+  }
+
+  const sourcePlan = planResult.data;
+  if (!sourcePlan) {
+    return errorResponse(404, "Lesson plan not found");
+  }
+
+  if (!canDuplicate(sourcePlan.share_access)) {
+    return errorResponse(403, "You do not have permission to duplicate this plan");
+  }
+
+  const stepsResult = await supabase
+    .from(LESSON_PLAN_STEPS_TABLE)
+    .select("*")
+    .eq("lesson_plan_id", id)
+    .order("position", { ascending: true });
+
+  if (stepsResult.error) {
+    return errorResponse(500, "Failed to load lesson plan steps");
+  }
+
+  const now = new Date().toISOString();
+  const insertResult = await supabase
+    .from(LESSON_PLAN_TABLE)
+    .insert({
+      title: payload.title?.trim() || `${sourcePlan.title} (Copy)`,
+      summary: sourcePlan.summary ?? null,
+      subject: sourcePlan.subject ?? null,
+      stage: sourcePlan.stage ?? null,
+      duration_minutes: sourcePlan.duration_minutes ?? null,
+      owner_id: payload.userId,
+      share_access: "owner",
+      metadata: sourcePlan.metadata ?? null,
+      created_at: now,
+      updated_at: now,
+    })
+    .select("*")
+    .single();
+
+  if (insertResult.error || !insertResult.data) {
+    return errorResponse(500, "Failed to duplicate lesson plan");
+  }
+
+  const newPlan = insertResult.data;
+  const steps = Array.isArray(stepsResult.data) ? stepsResult.data : [];
+  if (steps.length > 0) {
+    const clonedSteps = steps.map((step: Record<string, unknown>, index) => ({
+      lesson_plan_id: newPlan.id,
+      position: step.position ?? index,
+      title: step.title ?? null,
+      duration_minutes: step.duration_minutes ?? null,
+      notes: step.notes ?? null,
+      resources: step.resources ?? [],
+      created_at: now,
+      updated_at: now,
+    }));
+
+    const stepInsert = await supabase
+      .from(LESSON_PLAN_STEPS_TABLE)
+      .insert(clonedSteps)
+      .select("id");
+
+    if (stepInsert.error) {
+      return errorResponse(500, "Failed to duplicate lesson plan steps");
+    }
+  }
+
+  return jsonResponse({
+    plan: {
+      ...newPlan,
+      shareAccess: "owner",
+      readOnly: false,
+    },
+  }, 201);
+}
+
+function extractIdFromRequest(request: Request): string | null {
+  try {
+    const url = new URL(request.url);
+    const segments = url.pathname.split("/").filter(Boolean);
+    const id = segments[segments.length - 2];
+    return id ? decodeURIComponent(id) : null;
+  } catch {
+    return null;
+  }
+}
+
+function canDuplicate(shareAccess: string | null | undefined): boolean {
+  return shareAccess === "owner" || shareAccess === "editor";
+}

--- a/api/lesson-plans/[id]/export.ts
+++ b/api/lesson-plans/[id]/export.ts
@@ -1,0 +1,120 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+  parseJsonBody,
+} from "../../_lib/http";
+import { getSupabaseClient } from "../../_lib/supabase";
+
+const LESSON_PLAN_TABLE = "lesson_plan_builder_plans";
+
+interface ExportPayload {
+  userId?: string;
+  exportType?: string | null;
+  exportPath?: string | null;
+  bucket?: string | null;
+  expiresIn?: number | null;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+  const id = extractIdFromRequest(request);
+
+  if (!id) {
+    return errorResponse(400, "A lesson plan id is required");
+  }
+
+  if (method !== "POST") {
+    return methodNotAllowed(["POST"]);
+  }
+
+  return handleExport(request, id);
+}
+
+async function handleExport(request: Request, id: string): Promise<Response> {
+  const payload = (await parseJsonBody<ExportPayload>(request)) ?? {};
+  if (!payload.userId) {
+    return errorResponse(400, "A userId is required to export a lesson plan");
+  }
+
+  const supabase = getSupabaseClient();
+  const accessResult = await supabase
+    .from(LESSON_PLAN_TABLE)
+    .select("id, share_access")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (accessResult.error) {
+    return errorResponse(500, "Failed to verify lesson plan access");
+  }
+
+  if (!accessResult.data) {
+    return errorResponse(404, "Lesson plan not found");
+  }
+
+  if (!canExport(accessResult.data.share_access)) {
+    return errorResponse(403, "You do not have permission to export this plan");
+  }
+
+  const updates: Record<string, unknown> = {
+    last_exported_at: new Date().toISOString(),
+  };
+
+  if (payload.exportType !== undefined) {
+    updates.selected_export_type = payload.exportType;
+  }
+
+  if (payload.exportPath) {
+    updates.latest_export_path = payload.exportPath;
+  }
+
+  const updateResult = await supabase
+    .from(LESSON_PLAN_TABLE)
+    .update(updates)
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (updateResult.error || !updateResult.data) {
+    return errorResponse(500, "Failed to update export selection");
+  }
+
+  let signedUrl: string | null = null;
+  if (payload.exportPath && payload.bucket) {
+    const expiresIn = payload.expiresIn ?? 3600;
+    const storageResponse = await supabase.storage
+      .from(payload.bucket)
+      .createSignedUrl(payload.exportPath, expiresIn);
+
+    if (storageResponse.error) {
+      return errorResponse(500, "Failed to generate signed export link");
+    }
+
+    signedUrl = storageResponse.data?.signedUrl ?? null;
+  }
+
+  return jsonResponse({
+    plan: {
+      ...updateResult.data,
+      shareAccess: updateResult.data.share_access ?? "owner",
+      readOnly: false,
+    },
+    signedUrl,
+  });
+}
+
+function extractIdFromRequest(request: Request): string | null {
+  try {
+    const url = new URL(request.url);
+    const segments = url.pathname.split("/").filter(Boolean);
+    const id = segments[segments.length - 2];
+    return id ? decodeURIComponent(id) : null;
+  } catch {
+    return null;
+  }
+}
+
+function canExport(shareAccess: string | null | undefined): boolean {
+  return shareAccess === "owner" || shareAccess === "editor";
+}

--- a/api/lesson-plans/[id]/versions.ts
+++ b/api/lesson-plans/[id]/versions.ts
@@ -1,0 +1,136 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+  parseJsonBody,
+} from "../../_lib/http";
+import { getSupabaseClient } from "../../_lib/supabase";
+
+const LESSON_PLAN_TABLE = "lesson_plan_builder_plans";
+const LESSON_PLAN_STEPS_TABLE = "lesson_plan_steps";
+const VERSION_TABLE = "lesson_plan_versions";
+
+interface VersionPayload {
+  userId?: string;
+  label?: string | null;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+  const id = extractIdFromRequest(request);
+
+  if (!id) {
+    return errorResponse(400, "A lesson plan id is required");
+  }
+
+  if (method === "GET") {
+    return handleList(id);
+  }
+
+  if (method === "POST") {
+    return handleCreate(request, id);
+  }
+
+  return methodNotAllowed(["GET", "POST"]);
+}
+
+async function handleList(id: string): Promise<Response> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from(VERSION_TABLE)
+    .select("id, label, created_at, created_by")
+    .eq("lesson_plan_id", id)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return errorResponse(500, "Failed to load lesson plan versions");
+  }
+
+  return jsonResponse({ versions: data ?? [] });
+}
+
+async function handleCreate(request: Request, id: string): Promise<Response> {
+  const payload = (await parseJsonBody<VersionPayload>(request)) ?? {};
+  if (!payload.userId) {
+    return errorResponse(400, "A userId is required to create a version");
+  }
+
+  const supabase = getSupabaseClient();
+  const accessResult = await supabase
+    .from(LESSON_PLAN_TABLE)
+    .select("id, share_access")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (accessResult.error) {
+    return errorResponse(500, "Failed to verify lesson plan access");
+  }
+
+  if (!accessResult.data) {
+    return errorResponse(404, "Lesson plan not found");
+  }
+
+  if (!canSnapshot(accessResult.data.share_access)) {
+    return errorResponse(403, "You do not have permission to snapshot this plan");
+  }
+
+  const planResult = await supabase
+    .from(LESSON_PLAN_TABLE)
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (planResult.error || !planResult.data) {
+    return errorResponse(500, "Failed to load lesson plan");
+  }
+
+  const stepsResult = await supabase
+    .from(LESSON_PLAN_STEPS_TABLE)
+    .select("*")
+    .eq("lesson_plan_id", id)
+    .order("position", { ascending: true });
+
+  if (stepsResult.error) {
+    return errorResponse(500, "Failed to load lesson plan steps");
+  }
+
+  const snapshot = {
+    plan: planResult.data,
+    steps: stepsResult.data ?? [],
+  };
+
+  const now = new Date().toISOString();
+  const insertResult = await supabase
+    .from(VERSION_TABLE)
+    .insert({
+      lesson_plan_id: id,
+      label: payload.label ?? null,
+      snapshot,
+      created_by: payload.userId,
+      created_at: now,
+    })
+    .select("*")
+    .single();
+
+  if (insertResult.error || !insertResult.data) {
+    return errorResponse(500, "Failed to create version snapshot");
+  }
+
+  return jsonResponse({ version: insertResult.data }, 201);
+}
+
+function extractIdFromRequest(request: Request): string | null {
+  try {
+    const url = new URL(request.url);
+    const segments = url.pathname.split("/").filter(Boolean);
+    const id = segments[segments.length - 2];
+    return id ? decodeURIComponent(id) : null;
+  } catch {
+    return null;
+  }
+}
+
+function canSnapshot(shareAccess: string | null | undefined): boolean {
+  return shareAccess === "owner" || shareAccess === "editor";
+}

--- a/api/og-scrape.ts
+++ b/api/og-scrape.ts
@@ -1,0 +1,216 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+  parseJsonBody,
+} from "./_lib/http";
+
+interface OgScrapePayload {
+  url?: string;
+}
+
+interface OgMetadata {
+  title: string | null;
+  description: string | null;
+  siteName: string | null;
+  image: string | null;
+  url: string;
+  providerName: string | null;
+  embedHtml: string | null;
+}
+
+const ALLOWED_EMBED_PATTERNS = [/^https?:\/\//i];
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+  if (method !== "POST") {
+    return methodNotAllowed(["POST"]);
+  }
+
+  const payload = (await parseJsonBody<OgScrapePayload>(request)) ?? {};
+  if (!payload.url || payload.url.trim().length === 0) {
+    return errorResponse(400, "A URL is required");
+  }
+
+  const normalizedUrl = normalizeUrl(payload.url);
+  if (!normalizedUrl) {
+    return errorResponse(400, "The provided URL is invalid");
+  }
+
+  try {
+    const html = await fetchHtml(normalizedUrl);
+    const og = extractOgMetadata(html, normalizedUrl);
+    const oEmbedUrl = extractOEmbedUrl(html);
+
+    if (oEmbedUrl) {
+      const oEmbed = await fetchOEmbed(oEmbedUrl);
+      if (oEmbed.title && !og.title) {
+        og.title = oEmbed.title;
+      }
+      if (oEmbed.provider_name && !og.providerName) {
+        og.providerName = oEmbed.provider_name;
+      }
+      if (oEmbed.thumbnail_url && !og.image) {
+        og.image = oEmbed.thumbnail_url;
+      }
+      if (oEmbed.html) {
+        const sanitized = sanitizeEmbed(oEmbed.html);
+        if (!sanitized) {
+          return errorResponse(422, "The embed markup is not supported");
+        }
+        og.embedHtml = sanitized;
+      }
+    }
+
+    if (og.embedHtml) {
+      const host = tryParseUrlSrc(og.embedHtml);
+      if (!host) {
+        return errorResponse(422, "Unable to validate embed source");
+      }
+      if (!ALLOWED_EMBED_PATTERNS.some((pattern) => pattern.test(host))) {
+        return errorResponse(422, "Embeds from this host are not allowed");
+      }
+    }
+
+    return jsonResponse({
+      url: og.url,
+      metadata: og,
+    });
+  } catch (error) {
+    return errorResponse(500, error instanceof Error ? error.message : "Failed to load metadata");
+  }
+}
+
+function normalizeUrl(input: string): string | null {
+  try {
+    const trimmed = input.trim();
+    if (/^https?:\/\//i.test(trimmed)) {
+      return new URL(trimmed).toString();
+    }
+    if (/^\/\//.test(trimmed)) {
+      return new URL(`https:${trimmed}`).toString();
+    }
+    const sanitized = trimmed.replace(/^\/+/, "");
+    return new URL(`https://${sanitized}`).toString();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchHtml(url: string): Promise<string> {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "text/html,application/xhtml+xml",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch page metadata");
+  }
+
+  return await response.text();
+}
+
+function extractOgMetadata(html: string, url: string): OgMetadata {
+  const meta = createMetaLookup(html);
+  return {
+    title: meta("og:title") ?? meta("twitter:title") ?? extractTitle(html),
+    description:
+      meta("og:description") ??
+      meta("description") ??
+      meta("twitter:description") ??
+      null,
+    siteName: meta("og:site_name") ?? null,
+    image: meta("og:image") ?? meta("twitter:image") ?? null,
+    url,
+    providerName: meta("og:site_name") ?? null,
+    embedHtml: null,
+  };
+}
+
+function extractOEmbedUrl(html: string): string | null {
+  const linkRegex = /<link[^>]+rel=["']alternate["'][^>]*>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = linkRegex.exec(html))) {
+    const tag = match[0];
+    const typeMatch = tag.match(/type=["']([^"']+)["']/i);
+    if (!typeMatch || !/json\+oembed/i.test(typeMatch[1])) {
+      continue;
+    }
+    const hrefMatch = tag.match(/href=["']([^"']+)["']/i);
+    if (hrefMatch) {
+      try {
+        return new URL(hrefMatch[1]).toString();
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
+async function fetchOEmbed(url: string): Promise<Record<string, any>> {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error("Failed to fetch oEmbed metadata");
+  }
+  return (await response.json()) as Record<string, any>;
+}
+
+function sanitizeEmbed(html: string): string | null {
+  const stripped = html
+    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, "")
+    .replace(/on[a-z]+="[^"]*"/gi, "");
+  if (!/(<iframe|<blockquote)/i.test(stripped)) {
+    return null;
+  }
+  return stripped.trim();
+}
+
+function tryParseUrlSrc(html: string): string | null {
+  const srcMatch = html.match(/src=["']([^"']+)["']/i);
+  if (!srcMatch) {
+    return null;
+  }
+  try {
+    return new URL(srcMatch[1]).toString();
+  } catch {
+    return null;
+  }
+}
+
+function createMetaLookup(html: string): (name: string) => string | null {
+  const metaRegex = /<meta[^>]+>/gi;
+  const entries: Record<string, string> = {};
+  let match: RegExpExecArray | null;
+
+  while ((match = metaRegex.exec(html))) {
+    const tag = match[0];
+    const key =
+      matchAttribute(tag, "property") ||
+      matchAttribute(tag, "name") ||
+      matchAttribute(tag, "itemprop");
+    if (!key) continue;
+    const content = matchAttribute(tag, "content");
+    if (!content) continue;
+    entries[key.toLowerCase()] = content;
+  }
+
+  return (name: string) => entries[name.toLowerCase()] ?? null;
+}
+
+function matchAttribute(tag: string, attribute: string): string | null {
+  const regex = new RegExp(`${attribute}=["']([^"']+)["']`, "i");
+  const match = tag.match(regex);
+  return match ? match[1] : null;
+}
+
+function extractTitle(html: string): string | null {
+  const match = html.match(/<title>([^<]*)<\/title>/i);
+  return match ? match[1].trim() : null;
+}


### PR DESCRIPTION
## Summary
- add shared HTTP helpers and extend lesson plan list endpoint with POST creation using teacher defaults
- implement builder endpoints for lesson plan detail, duplication, versioning, and export with share access handling and resource snapshots
- expose activities listing/creation APIs plus OG scraping utility and comprehensive Vitest coverage with Supabase stubs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d098cd34988331b141a0c796ec63f6