### PR TITLE
Remove worksheets page routes and navigation

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -15,8 +15,6 @@ import TeacherDiary from '@/pages/TeacherDiary';
 import TeacherDiaryEntry from '@/pages/TeacherDiaryEntry';
 import LessonPlans from '@/pages/LessonPlans';
 import LessonPlan from '@/pages/LessonPlan';
-import Worksheets from '@/pages/Worksheets';
-import Worksheet from '@/pages/Worksheet';
 import BuilderLessonPlan from '@/pages/BuilderLessonPlan';
 import BuilderLessonPlanDetail from '@/pages/BuilderLessonPlanDetail';
 import Auth from '@/pages/Auth';
@@ -70,8 +68,6 @@ export const LocalizedRoutes = () => {
       <Route path="/builder/lesson-plans/:id" element={<RouteWrapper><BuilderLessonPlanDetail /></RouteWrapper>} />
       <Route path="/lesson-plans/builder" element={<LegacyBuilderRedirect />} />
       <Route path="/lesson-plans/builder/:id" element={<LegacyBuilderRedirect />} />
-      <Route path="/worksheets" element={<RouteWrapper><Worksheets /></RouteWrapper>} />
-      <Route path="/worksheets/:slug" element={<RouteWrapper><Worksheet /></RouteWrapper>} />
       <Route path="/builder" element={<RouteWrapper><Builder /></RouteWrapper>} />
       <Route path="/events" element={<RouteWrapper><Events /></RouteWrapper>} />
       <Route path="/events/:slug" element={<RouteWrapper><EventDetail /></RouteWrapper>} />
@@ -97,8 +93,6 @@ export const LocalizedRoutes = () => {
         <Route path="builder/lesson-plans/:id" element={<RouteWrapper><BuilderLessonPlanDetail /></RouteWrapper>} />
         <Route path="lesson-plans/builder" element={<LegacyBuilderRedirect includeLanguage />} />
         <Route path="lesson-plans/builder/:id" element={<LegacyBuilderRedirect includeLanguage />} />
-        <Route path="worksheets" element={<RouteWrapper><Worksheets /></RouteWrapper>} />
-        <Route path="worksheets/:slug" element={<RouteWrapper><Worksheet /></RouteWrapper>} />
         <Route path="builder" element={<RouteWrapper><Builder /></RouteWrapper>} />
         <Route path="events" element={<RouteWrapper><Events /></RouteWrapper>} />
         <Route path="events/:slug" element={<RouteWrapper><EventDetail /></RouteWrapper>} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -42,7 +42,6 @@ const Navigation = () => {
     { name: t.nav.blog, path: "/blog" },
     { name: t.nav.lessonPlans, path: "/lesson-plans" },
     { name: t.nav.builder, path: "/builder" },
-    { name: t.nav.worksheets, path: "/worksheets" },
     { name: t.nav.events, path: "/events" },
     { name: t.nav.services, path: "/services" },
     { name: t.nav.about, path: "/about" },

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -33,7 +33,6 @@ const createStaticRoutes = (dictionary: TranslationDictionary): RouteLink[] => [
   { title: dictionary.nav.about, url: "/about" },
   { title: dictionary.nav.services, url: "/services" },
   { title: dictionary.nav.blog, url: "/blog" },
-  { title: dictionary.nav.worksheets ?? "Worksheets", url: "/worksheets" },
   { title: dictionary.nav.events, url: "/events" },
   { title: dictionary.nav.edutech, url: "/edutech" },
   { title: dictionary.nav.teacherDiary, url: "/teacher-diary" },


### PR DESCRIPTION
## Summary
- remove the worksheets routes from the localized router so the page is no longer accessible
- drop the worksheets link from the navigation menu and sitemap listing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0bf35a23c8331b9ec0d3036b73dce