### PR TITLE
feat: extend lesson plan metadata and resources schema

### DIFF
--- a/api/_lib/lesson-builder-helpers.ts
+++ b/api/_lib/lesson-builder-helpers.ts
@@ -206,6 +206,8 @@ export function mapRecordToBuilderPlan(record: LessonPlanRecord): LessonBuilderP
     deliveryMethods: detail.deliveryMethods,
     technologyTags: detail.technologyTags,
     durationMinutes: detail.durationMinutes,
+    schoolLogoUrl: detail.schoolLogoUrl,
+    lessonDate: detail.lessonDate,
     overview: detail.overview,
     steps,
     standards,

--- a/api/_lib/lesson-plan-helpers.tsx
+++ b/api/_lib/lesson-plan-helpers.tsx
@@ -248,6 +248,9 @@ export function mapRecordToListItem(record: LessonPlanRecord): LessonPlanListIte
   const pdfUrl =
     nullableString(record.pdf_url) ?? nullableString(record.pdf) ?? null;
 
+  const schoolLogoUrl = nullableString(record.school_logo_url);
+  const lessonDate = nullableString(record.lesson_date);
+
   return {
     id: record.id,
     slug: record.slug,
@@ -260,6 +263,8 @@ export function mapRecordToListItem(record: LessonPlanRecord): LessonPlanListIte
     technologyTags: tech,
     durationMinutes: duration,
     pdfUrl,
+    schoolLogoUrl,
+    lessonDate,
     status: record.status ?? ("draft" as LessonPlanStatus),
     createdAt: nullableString(record.created_at),
     updatedAt: nullableString(record.updated_at),

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -802,9 +802,11 @@ export type Database = {
           duration_minutes: number | null
           grade_levels: string[]
           id: string
+          lesson_date: string | null
           materials: string[]
           objectives: string[]
           search_vector: unknown
+          school_logo_url: string | null
           slug: string
           standards: string[]
           status: string
@@ -820,9 +822,11 @@ export type Database = {
           duration_minutes?: number | null
           grade_levels?: string[]
           id?: string
+          lesson_date?: string | null
           materials?: string[]
           objectives?: string[]
           search_vector?: unknown
+          school_logo_url?: string | null
           slug: string
           standards?: string[]
           status?: string
@@ -838,9 +842,11 @@ export type Database = {
           duration_minutes?: number | null
           grade_levels?: string[]
           id?: string
+          lesson_date?: string | null
           materials?: string[]
           objectives?: string[]
           search_vector?: unknown
+          school_logo_url?: string | null
           slug?: string
           standards?: string[]
           status?: string
@@ -851,6 +857,186 @@ export type Database = {
           updated_at?: string
         }
         Relationships: []
+      }
+      lesson_plan_steps: {
+        Row: {
+          created_at: string
+          delivery_mode: "offline" | "blended" | "online" | null
+          duration_minutes: number | null
+          id: string
+          learning_goals: string | null
+          lesson_plan_id: string
+          notes: string | null
+          position: number | null
+          resources: Json | null
+          title: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          delivery_mode?: "offline" | "blended" | "online" | null
+          duration_minutes?: number | null
+          id?: string
+          learning_goals?: string | null
+          lesson_plan_id: string
+          notes?: string | null
+          position?: number | null
+          resources?: Json | null
+          title?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          delivery_mode?: "offline" | "blended" | "online" | null
+          duration_minutes?: number | null
+          id?: string
+          learning_goals?: string | null
+          lesson_plan_id?: string
+          notes?: string | null
+          position?: number | null
+          resources?: Json | null
+          title?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lesson_plan_steps_lesson_plan_id_fkey"
+            columns: ["lesson_plan_id"]
+            isOneToOne: false
+            referencedRelation: "lesson_plans"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      resources: {
+        Row: {
+          cost: string | null
+          created_at: string
+          created_by: string | null
+          delivery_mode: "offline" | "blended" | "online" | null
+          description: string | null
+          download_url: string | null
+          duration_minutes: number | null
+          grade_levels: string[]
+          id: string
+          language: string
+          learning_goals: string | null
+          lesson_plan_id: string | null
+          metadata: Json
+          provider: string | null
+          published_at: string | null
+          resource_type:
+            | "video"
+            | "article"
+            | "worksheet"
+            | "template"
+            | "interactive"
+            | "tool"
+            | "other"
+          search_vector: unknown
+          status: "draft" | "published" | "archived"
+          step_id: string | null
+          subjects: string[]
+          summary: string | null
+          tags: string[]
+          thumbnail_url: string | null
+          title: string
+          updated_at: string
+          url: string | null
+        }
+        Insert: {
+          cost?: string | null
+          created_at?: string
+          created_by?: string | null
+          delivery_mode?: "offline" | "blended" | "online" | null
+          description?: string | null
+          download_url?: string | null
+          duration_minutes?: number | null
+          grade_levels?: string[]
+          id?: string
+          language?: string
+          learning_goals?: string | null
+          lesson_plan_id?: string | null
+          metadata?: Json
+          provider?: string | null
+          published_at?: string | null
+          resource_type:
+            | "video"
+            | "article"
+            | "worksheet"
+            | "template"
+            | "interactive"
+            | "tool"
+            | "other"
+          search_vector?: unknown
+          status?: "draft" | "published" | "archived"
+          step_id?: string | null
+          subjects?: string[]
+          summary?: string | null
+          tags?: string[]
+          thumbnail_url?: string | null
+          title: string
+          updated_at?: string
+          url?: string | null
+        }
+        Update: {
+          cost?: string | null
+          created_at?: string
+          created_by?: string | null
+          delivery_mode?: "offline" | "blended" | "online" | null
+          description?: string | null
+          download_url?: string | null
+          duration_minutes?: number | null
+          grade_levels?: string[]
+          id?: string
+          language?: string
+          learning_goals?: string | null
+          lesson_plan_id?: string | null
+          metadata?: Json
+          provider?: string | null
+          published_at?: string | null
+          resource_type?:
+            | "video"
+            | "article"
+            | "worksheet"
+            | "template"
+            | "interactive"
+            | "tool"
+            | "other"
+          search_vector?: unknown
+          status?: "draft" | "published" | "archived"
+          step_id?: string | null
+          subjects?: string[]
+          summary?: string | null
+          tags?: string[]
+          thumbnail_url?: string | null
+          title?: string
+          updated_at?: string
+          url?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "resources_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "resources_lesson_plan_id_fkey"
+            columns: ["lesson_plan_id"]
+            isOneToOne: false
+            referencedRelation: "lesson_plans"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "resources_step_id_fkey"
+            columns: ["step_id"]
+            isOneToOne: false
+            referencedRelation: "lesson_plan_steps"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       newsletter_subscribers: {
         Row: {
@@ -903,6 +1089,7 @@ export type Database = {
           email: string | null
           full_name: string | null
           id: string
+          school_logo_url: string | null
           role: Database["public"]["Enums"]["user_role_enum"] | null
           updated_at: string | null
         }
@@ -911,6 +1098,7 @@ export type Database = {
           email?: string | null
           full_name?: string | null
           id: string
+          school_logo_url?: string | null
           role?: Database["public"]["Enums"]["user_role_enum"] | null
           updated_at?: string | null
         }
@@ -919,6 +1107,7 @@ export type Database = {
           email?: string | null
           full_name?: string | null
           id?: string
+          school_logo_url?: string | null
           role?: Database["public"]["Enums"]["user_role_enum"] | null
           updated_at?: string | null
         }

--- a/supabase/migrations/20251017090000_lesson_plan_resources.sql
+++ b/supabase/migrations/20251017090000_lesson_plan_resources.sql
@@ -1,0 +1,103 @@
+alter table if exists public.lesson_plans
+  add column if not exists school_logo_url text,
+  add column if not exists lesson_date date;
+
+alter table if exists public.profiles
+  add column if not exists school_logo_url text;
+
+-- Backfill lesson plan logos from profile data when available
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'lesson_plans'
+      AND column_name = 'owner_id'
+  ) THEN
+    UPDATE public.lesson_plans lp
+    SET school_logo_url = COALESCE(lp.school_logo_url, p.school_logo_url)
+    FROM public.profiles p
+    WHERE lp.owner_id = p.id
+      AND p.school_logo_url IS NOT NULL
+      AND (lp.school_logo_url IS NULL OR lp.school_logo_url = '');
+  END IF;
+END $$;
+
+-- Extend lesson plan steps with learning goal metadata
+alter table if exists public.lesson_plan_steps
+  add column if not exists learning_goals text,
+  add column if not exists delivery_mode text
+    check (delivery_mode in ('offline','blended','online'));
+
+-- Create resource catalog for lesson plans
+create table if not exists public.resources (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  lesson_plan_id uuid references public.lesson_plans(id) on delete set null,
+  step_id uuid references public.lesson_plan_steps(id) on delete set null,
+  title text not null,
+  summary text,
+  description text,
+  url text,
+  download_url text,
+  thumbnail_url text,
+  provider text,
+  resource_type text not null check (resource_type in ('video','article','worksheet','template','interactive','tool','other')),
+  delivery_mode text check (delivery_mode in ('offline','blended','online')),
+  learning_goals text,
+  subjects text[] not null default '{}'::text[],
+  grade_levels text[] not null default '{}'::text[],
+  tags text[] not null default '{}'::text[],
+  language text not null default 'en',
+  duration_minutes integer,
+  cost text,
+  status text not null default 'draft' check (status in ('draft','published','archived')),
+  published_at timestamptz,
+  created_by uuid references public.profiles(id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  search_vector tsvector generated always as (
+    setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(summary, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(array_to_string(tags, ' '), '')), 'C')
+  ) stored
+);
+
+drop trigger if exists resources_set_updated_at on public.resources;
+
+create trigger resources_set_updated_at
+  before update on public.resources
+  for each row
+  execute function public.update_updated_at_column();
+
+create index if not exists resources_search_idx
+  on public.resources using gin (search_vector);
+
+create index if not exists resources_tags_idx
+  on public.resources using gin (tags);
+
+create index if not exists resources_subjects_idx
+  on public.resources using gin (subjects);
+
+create index if not exists resources_grade_levels_idx
+  on public.resources using gin (grade_levels);
+
+create index if not exists resources_lesson_plan_idx
+  on public.resources (lesson_plan_id);
+
+create index if not exists resources_step_idx
+  on public.resources (step_id);
+
+alter table public.resources enable row level security;
+
+create policy if not exists "Public can read published resources"
+  on public.resources
+  for select
+  using (status = 'published');
+
+create policy if not exists "Service role can manage resources"
+  on public.resources
+  for all
+  using (auth.role() = 'service_role')
+  with check (true);

--- a/types/lesson-builder.ts
+++ b/types/lesson-builder.ts
@@ -64,6 +64,8 @@ export interface LessonBuilderPlan {
   deliveryMethods: string[];
   technologyTags: string[];
   durationMinutes: number | null;
+  schoolLogoUrl: string | null;
+  lessonDate: string | null;
   overview: LessonPlanOverview | null;
   steps: LessonBuilderStep[];
   standards: LessonBuilderStandard[];
@@ -176,6 +178,8 @@ function createListItemFromPlan(plan: LessonBuilderPlan): LessonPlanListItem {
     technologyTags: plan.technologyTags,
     durationMinutes: plan.durationMinutes,
     pdfUrl: null,
+    schoolLogoUrl: plan.schoolLogoUrl,
+    lessonDate: plan.lessonDate,
     status: plan.status,
     createdAt: plan.createdAt,
     updatedAt: plan.updatedAt,

--- a/types/lesson-plans.ts
+++ b/types/lesson-plans.ts
@@ -12,6 +12,8 @@ export interface LessonPlanListItem {
   technologyTags: string[];
   durationMinutes: number | null;
   pdfUrl: string | null;
+  schoolLogoUrl: string | null;
+  lessonDate: string | null;
   status: LessonPlanStatus;
   createdAt: string | null;
   updatedAt: string | null;
@@ -114,4 +116,6 @@ export interface LessonPlanRecord {
   updated_at?: string | null;
   published_at?: string | null;
   metadata?: unknown;
+  school_logo_url?: string | null;
+  lesson_date?: string | null;
 }


### PR DESCRIPTION
## Summary
- add a Supabase migration that augments lesson plans/steps and introduces the resources catalog with indexes and RLS policies
- refresh generated Supabase client types so the new columns and relationships are available in TypeScript
- expose the school logo and lesson date fields through shared lesson plan DTOs and builder mapping helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0c017c0e4833187d87a4281af3006