### PR TITLE
Add educator resources API and account management UI

### DIFF
--- a/api/__tests__/resources.test.ts
+++ b/api/__tests__/resources.test.ts
@@ -1,0 +1,337 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import listHandler from "../resources";
+import updateHandler from "../resources/[id]";
+import type { ResourceCard, ResourceListResponse, ResourceRecord } from "../../types/resources";
+
+interface SupabaseResponse {
+  data: unknown;
+  error?: { message: string } | null;
+  count?: number | null;
+}
+
+const { SupabaseStub, createStub } = vi.hoisted(() => {
+  interface CallRecord {
+    table: string;
+    method: string;
+    args: unknown[];
+  }
+
+  class QueryBuilder {
+    public readonly calls: CallRecord[] = [];
+
+    constructor(
+      private readonly parent: SupabaseStub,
+      private readonly table: string,
+      private response: SupabaseResponse
+    ) {
+      this.record("from", []);
+    }
+
+    private record(method: string, args: unknown[]): this {
+      const entry: CallRecord = { table: this.table, method, args };
+      this.calls.push(entry);
+      this.parent.calls.push(entry);
+      return this;
+    }
+
+    select(field: string, options?: unknown): this {
+      return this.record("select", [field, options]);
+    }
+
+    eq(column: string, value: unknown): this {
+      return this.record("eq", [column, value]);
+    }
+
+    order(column: string, options?: unknown): this {
+      return this.record("order", [column, options]);
+    }
+
+    or(condition: string): this {
+      return this.record("or", [condition]);
+    }
+
+    overlaps(column: string, values: unknown[]): this {
+      return this.record("overlaps", [column, values]);
+    }
+
+    in(column: string, values: unknown[]): this {
+      return this.record("in", [column, values]);
+    }
+
+    range(from: number, to: number): this {
+      return this.record("range", [from, to]);
+    }
+
+    insert(values: unknown): this {
+      return this.record("insert", [values]);
+    }
+
+    update(values: unknown): this {
+      return this.record("update", [values]);
+    }
+
+    maybeSingle() {
+      this.record("maybeSingle", []);
+      return Promise.resolve({
+        data: this.response.data,
+        error: this.response.error ?? null,
+      });
+    }
+
+    single() {
+      this.record("single", []);
+      return Promise.resolve({
+        data: this.response.data,
+        error: this.response.error ?? null,
+      });
+    }
+
+    then<TResult1 = any, TResult2 = never>(
+      onfulfilled?:
+        | ((value: { data: unknown; error: { message: string } | null; count?: number | null }) =>
+            | TResult1
+            | PromiseLike<TResult1>)
+        | null,
+      onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2> {
+      this.record("then", []);
+      const payload = {
+        data: this.response.data,
+        error: this.response.error ?? null,
+        count: this.response.count ?? null,
+      };
+      if (onfulfilled) {
+        try {
+          return Promise.resolve(onfulfilled(payload));
+        } catch (error) {
+          if (onrejected) {
+            return Promise.resolve(onrejected(error));
+          }
+          return Promise.reject(error);
+        }
+      }
+      return Promise.resolve(payload as unknown as TResult1);
+    }
+  }
+
+  class SupabaseStub {
+    public calls: CallRecord[] = [];
+    private responses: SupabaseResponse[] = [];
+
+    from(table: string): QueryBuilder {
+      const response = this.responses.shift() ?? { data: null, error: null, count: null };
+      return new QueryBuilder(this, table, response);
+    }
+
+    setResponses(responses: SupabaseResponse[]) {
+      this.responses = responses.map((response) => ({
+        data: response.data,
+        error: response.error ?? null,
+        count: response.count ?? null,
+      }));
+      this.calls = [];
+    }
+  }
+
+  return { SupabaseStub, createStub: () => new SupabaseStub() };
+});
+
+vi.mock("../_lib/supabase", () => {
+  const stub = createStub();
+  return {
+    getSupabaseClient: () => stub,
+    __setResponses: (responses: SupabaseResponse[]) => stub.setResponses(responses),
+    __getStub: () => stub,
+  };
+});
+
+vi.mock("../_lib/open-graph", async () => {
+  const actual = await vi.importActual<typeof import("../_lib/open-graph")>("../_lib/open-graph");
+  return {
+    ...actual,
+    loadOpenGraphMetadata: vi.fn(async (url: string) => ({
+      metadata: {
+        title: "OG Title",
+        description: "OG Description",
+        siteName: "Example",
+        image: "https://cdn.example.com/thumb.jpg",
+        url,
+        providerName: "Example",
+        embedHtml: null,
+      },
+      embedSrc: null,
+    })),
+  };
+});
+
+let setResponses: (responses: SupabaseResponse[]) => void;
+let getStub: () => InstanceType<typeof SupabaseStub>;
+
+beforeAll(async () => {
+  const supabaseModule = (await import("../_lib/supabase")) as unknown as {
+    __setResponses: (responses: SupabaseResponse[]) => void;
+    __getStub: () => InstanceType<typeof SupabaseStub>;
+  };
+  setResponses = supabaseModule.__setResponses;
+  getStub = supabaseModule.__getStub;
+});
+
+beforeEach(() => {
+  setResponses([]);
+});
+
+function createRecord(overrides: Partial<ResourceRecord> = {}): ResourceRecord {
+  const base: ResourceRecord = {
+    id: "resource-1",
+    owner_id: "user-1",
+    title: "Example resource",
+    description: "Helpful description",
+    url: "https://example.com/",
+    normalized_url: "https://example.com/",
+    domain: "example.com",
+    favicon_url: "https://www.google.com/s2/favicons?domain_url=https%3A%2F%2Fexample.com",
+    thumbnail_url: "https://cdn.example.com/thumb.jpg",
+    resource_type: "Video",
+    subjects: ["Math"],
+    topics: ["STEM"],
+    tags: ["assessment"],
+    instructional_notes: null,
+    status: "draft",
+    visibility: "private",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+  return { ...base, ...overrides };
+}
+
+describe("resources API", () => {
+  it("applies search filters when listing resources", async () => {
+    const record = createRecord({ status: "published", visibility: "public" });
+    setResponses([
+      { data: [record], count: 25 },
+    ]);
+
+    const request = new Request(
+      "http://localhost/api/resources?q=Math&subjects=Math,Science&topics=STEM&tags=Project&types=Video&status=published&visibility=public&page=2&limit=5",
+      { method: "GET" }
+    );
+
+    const response = await listHandler(request);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ResourceListResponse;
+    expect(body.items).toHaveLength(1);
+    expect(body.page).toBe(2);
+    expect(body.pageSize).toBe(5);
+    expect(body.total).toBe(25);
+
+    const calls = getStub().calls;
+    expect(calls.some((call) => call.method === "or")).toBe(true);
+    expect(
+      calls.filter((call) => call.method === "overlaps" && call.args[0] === "subjects").length
+    ).toBe(1);
+    expect(
+      calls.filter((call) => call.method === "overlaps" && call.args[0] === "topics").length
+    ).toBe(1);
+    expect(
+      calls.filter((call) => call.method === "overlaps" && call.args[0] === "tags").length
+    ).toBe(1);
+    expect(
+      calls.some((call) => call.method === "in" && call.args[0] === "resource_type")
+    ).toBe(true);
+  });
+
+  it("creates a resource with normalized url and metadata", async () => {
+    const inserted = createRecord({
+      id: "resource-new",
+      owner_id: "user-1",
+      status: "draft",
+      visibility: "private",
+      subjects: ["Math"],
+      tags: ["ai"],
+    });
+
+    setResponses([
+      { data: null },
+      { data: inserted },
+    ]);
+
+    const request = new Request("http://localhost/api/resources", {
+      method: "POST",
+      body: JSON.stringify({
+        userId: "user-1",
+        url: "https://example.com/?utm_source=newsletter",
+        subjects: ["Math"],
+        tags: ["ai"],
+      }),
+    });
+
+    const response = await listHandler(request);
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as { resource: ResourceCard };
+    expect(body.resource.url).toBe("https://example.com/");
+    expect(body.resource.domain).toBe("example.com");
+    expect(body.resource.subjects).toEqual(["Math"]);
+
+    const insertCall = getStub().calls.find((call) => call.method === "insert");
+    expect(insertCall).toBeTruthy();
+    const insertedPayload = insertCall?.args[0] as Record<string, unknown>;
+    expect(insertedPayload.owner_id).toBe("user-1");
+    expect(insertedPayload.normalized_url).toBe("https://example.com/");
+    expect(insertedPayload.subjects).toEqual(["Math"]);
+  });
+
+  it("updates a resource and refreshes metadata", async () => {
+    const existing = createRecord({
+      id: "resource-1",
+      owner_id: "user-1",
+      url: "https://old.example.com/",
+      normalized_url: "https://old.example.com/",
+      domain: "old.example.com",
+      status: "draft",
+      visibility: "private",
+    });
+    const updated = createRecord({
+      id: "resource-1",
+      owner_id: "user-1",
+      url: "https://new.example.com/",
+      normalized_url: "https://new.example.com/",
+      domain: "new.example.com",
+      status: "published",
+      visibility: "public",
+      subjects: ["Math", "Science"],
+    });
+
+    setResponses([
+      { data: existing },
+      { data: null },
+      { data: updated },
+    ]);
+
+    const request = new Request("http://localhost/api/resources/resource-1", {
+      method: "PUT",
+      body: JSON.stringify({
+        userId: "user-1",
+        url: "https://new.example.com/?utm_campaign=test",
+        status: "published",
+        visibility: "public",
+        subjects: ["Math", "Science"],
+        refreshMetadata: true,
+      }),
+    });
+
+    const response = await updateHandler(request);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { resource: ResourceCard };
+    expect(body.resource.url).toBe("https://new.example.com/");
+    expect(body.resource.status).toBe("published");
+    expect(body.resource.visibility).toBe("public");
+    expect(body.resource.subjects).toEqual(["Math", "Science"]);
+
+    const updateCall = getStub().calls.find((call) => call.method === "update");
+    expect(updateCall).toBeTruthy();
+    const updatePayload = updateCall?.args[0] as Record<string, unknown>;
+    expect(updatePayload.normalized_url).toBe("https://new.example.com/");
+    expect(updatePayload.status).toBe("published");
+  });
+});

--- a/api/_lib/open-graph.ts
+++ b/api/_lib/open-graph.ts
@@ -1,0 +1,188 @@
+export interface OpenGraphMetadata {
+  title: string | null;
+  description: string | null;
+  siteName: string | null;
+  image: string | null;
+  url: string;
+  providerName: string | null;
+  embedHtml: string | null;
+}
+
+export interface OpenGraphResult {
+  metadata: OpenGraphMetadata;
+  embedSrc: string | null;
+  hadOEmbedHtml: boolean;
+}
+
+const DEFAULT_ACCEPT_HEADER = "text/html,application/xhtml+xml";
+
+export function normalizeInputUrl(input: string): string | null {
+  try {
+    const trimmed = input.trim();
+    if (/^https?:\/\//i.test(trimmed)) {
+      return new URL(trimmed).toString();
+    }
+    if (/^\/\//.test(trimmed)) {
+      return new URL(`https:${trimmed}`).toString();
+    }
+    const sanitized = trimmed.replace(/^\/+/, "");
+    return new URL(`https://${sanitized}`).toString();
+  } catch {
+    return null;
+  }
+}
+
+export function stripTrackingParameters(url: URL): URL {
+  const next = new URL(url.toString());
+  const params = Array.from(next.searchParams.keys());
+  for (const key of params) {
+    if (/^utm_/i.test(key) || /^fbclid$/i.test(key) || /^gclid$/i.test(key)) {
+      next.searchParams.delete(key);
+    }
+  }
+  next.hash = "";
+  return next;
+}
+
+export async function loadOpenGraphMetadata(url: string): Promise<OpenGraphResult> {
+  const html = await fetchHtml(url);
+  const metadata = extractOgMetadata(html, url);
+  const oEmbedUrl = extractOEmbedUrl(html);
+  let hadOEmbedHtml = false;
+
+  if (oEmbedUrl) {
+    const oEmbed = await fetchOEmbed(oEmbedUrl);
+    if (typeof oEmbed.html === "string" && oEmbed.html.length > 0) {
+      hadOEmbedHtml = true;
+    }
+    if (oEmbed.title && !metadata.title) {
+      metadata.title = oEmbed.title;
+    }
+    if (oEmbed.provider_name && !metadata.providerName) {
+      metadata.providerName = oEmbed.provider_name;
+    }
+    if (oEmbed.thumbnail_url && !metadata.image) {
+      metadata.image = oEmbed.thumbnail_url;
+    }
+    if (oEmbed.html) {
+      metadata.embedHtml = sanitizeEmbed(oEmbed.html);
+    }
+  }
+
+  const embedSrc = metadata.embedHtml ? tryParseUrlSrc(metadata.embedHtml) : null;
+  return { metadata, embedSrc, hadOEmbedHtml };
+}
+
+async function fetchHtml(url: string): Promise<string> {
+  const response = await fetch(url, {
+    headers: { Accept: DEFAULT_ACCEPT_HEADER },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch page metadata");
+  }
+
+  return await response.text();
+}
+
+function extractOgMetadata(html: string, url: string): OpenGraphMetadata {
+  const meta = createMetaLookup(html);
+  return {
+    title: meta("og:title") ?? meta("twitter:title") ?? extractTitle(html),
+    description:
+      meta("og:description") ??
+      meta("description") ??
+      meta("twitter:description") ??
+      null,
+    siteName: meta("og:site_name") ?? null,
+    image: meta("og:image") ?? meta("twitter:image") ?? null,
+    url,
+    providerName: meta("og:site_name") ?? null,
+    embedHtml: null,
+  };
+}
+
+function extractTitle(html: string): string | null {
+  const match = html.match(/<title>([^<]*)<\/title>/i);
+  return match ? match[1].trim() : null;
+}
+
+function extractOEmbedUrl(html: string): string | null {
+  const linkRegex = /<link[^>]+rel=["']alternate["'][^>]*>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = linkRegex.exec(html))) {
+    const tag = match[0];
+    const typeMatch = tag.match(/type=["']([^"']+)["']/i);
+    if (!typeMatch || !/json\+oembed/i.test(typeMatch[1])) {
+      continue;
+    }
+    const hrefMatch = tag.match(/href=["']([^"']+)["']/i);
+    if (hrefMatch) {
+      try {
+        return new URL(hrefMatch[1]).toString();
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
+async function fetchOEmbed(url: string): Promise<Record<string, any>> {
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error("Failed to fetch oEmbed metadata");
+  }
+  return (await response.json()) as Record<string, any>;
+}
+
+export function sanitizeEmbed(html: string): string | null {
+  const stripped = html
+    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, "")
+    .replace(/on[a-z]+="[^"]*"/gi, "");
+  if (!/(<iframe|<blockquote)/i.test(stripped)) {
+    return null;
+  }
+  return stripped.trim();
+}
+
+export function tryParseUrlSrc(html: string): string | null {
+  const srcMatch = html.match(/src=["']([^"']+)["']/i);
+  if (!srcMatch) {
+    return null;
+  }
+  try {
+    return new URL(srcMatch[1]).toString();
+  } catch {
+    return null;
+  }
+}
+
+function createMetaLookup(html: string): (name: string) => string | null {
+  const metaRegex = /<meta[^>]+>/gi;
+  const entries: Record<string, string> = {};
+  let match: RegExpExecArray | null;
+
+  while ((match = metaRegex.exec(html))) {
+    const tag = match[0];
+    const key =
+      matchAttribute(tag, "property") ||
+      matchAttribute(tag, "name") ||
+      matchAttribute(tag, "itemprop");
+    if (!key) continue;
+    const content = matchAttribute(tag, "content");
+    if (!content) continue;
+    entries[key.toLowerCase()] = content.trim();
+  }
+
+  return (name: string) => entries[name.toLowerCase()] ?? null;
+}
+
+function matchAttribute(tag: string, attribute: string): string | null {
+  const regex = new RegExp(`${attribute}=["']([^"']+)["']`, "i");
+  const match = tag.match(regex);
+  return match ? match[1].trim() : null;
+}
+

--- a/api/_lib/resource-helpers.ts
+++ b/api/_lib/resource-helpers.ts
@@ -1,0 +1,176 @@
+import { normalizeInputUrl, stripTrackingParameters } from "./open-graph";
+import type {
+  ResourceCard,
+  ResourceRecord,
+  ResourceStatus,
+  ResourceVisibility,
+} from "../../types/resources";
+
+export interface ResourceListFilters {
+  q: string | null;
+  page: number;
+  limit: number;
+  offset: number;
+  id: string | null;
+  subjects: string[];
+  topics: string[];
+  tags: string[];
+  types: string[];
+  status: ResourceStatus | null;
+  visibility: ResourceVisibility | null;
+  ownerId: string | null;
+}
+
+export interface PaginatedResourceResponse {
+  items: ResourceCard[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+  nextPage: number | null;
+}
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+export function parseRequestUrl(request: Request): URL {
+  try {
+    return new URL(request.url);
+  } catch {
+    return new URL(request.url, "http://localhost");
+  }
+}
+
+export function parseListFilters(url: URL): ResourceListFilters {
+  const params = url.searchParams;
+  const limit = clampLimit(parseIntSafe(params.get("limit")) ?? DEFAULT_LIMIT);
+  const page = Math.max(1, parseIntSafe(params.get("page")) ?? 1);
+  const offset = (page - 1) * limit;
+  return {
+    q: sanitize(params.get("q")),
+    page,
+    limit,
+    offset,
+    id: sanitize(params.get("id")),
+    subjects: parseList(params, "subjects"),
+    topics: parseList(params, "topics"),
+    tags: parseList(params, "tags"),
+    types: parseList(params, "types"),
+    status: parseEnum<ResourceStatus>(params.get("status"), ["draft", "published", "archived"]),
+    visibility: parseEnum<ResourceVisibility>(params.get("visibility"), ["private", "unlisted", "public"]),
+    ownerId: sanitize(params.get("ownerId")),
+  };
+}
+
+export function mapRecordToCard(record: ResourceRecord): ResourceCard {
+  return {
+    id: record.id,
+    title: record.title,
+    description: record.description ?? null,
+    url: record.url,
+    domain: record.domain,
+    faviconUrl: record.favicon_url ?? null,
+    thumbnailUrl: record.thumbnail_url ?? null,
+    resourceType: record.resource_type ?? null,
+    subjects: cleanList(record.subjects),
+    topics: cleanList(record.topics),
+    tags: cleanList(record.tags),
+    instructionalNotes: record.instructional_notes ?? null,
+    status: record.status ?? "draft",
+    visibility: record.visibility ?? "private",
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+  };
+}
+
+export function normalizeResourceUrl(input: string): string | null {
+  const normalized = normalizeInputUrl(input);
+  if (!normalized) {
+    return null;
+  }
+  try {
+    const stripped = stripTrackingParameters(new URL(normalized));
+    stripped.hash = "";
+    if (stripped.pathname === "") {
+      stripped.pathname = "/";
+    }
+    return stripped.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function extractDomain(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+export function buildFaviconUrl(url: string): string {
+  try {
+    const target = new URL(url);
+    const origin = `${target.protocol}//${target.hostname}`;
+    return `https://www.google.com/s2/favicons?domain_url=${encodeURIComponent(origin)}`;
+  } catch {
+    return "";
+  }
+}
+
+export function cleanList(value: string[] | null | undefined): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const unique = new Set(
+    value
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter(Boolean)
+  );
+  return Array.from(unique);
+}
+
+export function sanitizeInputList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const entries = value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+  return Array.from(new Set(entries));
+}
+
+function parseList(params: URLSearchParams, key: string): string[] {
+  const raw = params.getAll(key);
+  const entries = raw
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return Array.from(new Set(entries));
+}
+
+function clampLimit(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(MAX_LIMIT, Math.max(1, Math.trunc(value)));
+}
+
+function parseIntSafe(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function sanitize(value: string | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseEnum<T extends string>(value: string | null, allowed: readonly T[]): T | null {
+  if (!value) return null;
+  const lower = value.trim().toLowerCase();
+  const match = allowed.find((option) => option.toLowerCase() === lower);
+  return match ?? null;
+}

--- a/api/og-scrape.ts
+++ b/api/og-scrape.ts
@@ -5,19 +5,15 @@ import {
   normalizeMethod,
   parseJsonBody,
 } from "./_lib/http";
+import {
+  loadOpenGraphMetadata,
+  normalizeInputUrl,
+  sanitizeEmbed,
+  tryParseUrlSrc,
+} from "./_lib/open-graph";
 
 interface OgScrapePayload {
   url?: string;
-}
-
-interface OgMetadata {
-  title: string | null;
-  description: string | null;
-  siteName: string | null;
-  image: string | null;
-  url: string;
-  providerName: string | null;
-  embedHtml: string | null;
 }
 
 const ALLOWED_EMBED_PATTERNS = [/^https?:\/\//i];
@@ -33,38 +29,23 @@ export default async function handler(request: Request): Promise<Response> {
     return errorResponse(400, "A URL is required");
   }
 
-  const normalizedUrl = normalizeUrl(payload.url);
+  const normalizedUrl = normalizeInputUrl(payload.url);
   if (!normalizedUrl) {
     return errorResponse(400, "The provided URL is invalid");
   }
 
   try {
-    const html = await fetchHtml(normalizedUrl);
-    const og = extractOgMetadata(html, normalizedUrl);
-    const oEmbedUrl = extractOEmbedUrl(html);
+    const { metadata, embedSrc, hadOEmbedHtml } = await loadOpenGraphMetadata(normalizedUrl);
 
-    if (oEmbedUrl) {
-      const oEmbed = await fetchOEmbed(oEmbedUrl);
-      if (oEmbed.title && !og.title) {
-        og.title = oEmbed.title;
-      }
-      if (oEmbed.provider_name && !og.providerName) {
-        og.providerName = oEmbed.provider_name;
-      }
-      if (oEmbed.thumbnail_url && !og.image) {
-        og.image = oEmbed.thumbnail_url;
-      }
-      if (oEmbed.html) {
-        const sanitized = sanitizeEmbed(oEmbed.html);
-        if (!sanitized) {
-          return errorResponse(422, "The embed markup is not supported");
-        }
-        og.embedHtml = sanitized;
-      }
+    if (hadOEmbedHtml && !metadata.embedHtml) {
+      return errorResponse(422, "The embed markup is not supported");
     }
 
-    if (og.embedHtml) {
-      const host = tryParseUrlSrc(og.embedHtml);
+    if (metadata.embedHtml) {
+      if (!sanitizeEmbed(metadata.embedHtml)) {
+        return errorResponse(422, "The embed markup is not supported");
+      }
+      const host = embedSrc ?? tryParseUrlSrc(metadata.embedHtml);
       if (!host) {
         return errorResponse(422, "Unable to validate embed source");
       }
@@ -74,143 +55,10 @@ export default async function handler(request: Request): Promise<Response> {
     }
 
     return jsonResponse({
-      url: og.url,
-      metadata: og,
+      url: metadata.url,
+      metadata,
     });
   } catch (error) {
     return errorResponse(500, error instanceof Error ? error.message : "Failed to load metadata");
   }
-}
-
-function normalizeUrl(input: string): string | null {
-  try {
-    const trimmed = input.trim();
-    if (/^https?:\/\//i.test(trimmed)) {
-      return new URL(trimmed).toString();
-    }
-    if (/^\/\//.test(trimmed)) {
-      return new URL(`https:${trimmed}`).toString();
-    }
-    const sanitized = trimmed.replace(/^\/+/, "");
-    return new URL(`https://${sanitized}`).toString();
-  } catch {
-    return null;
-  }
-}
-
-async function fetchHtml(url: string): Promise<string> {
-  const response = await fetch(url, {
-    headers: {
-      Accept: "text/html,application/xhtml+xml",
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error("Failed to fetch page metadata");
-  }
-
-  return await response.text();
-}
-
-function extractOgMetadata(html: string, url: string): OgMetadata {
-  const meta = createMetaLookup(html);
-  return {
-    title: meta("og:title") ?? meta("twitter:title") ?? extractTitle(html),
-    description:
-      meta("og:description") ??
-      meta("description") ??
-      meta("twitter:description") ??
-      null,
-    siteName: meta("og:site_name") ?? null,
-    image: meta("og:image") ?? meta("twitter:image") ?? null,
-    url,
-    providerName: meta("og:site_name") ?? null,
-    embedHtml: null,
-  };
-}
-
-function extractOEmbedUrl(html: string): string | null {
-  const linkRegex = /<link[^>]+rel=["']alternate["'][^>]*>/gi;
-  let match: RegExpExecArray | null;
-  while ((match = linkRegex.exec(html))) {
-    const tag = match[0];
-    const typeMatch = tag.match(/type=["']([^"']+)["']/i);
-    if (!typeMatch || !/json\+oembed/i.test(typeMatch[1])) {
-      continue;
-    }
-    const hrefMatch = tag.match(/href=["']([^"']+)["']/i);
-    if (hrefMatch) {
-      try {
-        return new URL(hrefMatch[1]).toString();
-      } catch {
-        continue;
-      }
-    }
-  }
-  return null;
-}
-
-async function fetchOEmbed(url: string): Promise<Record<string, any>> {
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-    },
-  });
-  if (!response.ok) {
-    throw new Error("Failed to fetch oEmbed metadata");
-  }
-  return (await response.json()) as Record<string, any>;
-}
-
-function sanitizeEmbed(html: string): string | null {
-  const stripped = html
-    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, "")
-    .replace(/on[a-z]+="[^"]*"/gi, "");
-  if (!/(<iframe|<blockquote)/i.test(stripped)) {
-    return null;
-  }
-  return stripped.trim();
-}
-
-function tryParseUrlSrc(html: string): string | null {
-  const srcMatch = html.match(/src=["']([^"']+)["']/i);
-  if (!srcMatch) {
-    return null;
-  }
-  try {
-    return new URL(srcMatch[1]).toString();
-  } catch {
-    return null;
-  }
-}
-
-function createMetaLookup(html: string): (name: string) => string | null {
-  const metaRegex = /<meta[^>]+>/gi;
-  const entries: Record<string, string> = {};
-  let match: RegExpExecArray | null;
-
-  while ((match = metaRegex.exec(html))) {
-    const tag = match[0];
-    const key =
-      matchAttribute(tag, "property") ||
-      matchAttribute(tag, "name") ||
-      matchAttribute(tag, "itemprop");
-    if (!key) continue;
-    const content = matchAttribute(tag, "content");
-    if (!content) continue;
-    entries[key.toLowerCase()] = content;
-  }
-
-  return (name: string) => entries[name.toLowerCase()] ?? null;
-}
-
-function matchAttribute(tag: string, attribute: string): string | null {
-  const regex = new RegExp(`${attribute}=["']([^"']+)["']`, "i");
-  const match = tag.match(regex);
-  return match ? match[1] : null;
-}
-
-function extractTitle(html: string): string | null {
-  const match = html.match(/<title>([^<]*)<\/title>/i);
-  return match ? match[1].trim() : null;
 }

--- a/api/resources/[id].ts
+++ b/api/resources/[id].ts
@@ -1,0 +1,238 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+  parseJsonBody,
+} from "../_lib/http";
+import { getSupabaseClient } from "../_lib/supabase";
+import {
+  buildFaviconUrl,
+  extractDomain,
+  mapRecordToCard,
+  normalizeResourceUrl,
+  sanitizeInputList,
+} from "../_lib/resource-helpers";
+import { loadOpenGraphMetadata } from "../_lib/open-graph";
+import type { ResourceRecord, ResourceStatus, ResourceVisibility } from "../../types/resources";
+
+interface ResourceUpdatePayload {
+  userId?: string;
+  title?: string | null;
+  description?: string | null;
+  url?: string | null;
+  resourceType?: string | null;
+  subjects?: string[];
+  topics?: string[];
+  tags?: string[];
+  status?: ResourceStatus;
+  visibility?: ResourceVisibility;
+  instructionalNotes?: string | null;
+  thumbnailUrl?: string | null;
+  refreshMetadata?: boolean;
+}
+
+const TABLE_NAME = "educator_resources";
+const VALID_STATUS: ResourceStatus[] = ["draft", "published", "archived"];
+const VALID_VISIBILITY: ResourceVisibility[] = ["private", "unlisted", "public"];
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+  const id = extractIdFromRequest(request);
+
+  if (!id) {
+    return errorResponse(400, "A resource id is required");
+  }
+
+  if (method !== "PUT" && method !== "PATCH") {
+    return methodNotAllowed(["PUT", "PATCH"]);
+  }
+
+  return handleUpdate(request, id);
+}
+
+async function handleUpdate(request: Request, id: string): Promise<Response> {
+  const payload = (await parseJsonBody<ResourceUpdatePayload>(request)) ?? {};
+
+  if (!payload.userId) {
+    return errorResponse(400, "An authenticated userId is required");
+  }
+
+  const supabase = getSupabaseClient();
+  const existingResult = await supabase
+    .from<ResourceRecord>(TABLE_NAME)
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (existingResult.error) {
+    return errorResponse(500, "Failed to load resource");
+  }
+
+  const existing = existingResult.data;
+  if (!existing) {
+    return errorResponse(404, "Resource not found");
+  }
+
+  if (existing.owner_id !== payload.userId) {
+    return errorResponse(403, "You do not have permission to update this resource");
+  }
+
+  const updates: Partial<ResourceRecord> = {};
+  let metadata: Awaited<ReturnType<typeof loadOpenGraphMetadata>> | null = null;
+  let normalizedUrl: string | null = null;
+
+  if (typeof payload.url === "string") {
+    if (payload.url.trim().length === 0) {
+      return errorResponse(422, "A resource URL cannot be empty");
+    }
+    normalizedUrl = normalizeResourceUrl(payload.url);
+    if (!normalizedUrl) {
+      return errorResponse(422, "The provided URL is invalid");
+    }
+
+    if (normalizedUrl !== existing.normalized_url) {
+      const duplicateCheck = await supabase
+        .from<ResourceRecord>(TABLE_NAME)
+        .select("id, owner_id")
+        .eq("normalized_url", normalizedUrl)
+        .maybeSingle();
+
+      if (duplicateCheck.error) {
+        return errorResponse(500, "Failed to verify existing resources");
+      }
+
+      if (duplicateCheck.data && duplicateCheck.data.id !== existing.id) {
+        const isOwner = duplicateCheck.data.owner_id === payload.userId;
+        const message = isOwner
+          ? "You have already submitted this resource"
+          : "This resource already exists in the library";
+        return errorResponse(409, message);
+      }
+    }
+  }
+
+  if (normalizedUrl && normalizedUrl !== existing.normalized_url) {
+    updates.url = normalizedUrl;
+    updates.normalized_url = normalizedUrl;
+    updates.domain = extractDomain(normalizedUrl);
+    metadata = await tryLoadMetadata(normalizedUrl);
+    updates.favicon_url = buildFaviconUrl(normalizedUrl);
+    if (metadata?.metadata.image) {
+      updates.thumbnail_url = metadata.metadata.image;
+    }
+  } else if (payload.refreshMetadata) {
+    metadata = await tryLoadMetadata(existing.normalized_url);
+    if (metadata?.metadata.image) {
+      updates.thumbnail_url = metadata.metadata.image;
+    }
+  }
+
+  if (typeof payload.title === "string") {
+    const trimmed = payload.title.trim();
+    if (trimmed.length > 0) {
+      updates.title = trimmed;
+    }
+  }
+
+  if (payload.description !== undefined) {
+    updates.description = sanitizeNullable(payload.description);
+  }
+
+  if (payload.resourceType !== undefined) {
+    updates.resource_type = payload.resourceType ?? null;
+  }
+
+  if (payload.thumbnailUrl !== undefined) {
+    const trimmed = payload.thumbnailUrl?.trim();
+    updates.thumbnail_url = trimmed && trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (payload.instructionalNotes !== undefined) {
+    updates.instructional_notes = sanitizeNullable(payload.instructionalNotes);
+  }
+
+  if (payload.subjects !== undefined) {
+    updates.subjects = sanitizeInputList(payload.subjects);
+  }
+
+  if (payload.topics !== undefined) {
+    updates.topics = sanitizeInputList(payload.topics);
+  }
+
+  if (payload.tags !== undefined) {
+    updates.tags = sanitizeInputList(payload.tags);
+  }
+
+  if (payload.status) {
+    if (!VALID_STATUS.includes(payload.status)) {
+      return errorResponse(422, "Invalid status value");
+    }
+    updates.status = payload.status;
+  }
+
+  if (payload.visibility) {
+    if (!VALID_VISIBILITY.includes(payload.visibility)) {
+      return errorResponse(422, "Invalid visibility value");
+    }
+    updates.visibility = payload.visibility;
+  }
+
+  if (metadata && !updates.title) {
+    const candidate = metadata.metadata.title;
+    if (candidate && candidate.trim().length > 0) {
+      updates.title = candidate.trim();
+    }
+  }
+
+  if (metadata && updates.description == null) {
+    updates.description = sanitizeNullable(metadata.metadata.description);
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return jsonResponse({ resource: mapRecordToCard(existing) });
+  }
+
+  updates.updated_at = new Date().toISOString();
+
+  const updateResult = await supabase
+    .from<ResourceRecord>(TABLE_NAME)
+    .update(updates)
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (updateResult.error || !updateResult.data) {
+    return errorResponse(500, "Failed to update resource");
+  }
+
+  const resource = mapRecordToCard(updateResult.data);
+  return jsonResponse({ resource });
+}
+
+function extractIdFromRequest(request: Request): string | null {
+  try {
+    const url = new URL(request.url, "http://localhost");
+    const segments = url.pathname.split("/").filter(Boolean);
+    const id = segments.pop();
+    return id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeNullable(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+async function tryLoadMetadata(url: string) {
+  try {
+    return await loadOpenGraphMetadata(url);
+  } catch {
+    return null;
+  }
+}

--- a/api/resources/index.ts
+++ b/api/resources/index.ts
@@ -1,0 +1,257 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+  parseJsonBody,
+} from "../_lib/http";
+import { getSupabaseClient } from "../_lib/supabase";
+import {
+  buildFaviconUrl,
+  extractDomain,
+  mapRecordToCard,
+  normalizeResourceUrl,
+  parseListFilters,
+  parseRequestUrl,
+  sanitizeInputList,
+} from "../_lib/resource-helpers";
+import { loadOpenGraphMetadata } from "../_lib/open-graph";
+import type { ResourceRecord, ResourceStatus, ResourceVisibility } from "../../types/resources";
+
+interface ResourceCreatePayload {
+  userId?: string;
+  title?: string;
+  description?: string | null;
+  url?: string;
+  resourceType?: string | null;
+  subjects?: string[];
+  topics?: string[];
+  tags?: string[];
+  status?: ResourceStatus;
+  visibility?: ResourceVisibility;
+  instructionalNotes?: string | null;
+  thumbnailUrl?: string | null;
+}
+
+const TABLE_NAME = "educator_resources";
+const VALID_STATUS: ResourceStatus[] = ["draft", "published", "archived"];
+const VALID_VISIBILITY: ResourceVisibility[] = ["private", "unlisted", "public"];
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+
+  if (method === "GET") {
+    return handleList(request);
+  }
+
+  if (method === "POST") {
+    return handleCreate(request);
+  }
+
+  return methodNotAllowed(["GET", "POST"]);
+}
+
+async function handleList(request: Request): Promise<Response> {
+  const url = parseRequestUrl(request);
+  const filters = parseListFilters(url);
+  const supabase = getSupabaseClient();
+
+  let query = supabase
+    .from<ResourceRecord>(TABLE_NAME)
+    .select("*", { count: "exact" })
+    .order("created_at", { ascending: false });
+
+  if (filters.ownerId) {
+    query = query.eq("owner_id", filters.ownerId);
+  } else {
+    query = query.eq("visibility", "public").eq("status", "published");
+  }
+
+  if (filters.id) {
+    query = query.eq("id", filters.id);
+  }
+
+  if (filters.status) {
+    query = query.eq("status", filters.status);
+  }
+
+  if (filters.visibility) {
+    query = query.eq("visibility", filters.visibility);
+  }
+
+  if (filters.q) {
+    const escaped = escapeIlike(filters.q);
+    const condition = [`title.ilike.${escaped}`, `description.ilike.${escaped}`, `domain.ilike.${escaped}`];
+    query = query.or(condition.join(","));
+  }
+
+  if (filters.subjects.length > 0) {
+    query = query.overlaps("subjects", filters.subjects);
+  }
+
+  if (filters.topics.length > 0) {
+    query = query.overlaps("topics", filters.topics);
+  }
+
+  if (filters.tags.length > 0) {
+    query = query.overlaps("tags", filters.tags);
+  }
+
+  if (filters.types.length > 0) {
+    query = query.in("resource_type", filters.types);
+  }
+
+  const rangeEnd = filters.offset + filters.limit - 1;
+  query = query.range(filters.offset, rangeEnd);
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    return errorResponse(500, "Failed to load resources");
+  }
+
+  const records: ResourceRecord[] = Array.isArray(data) ? (data as ResourceRecord[]) : [];
+  const items = records.map(mapRecordToCard);
+  const total = count ?? records.length;
+  const hasMore = filters.offset + filters.limit < total;
+
+  return jsonResponse({
+    items,
+    total,
+    page: filters.page,
+    pageSize: filters.limit,
+    hasMore,
+    nextPage: hasMore ? filters.page + 1 : null,
+  });
+}
+
+async function handleCreate(request: Request): Promise<Response> {
+  const payload = (await parseJsonBody<ResourceCreatePayload>(request)) ?? {};
+
+  if (!payload.userId) {
+    return errorResponse(400, "An authenticated userId is required");
+  }
+
+  if (!payload.url || payload.url.trim().length === 0) {
+    return errorResponse(422, "A resource URL is required");
+  }
+
+  const normalizedUrl = normalizeResourceUrl(payload.url);
+  if (!normalizedUrl) {
+    return errorResponse(422, "The provided URL is invalid");
+  }
+
+  const supabase = getSupabaseClient();
+
+  const duplicateCheck = await supabase
+    .from<ResourceRecord>(TABLE_NAME)
+    .select("id, owner_id")
+    .eq("normalized_url", normalizedUrl)
+    .maybeSingle();
+
+  if (duplicateCheck.error) {
+    return errorResponse(500, "Failed to verify existing resources");
+  }
+
+  if (duplicateCheck.data) {
+    const isOwner = duplicateCheck.data.owner_id === payload.userId;
+    const message = isOwner
+      ? "You have already submitted this resource"
+      : "This resource already exists in the library";
+    return errorResponse(409, message);
+  }
+
+  const metadata = await tryLoadMetadata(normalizedUrl);
+  const domain = extractDomain(normalizedUrl);
+  const now = new Date().toISOString();
+  const status = validateStatus(payload.status) ?? "draft";
+  const visibility = validateVisibility(payload.visibility) ?? "private";
+
+  const title = pickString(payload.title, metadata?.metadata.title, domain);
+  const description = pickNullableString(payload.description, metadata?.metadata.description);
+  const thumbnailUrl = payload.thumbnailUrl ?? metadata?.metadata.image ?? null;
+  const faviconUrl = buildFaviconUrl(normalizedUrl);
+  const sanitizedFavicon = faviconUrl && faviconUrl.length > 0 ? faviconUrl : null;
+
+  const insertPayload = {
+    owner_id: payload.userId,
+    title,
+    description,
+    url: normalizedUrl,
+    normalized_url: normalizedUrl,
+    domain,
+    favicon_url: sanitizedFavicon,
+    thumbnail_url: thumbnailUrl,
+    resource_type: payload.resourceType ?? null,
+    subjects: sanitizeInputList(payload.subjects),
+    topics: sanitizeInputList(payload.topics),
+    tags: sanitizeInputList(payload.tags),
+    instructional_notes: pickNullableString(payload.instructionalNotes),
+    status,
+    visibility,
+    created_at: now,
+    updated_at: now,
+  } satisfies Partial<ResourceRecord> & {
+    owner_id: string;
+    title: string;
+    url: string;
+    normalized_url: string;
+    domain: string;
+  };
+
+  const insertResult = await supabase
+    .from<ResourceRecord>(TABLE_NAME)
+    .insert(insertPayload)
+    .select("*")
+    .single();
+
+  if (insertResult.error || !insertResult.data) {
+    return errorResponse(500, "Failed to create resource");
+  }
+
+  const resource = mapRecordToCard(insertResult.data);
+  return jsonResponse({ resource }, 201);
+}
+
+function escapeIlike(value: string): string {
+  return `%${value.replace(/%/g, "\\%").replace(/_/g, "\\_")}%`;
+}
+
+function pickString(...values: Array<string | null | undefined>): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return "Untitled resource";
+}
+
+function pickNullableString(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  }
+  return null;
+}
+
+function validateStatus(status: ResourceStatus | undefined): ResourceStatus | null {
+  if (!status) return null;
+  return VALID_STATUS.includes(status) ? status : null;
+}
+
+function validateVisibility(visibility: ResourceVisibility | undefined): ResourceVisibility | null {
+  if (!visibility) return null;
+  return VALID_VISIBILITY.includes(visibility) ? visibility : null;
+}
+
+async function tryLoadMetadata(url: string) {
+  try {
+    return await loadOpenGraphMetadata(url);
+  } catch {
+    return null;
+  }
+}

--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -19,6 +19,9 @@ import BuilderLessonPlan from '@/pages/BuilderLessonPlan';
 import BuilderLessonPlanDetail from '@/pages/BuilderLessonPlanDetail';
 import Auth from '@/pages/Auth';
 import Account from '@/pages/Account';
+import AccountResources from '@/pages/AccountResources';
+import AccountResourceNew from '@/pages/AccountResourceNew';
+import AccountResourceEdit from '@/pages/AccountResourceEdit';
 import NotFound from '@/pages/NotFound';
 import Sitemap from '@/pages/Sitemap';
 import Navigation from '@/components/Navigation';
@@ -78,6 +81,9 @@ export const LocalizedRoutes = () => {
       <Route path="/teacher-diary/:slug" element={<RouteWrapper><TeacherDiaryEntry /></RouteWrapper>} />
       <Route path="/auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
       <Route path="/account" element={<RouteWrapper><Account /></RouteWrapper>} />
+      <Route path="/account/resources" element={<RouteWrapper><AccountResources /></RouteWrapper>} />
+      <Route path="/account/resources/new" element={<RouteWrapper><AccountResourceNew /></RouteWrapper>} />
+      <Route path="/account/resources/:id" element={<RouteWrapper><AccountResourceEdit /></RouteWrapper>} />
       <Route path="/sitemap" element={<RouteWrapper><Sitemap /></RouteWrapper>} />
       
       {/* Localized routes for Albanian and Vietnamese */}
@@ -103,6 +109,9 @@ export const LocalizedRoutes = () => {
         <Route path="teacher-diary/:slug" element={<RouteWrapper><TeacherDiaryEntry /></RouteWrapper>} />
         <Route path="auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
         <Route path="account" element={<RouteWrapper><Account /></RouteWrapper>} />
+        <Route path="account/resources" element={<RouteWrapper><AccountResources /></RouteWrapper>} />
+        <Route path="account/resources/new" element={<RouteWrapper><AccountResourceNew /></RouteWrapper>} />
+        <Route path="account/resources/:id" element={<RouteWrapper><AccountResourceEdit /></RouteWrapper>} />
         <Route path="sitemap" element={<RouteWrapper><Sitemap /></RouteWrapper>} />
       </Route>
       

--- a/src/components/account/resources/AccountResourceForm.tsx
+++ b/src/components/account/resources/AccountResourceForm.tsx
@@ -1,0 +1,373 @@
+import { useEffect, useMemo, useState, type ReactNode, type KeyboardEvent } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm, Controller } from "react-hook-form";
+
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useToast } from "@/hooks/use-toast";
+import { useLanguage } from "@/contexts/LanguageContext";
+import type { ResourceCard, ResourceStatus, ResourceVisibility } from "../../../../types/resources";
+import {
+  ResourceApiError,
+  createResource,
+  updateResource,
+  type ResourceCreateRequest,
+  type ResourceUpdateRequest,
+} from "@/lib/resources-api";
+
+interface AccountResourceFormProps {
+  userId: string;
+  resource?: ResourceCard | null;
+  onSuccess?: (resource: ResourceCard) => void;
+}
+
+interface FormValues {
+  title: string;
+  url: string;
+  description: string;
+  resourceType: string;
+  subjects: string[];
+  topics: string[];
+  tags: string[];
+  status: ResourceStatus;
+  visibility: ResourceVisibility;
+  instructionalNotes: string;
+  thumbnailUrl: string;
+}
+
+const STATUS_OPTIONS: ResourceStatus[] = ["draft", "published", "archived"];
+const VISIBILITY_OPTIONS: ResourceVisibility[] = ["private", "unlisted", "public"];
+const SUBJECT_SUGGESTIONS = ["Math", "Science", "English", "ICT", "STEAM"];
+const TOPIC_SUGGESTIONS = ["STEM", "Assessment", "Differentiation", "Project-Based Learning"];
+const TAG_SUGGESTIONS = ["ai", "worksheet", "video", "interactive", "free"];
+
+export function AccountResourceForm({ userId, resource, onSuccess }: AccountResourceFormProps) {
+  const { toast } = useToast();
+  const { t } = useLanguage();
+  const queryClient = useQueryClient();
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const defaultValues = useMemo<FormValues>(() => ({
+    title: resource?.title ?? "",
+    url: resource?.url ?? "",
+    description: resource?.description ?? "",
+    resourceType: resource?.resourceType ?? "",
+    subjects: resource?.subjects ?? [],
+    topics: resource?.topics ?? [],
+    tags: resource?.tags ?? [],
+    status: resource?.status ?? "draft",
+    visibility: resource?.visibility ?? "private",
+    instructionalNotes: resource?.instructionalNotes ?? "",
+    thumbnailUrl: resource?.thumbnailUrl ?? "",
+  }), [resource]);
+
+  const form = useForm<FormValues>({
+    defaultValues,
+  });
+
+  useEffect(() => {
+    form.reset(defaultValues);
+  }, [defaultValues, form]);
+
+  const isEdit = Boolean(resource);
+
+  const mutation = useMutation({
+    mutationFn: async (values: FormValues) => {
+      const basePayload = {
+        userId,
+        title: values.title,
+        description: values.description || null,
+        resourceType: values.resourceType || null,
+        subjects: values.subjects,
+        topics: values.topics,
+        tags: values.tags,
+        status: values.status,
+        visibility: values.visibility,
+        instructionalNotes: values.instructionalNotes || null,
+        thumbnailUrl: values.thumbnailUrl || null,
+      } satisfies Omit<ResourceCreateRequest, "url"> & ResourceUpdateRequest;
+
+      if (isEdit && resource) {
+        const updatePayload: ResourceUpdateRequest = {
+          ...basePayload,
+          url: values.url || resource.url,
+        };
+        return await updateResource(resource.id, updatePayload);
+      }
+
+      const createPayload: ResourceCreateRequest = {
+        ...basePayload,
+        url: values.url,
+      };
+      return await createResource(createPayload);
+    },
+    onSuccess: (result) => {
+      setFormError(null);
+      queryClient.invalidateQueries({ queryKey: ["account-resources", userId] });
+      toast({
+        title: isEdit ? t.account.resources.toast.updated : t.account.resources.toast.created,
+        variant: "default",
+      });
+      onSuccess?.(result);
+    },
+    onError: (error) => {
+      const message = error instanceof ResourceApiError ? error.message : t.common.error;
+      setFormError(message);
+      toast({ title: t.common.error, description: message, variant: "destructive" });
+    },
+  });
+
+  const handleSubmit = form.handleSubmit((values) => {
+    mutation.mutate(values);
+  });
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardTitle>
+            {isEdit ? t.account.resources.form.editTitle : t.account.resources.form.title}
+          </CardTitle>
+          <CardDescription>
+            {isEdit ? t.account.resources.form.editDescription : t.account.resources.form.description}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {formError && (
+            <Alert variant="destructive">
+              <AlertTitle>{t.common.error}</AlertTitle>
+              <AlertDescription>{formError}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <FormField label={t.account.resources.form.titleLabel}>
+              <Input
+                {...form.register("title", { required: true })}
+                placeholder={t.account.resources.form.titlePlaceholder}
+              />
+            </FormField>
+            <FormField label={t.account.resources.form.urlLabel}>
+              <Input
+                {...form.register("url", { required: !isEdit })}
+                placeholder="https://"
+                type="url"
+              />
+            </FormField>
+          </div>
+
+          <FormField label={t.account.resources.form.descriptionLabel}>
+            <Textarea
+              {...form.register("description")}
+              rows={3}
+              placeholder={t.account.resources.form.descriptionPlaceholder}
+            />
+          </FormField>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <FormField label={t.account.resources.form.typeLabel}>
+              <Input {...form.register("resourceType")} placeholder={t.account.resources.form.typePlaceholder} />
+            </FormField>
+            <FormField label={t.account.resources.form.statusLabel}>
+              <Controller
+                control={form.control}
+                name="status"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder={t.account.resources.form.statusPlaceholder} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {STATUS_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {t.account.resources.status[option] ?? option}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </FormField>
+            <FormField label={t.account.resources.form.visibilityLabel}>
+              <Controller
+                control={form.control}
+                name="visibility"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder={t.account.resources.form.visibilityPlaceholder} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {VISIBILITY_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {t.account.resources.visibility[option] ?? option}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </FormField>
+          </div>
+
+          <Controller
+            control={form.control}
+            name="subjects"
+            render={({ field }) => (
+              <TokenField
+                label={t.account.resources.form.subjectsLabel}
+                placeholder={t.account.resources.form.subjectsPlaceholder}
+                value={field.value}
+                onChange={field.onChange}
+                suggestions={SUBJECT_SUGGESTIONS}
+              />
+            )}
+          />
+
+          <Controller
+            control={form.control}
+            name="topics"
+            render={({ field }) => (
+              <TokenField
+                label={t.account.resources.form.topicsLabel}
+                placeholder={t.account.resources.form.topicsPlaceholder}
+                value={field.value}
+                onChange={field.onChange}
+                suggestions={TOPIC_SUGGESTIONS}
+              />
+            )}
+          />
+
+          <Controller
+            control={form.control}
+            name="tags"
+            render={({ field }) => (
+              <TokenField
+                label={t.account.resources.form.tagsLabel}
+                placeholder={t.account.resources.form.tagsPlaceholder}
+                value={field.value}
+                onChange={field.onChange}
+                suggestions={TAG_SUGGESTIONS}
+              />
+            )}
+          />
+
+          <FormField label={t.account.resources.form.thumbnailLabel}>
+            <Input {...form.register("thumbnailUrl")} placeholder={t.account.resources.form.thumbnailPlaceholder} />
+          </FormField>
+
+          <FormField label={t.account.resources.form.notesLabel}>
+            <Textarea
+              {...form.register("instructionalNotes")}
+              rows={4}
+              placeholder={t.account.resources.form.notesPlaceholder}
+            />
+          </FormField>
+        </CardContent>
+        <CardFooter className="flex items-center justify-end gap-3">
+          <Button variant="outline" type="button" onClick={() => form.reset(defaultValues)} disabled={mutation.isPending}>
+            {t.common.cancel}
+          </Button>
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending ? t.common.loading : isEdit ? t.common.save : t.account.resources.form.submit}
+          </Button>
+        </CardFooter>
+      </Card>
+    </form>
+  );
+}
+
+interface TokenFieldProps {
+  label: string;
+  placeholder: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+  suggestions?: string[];
+}
+
+function TokenField({ label, placeholder, value, onChange, suggestions = [] }: TokenFieldProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  const handleAdd = (token: string) => {
+    const trimmed = token.trim();
+    if (!trimmed) return;
+    if (value.includes(trimmed)) {
+      setInputValue("");
+      return;
+    }
+    onChange([...value, trimmed]);
+    setInputValue("");
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      handleAdd(inputValue);
+    } else if (event.key === "Backspace" && inputValue.length === 0 && value.length > 0) {
+      onChange(value.slice(0, -1));
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      <div className="flex flex-wrap gap-2 rounded-md border border-input p-2">
+        {value.map((item) => (
+          <Badge key={item} variant="secondary" className="flex items-center gap-1">
+            {item}
+            <button
+              type="button"
+              className="text-xs"
+              aria-label={`Remove ${item}`}
+              onClick={() => onChange(value.filter((token) => token !== item))}
+            >
+              ×
+            </button>
+          </Badge>
+        ))}
+        <Input
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => handleAdd(inputValue)}
+          placeholder={placeholder}
+          className="border-0 shadow-none focus-visible:ring-0"
+        />
+      </div>
+      {suggestions.length > 0 && (
+        <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+          {suggestions.map((suggestion) => (
+            <button
+              key={suggestion}
+              type="button"
+              onClick={() => handleAdd(suggestion)}
+              className="rounded-full border border-dashed border-input px-3 py-1 hover:border-primary hover:text-primary"
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface FormFieldProps {
+  label: string;
+  children: ReactNode;
+}
+
+function FormField({ label, children }: FormFieldProps) {
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      {children}
+    </div>
+  );
+}

--- a/src/components/account/resources/AccountResourcesList.tsx
+++ b/src/components/account/resources/AccountResourcesList.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/hooks/use-toast";
+import { useLanguage } from "@/contexts/LanguageContext";
+import type { ResourceCard, ResourceStatus, ResourceVisibility } from "../../../../types/resources";
+import { searchResources, updateResource } from "@/lib/resources-api";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+
+interface AccountResourcesListProps {
+  userId: string;
+  onEdit?: (resource: ResourceCard) => void;
+}
+
+const STATUS_OPTIONS: ResourceStatus[] = ["draft", "published", "archived"];
+const VISIBILITY_OPTIONS: ResourceVisibility[] = ["private", "unlisted", "public"];
+
+export function AccountResourcesList({ userId, onEdit }: AccountResourcesListProps) {
+  const { t, language } = useLanguage();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(1);
+
+  const query = useQuery({
+    queryKey: ["account-resources", userId, page],
+    queryFn: async () => {
+      return await searchResources({ ownerId: userId, page, limit: 10 });
+    },
+    enabled: Boolean(userId),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ id, status, visibility }: { id: string; status?: ResourceStatus; visibility?: ResourceVisibility }) => {
+      return await updateResource(id, {
+        userId,
+        status,
+        visibility,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["account-resources", userId] });
+      toast({ title: t.account.resources.toast.updated });
+    },
+    onError: () => {
+      toast({ title: t.common.error, description: t.account.resources.toast.updateError, variant: "destructive" });
+    },
+  });
+
+  const resources = query.data?.items ?? [];
+  const isLoading = query.isLoading;
+
+  return (
+    <Card className="shadow-sm">
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <CardTitle>{t.account.resources.listTitle}</CardTitle>
+          <CardDescription>{t.account.resources.listDescription}</CardDescription>
+        </div>
+        <Button asChild>
+          <Link to={getLocalizedPath("/account/resources/new", language)}>{t.account.resources.newCta}</Link>
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-4">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        ) : resources.length === 0 ? (
+          <div className="space-y-4 rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+            <p>{t.account.resources.empty}</p>
+            <Button asChild variant="secondary">
+              <Link to={getLocalizedPath("/account/resources/new", language)}>{t.account.resources.emptyCta}</Link>
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {resources.map((resource) => (
+              <div key={resource.id} className="rounded-lg border p-4 shadow-sm">
+                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div className="space-y-1">
+                    <h3 className="text-lg font-semibold">{resource.title}</h3>
+                    <p className="text-sm text-muted-foreground">{resource.domain}</p>
+                    <div className="flex flex-wrap gap-2 pt-2 text-xs text-muted-foreground">
+                      {resource.subjects.map((subject) => (
+                        <Badge key={subject} variant="secondary">
+                          {subject}
+                        </Badge>
+                      ))}
+                      {resource.tags.map((tag) => (
+                        <Badge key={tag} variant="outline">
+                          #{tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-start gap-3 md:items-end">
+                    <div className="flex gap-3">
+                      <Select
+                        value={resource.status}
+                        onValueChange={(value: ResourceStatus) =>
+                          updateMutation.mutate({ id: resource.id, status: value })
+                        }
+                      >
+                        <SelectTrigger className="w-[150px]">
+                          <SelectValue placeholder={t.account.resources.statusLabel} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {STATUS_OPTIONS.map((option) => (
+                            <SelectItem key={option} value={option}>
+                              {t.account.resources.status[option] ?? option}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        value={resource.visibility}
+                        onValueChange={(value: ResourceVisibility) =>
+                          updateMutation.mutate({ id: resource.id, visibility: value })
+                        }
+                      >
+                        <SelectTrigger className="w-[150px]">
+                          <SelectValue placeholder={t.account.resources.visibilityLabel} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {VISIBILITY_OPTIONS.map((option) => (
+                            <SelectItem key={option} value={option}>
+                              {t.account.resources.visibility[option] ?? option}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button asChild variant="outline" size="sm">
+                        <a href={resource.url} target="_blank" rel="noreferrer">
+                          {t.account.resources.viewLink}
+                        </a>
+                      </Button>
+                      <Button
+                        size="sm"
+                        onClick={() => (onEdit ? onEdit(resource) : navigateToEdit(resource.id, language))}
+                      >
+                        {t.common.edit}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+            {query.data && query.data.total > resources.length && (
+              <div className="flex items-center justify-between pt-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page === 1}
+                  onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+                >
+                  {t.common.previous}
+                </Button>
+                <span className="text-sm text-muted-foreground">
+                  {t.account.resources.pagination.replace("{current}", String(page)).replace(
+                    "{total}",
+                    Math.max(1, Math.ceil((query.data?.total ?? 0) / (query.data?.pageSize ?? 1))).toString()
+                  )}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!query.data?.hasMore}
+                  onClick={() => setPage((prev) => prev + 1)}
+                >
+                  {t.common.next}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function navigateToEdit(id: string, language: string) {
+  const path = getLocalizedPath(`/account/resources/${id}`, language);
+  window.location.href = path;
+}

--- a/src/hooks/useRequireAuth.ts
+++ b/src/hooks/useRequireAuth.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import type { User } from "@supabase/supabase-js";
+import { useNavigate } from "react-router-dom";
+
+import { supabase } from "@/integrations/supabase/client";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+
+export function useRequireAuth() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+  const { language } = useLanguage();
+
+  useEffect(() => {
+    let isMounted = true;
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (!isMounted) return;
+      if (!user) {
+        navigate(getLocalizedPath("/auth", language));
+      } else {
+        setUser(user);
+      }
+      setLoading(false);
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [navigate, language]);
+
+  useEffect(() => {
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!session?.user) {
+        navigate(getLocalizedPath("/auth", language));
+      } else {
+        setUser(session.user);
+      }
+    });
+
+    return () => {
+      data.subscription.unsubscribe();
+    };
+  }, [navigate, language]);
+
+  return { user, loading };
+}

--- a/src/lib/resources-api.ts
+++ b/src/lib/resources-api.ts
@@ -1,0 +1,125 @@
+import type {
+  ResourceCard,
+  ResourceListResponse,
+  ResourceStatus,
+  ResourceVisibility,
+} from "../../types/resources";
+
+export class ResourceApiError extends Error {
+  constructor(public status: number, message: string, public payload?: unknown) {
+    super(message);
+    this.name = "ResourceApiError";
+  }
+}
+
+export interface ResourceSearchParams {
+  q?: string;
+  page?: number;
+  limit?: number;
+  id?: string;
+  subjects?: string[];
+  topics?: string[];
+  tags?: string[];
+  types?: string[];
+  status?: ResourceStatus;
+  visibility?: ResourceVisibility;
+  ownerId?: string;
+}
+
+export interface ResourceCreateRequest {
+  userId: string;
+  title?: string;
+  description?: string | null;
+  url: string;
+  resourceType?: string | null;
+  subjects?: string[];
+  topics?: string[];
+  tags?: string[];
+  status?: ResourceStatus;
+  visibility?: ResourceVisibility;
+  instructionalNotes?: string | null;
+  thumbnailUrl?: string | null;
+}
+
+export interface ResourceUpdateRequest {
+  userId: string;
+  title?: string | null;
+  description?: string | null;
+  url?: string | null;
+  resourceType?: string | null;
+  subjects?: string[];
+  topics?: string[];
+  tags?: string[];
+  status?: ResourceStatus;
+  visibility?: ResourceVisibility;
+  instructionalNotes?: string | null;
+  thumbnailUrl?: string | null;
+  refreshMetadata?: boolean;
+}
+
+interface ResourceResponsePayload {
+  resource: ResourceCard;
+}
+
+export async function searchResources(params: ResourceSearchParams = {}): Promise<ResourceListResponse> {
+  const query = new URLSearchParams();
+
+  if (params.q) query.set("q", params.q);
+  if (params.page) query.set("page", String(params.page));
+  if (params.limit) query.set("limit", String(params.limit));
+  if (params.id) query.set("id", params.id);
+  if (params.status) query.set("status", params.status);
+  if (params.visibility) query.set("visibility", params.visibility);
+  if (params.ownerId) query.set("ownerId", params.ownerId);
+
+  appendList(query, "subjects", params.subjects);
+  appendList(query, "topics", params.topics);
+  appendList(query, "tags", params.tags);
+  appendList(query, "types", params.types);
+
+  return request<ResourceListResponse>(`/api/resources${query.toString() ? `?${query.toString()}` : ""}`);
+}
+
+export async function createResource(payload: ResourceCreateRequest): Promise<ResourceCard> {
+  const response = await request<ResourceResponsePayload>("/api/resources", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return response.resource;
+}
+
+export async function updateResource(id: string, payload: ResourceUpdateRequest): Promise<ResourceCard> {
+  const response = await request<ResourceResponsePayload>(`/api/resources/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return response.resource;
+}
+
+export async function getResource(id: string, ownerId: string): Promise<ResourceCard | null> {
+  const result = await searchResources({ id, ownerId, limit: 1, page: 1 });
+  return result.items[0] ?? null;
+}
+
+async function request<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, init);
+  const contentType = response.headers.get("Content-Type");
+  const isJson = contentType ? /application\/json/i.test(contentType) : false;
+  const data = isJson ? await response.json().catch(() => ({})) : null;
+
+  if (!response.ok) {
+    const message = data && typeof data === "object" && "error" in data && typeof (data as Record<string, unknown>).error === "string"
+      ? ((data as Record<string, unknown>).error as string)
+      : response.statusText || "Request failed";
+    throw new ResourceApiError(response.status, message, data ?? undefined);
+  }
+
+  return (data as T) ?? ({} as T);
+}
+
+function appendList(params: URLSearchParams, key: string, values?: string[]) {
+  if (!values || values.length === 0) return;
+  params.append(key, values.join(","));
+}

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { User as SupabaseUser } from "@supabase/supabase-js";
 import { format } from "date-fns";
@@ -514,6 +514,11 @@ const Account = () => {
               </div>
             </div>
             <div className="flex flex-wrap gap-3">
+              <Button asChild variant="secondary" className="gap-2">
+                <Link to={getLocalizedPath("/account/resources", language)}>
+                  {t.account.resources.manageCta}
+                </Link>
+              </Button>
               <Button variant="outline" className="gap-2" onClick={() => fileInputRef.current?.click()}>
                 <Camera className="h-4 w-4" />
                 {t.account.image.changeButton}

--- a/src/pages/AccountResourceEdit.tsx
+++ b/src/pages/AccountResourceEdit.tsx
@@ -1,0 +1,72 @@
+import { Navigate, useParams, useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+
+import { SEO } from "@/components/SEO";
+import { AccountResourceForm } from "@/components/account/resources/AccountResourceForm";
+import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+import { getResource } from "@/lib/resources-api";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const AccountResourceEdit = () => {
+  const { id } = useParams<{ id: string }>();
+  const { user, loading } = useRequireAuth();
+  const { t, language } = useLanguage();
+  const navigate = useNavigate();
+
+  const resourceQuery = useQuery({
+    queryKey: ["account-resource", user?.id, id],
+    enabled: Boolean(user?.id && id),
+    queryFn: async () => {
+      if (!user?.id || !id) return null;
+      return await getResource(id, user.id);
+    },
+  });
+
+  if (loading || resourceQuery.isLoading) {
+    return (
+      <div className="container space-y-6 py-10">
+        <Skeleton className="h-12 w-1/3" />
+        <Skeleton className="h-[420px] w-full" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to={getLocalizedPath("/auth", language)} replace />;
+  }
+
+  if (!id) {
+    return <Navigate to={getLocalizedPath("/account/resources", language)} replace />;
+  }
+
+  if (!resourceQuery.data) {
+    return <Navigate to={getLocalizedPath("/account/resources", language)} replace />;
+  }
+
+  return (
+    <div className="min-h-screen bg-muted/10 pb-16">
+      <SEO
+        title={t.account.resources.edit.seo.title.replace("{title}", resourceQuery.data.title)}
+        description={t.account.resources.edit.seo.description}
+        canonicalUrl={t.account.resources.edit.seo.canonical}
+      />
+      <div className="container space-y-6 py-10">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold tracking-tight">{t.account.resources.edit.heading}</h1>
+          <p className="text-muted-foreground">{t.account.resources.edit.subheading}</p>
+        </div>
+        <AccountResourceForm
+          userId={user.id}
+          resource={resourceQuery.data}
+          onSuccess={(updated) => {
+            navigate(getLocalizedPath(`/account/resources/${updated.id}`, language));
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AccountResourceEdit;

--- a/src/pages/AccountResourceNew.tsx
+++ b/src/pages/AccountResourceNew.tsx
@@ -1,0 +1,52 @@
+import { Navigate, useNavigate } from "react-router-dom";
+
+import { SEO } from "@/components/SEO";
+import { AccountResourceForm } from "@/components/account/resources/AccountResourceForm";
+import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+
+const AccountResourceNew = () => {
+  const { user, loading } = useRequireAuth();
+  const { t, language } = useLanguage();
+  const navigate = useNavigate();
+
+  if (loading) {
+    return (
+      <div className="container space-y-6 py-10">
+        <div className="grid gap-4">
+          <div className="h-12 animate-pulse rounded-md bg-muted" />
+          <div className="h-[420px] animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to={getLocalizedPath("/auth", language)} replace />;
+  }
+
+  return (
+    <div className="min-h-screen bg-muted/10 pb-16">
+      <SEO
+        title={t.account.resources.new.seo.title}
+        description={t.account.resources.new.seo.description}
+        canonicalUrl={t.account.resources.new.seo.canonical}
+      />
+      <div className="container space-y-6 py-10">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold tracking-tight">{t.account.resources.new.heading}</h1>
+          <p className="text-muted-foreground">{t.account.resources.new.subheading}</p>
+        </div>
+        <AccountResourceForm
+          userId={user.id}
+          onSuccess={(resource) => {
+            navigate(getLocalizedPath(`/account/resources/${resource.id}`, language));
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AccountResourceNew;

--- a/src/pages/AccountResources.tsx
+++ b/src/pages/AccountResources.tsx
@@ -1,0 +1,47 @@
+import { Navigate } from "react-router-dom";
+
+import { SEO } from "@/components/SEO";
+import { AccountResourcesList } from "@/components/account/resources/AccountResourcesList";
+import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+
+const AccountResources = () => {
+  const { user, loading } = useRequireAuth();
+  const { t, language } = useLanguage();
+
+  if (loading) {
+    return (
+      <div className="container space-y-6 py-10">
+        <div className="grid gap-4">
+          <div className="h-12 animate-pulse rounded-md bg-muted" />
+          <div className="h-48 animate-pulse rounded-md bg-muted" />
+          <div className="h-48 animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to={getLocalizedPath("/auth", language)} replace />;
+  }
+
+  return (
+    <div className="min-h-screen bg-muted/10 pb-16">
+      <SEO
+        title={t.account.resources.seo.title}
+        description={t.account.resources.seo.description}
+        canonicalUrl={t.account.resources.seo.canonical}
+      />
+      <div className="container space-y-8 py-10">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold tracking-tight">{t.account.resources.heading}</h1>
+          <p className="text-muted-foreground">{t.account.resources.subheading}</p>
+        </div>
+        <AccountResourcesList userId={user.id} />
+      </div>
+    </div>
+  );
+};
+
+export default AccountResources;

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1299,6 +1299,86 @@ export const en = {
       lastLogin: "Last sign in",
       neverLoggedIn: "No sign-in recorded yet"
     },
+    resources: {
+      manageCta: "Manage resources",
+      heading: "My teaching resources",
+      subheading: "Update the links and materials you've shared with the community.",
+      seo: {
+        title: "My Resources | SchoolTech Hub",
+        description: "Review, update, and share your classroom resources from a single dashboard.",
+        canonical: "https://schooltechhub.com/account/resources"
+      },
+      listTitle: "Your resources",
+      listDescription: "Adjust visibility, update metadata, or add a new resource for peers.",
+      newCta: "Submit resource",
+      empty: "You haven't added any resources yet.",
+      emptyCta: "Add your first resource",
+      viewLink: "Open resource",
+      statusLabel: "Status",
+      visibilityLabel: "Visibility",
+      pagination: "Page {current} of {total}",
+      toast: {
+        created: "Resource submitted",
+        updated: "Resource updated",
+        updateError: "We couldn't update that resource"
+      },
+      status: {
+        draft: "Draft",
+        published: "Published",
+        archived: "Archived"
+      },
+      visibility: {
+        private: "Private",
+        unlisted: "Unlisted",
+        public: "Public"
+      },
+      form: {
+        title: "Submit a resource",
+        editTitle: "Update resource",
+        description: "Share resources you trust with fellow educators.",
+        editDescription: "Keep the details, metadata, and notes accurate for this resource.",
+        titleLabel: "Title",
+        titlePlaceholder: "Resource name",
+        urlLabel: "Link",
+        descriptionLabel: "Summary",
+        descriptionPlaceholder: "What does this resource help educators accomplish?",
+        typeLabel: "Resource type",
+        typePlaceholder: "e.g. Video, Template, Article",
+        statusLabel: "Status",
+        statusPlaceholder: "Select status",
+        visibilityLabel: "Visibility",
+        visibilityPlaceholder: "Select visibility",
+        subjectsLabel: "Subjects",
+        subjectsPlaceholder: "Add a subject and press enter",
+        topicsLabel: "Topics",
+        topicsPlaceholder: "Add a topic and press enter",
+        tagsLabel: "Tags",
+        tagsPlaceholder: "Add tags to help discovery",
+        thumbnailLabel: "Thumbnail image",
+        thumbnailPlaceholder: "https://example.com/preview.jpg",
+        notesLabel: "Instructional notes",
+        notesPlaceholder: "Explain how you use this resource in class",
+        submit: "Save resource"
+      },
+      new: {
+        heading: "Submit a new resource",
+        subheading: "Share a classroom-ready resource with other educators.",
+        seo: {
+          title: "Submit Resource | SchoolTech Hub",
+          description: "Add a new classroom resource for teachers to discover.",
+          canonical: "https://schooltechhub.com/account/resources/new"
+        }
+      },
+      edit: {
+        heading: "Edit resource",
+        subheading: "Keep resource details accurate before publishing.",
+        seo: {
+          title: "Edit {title} | SchoolTech Hub",
+          description: "Update the metadata and notes for this teaching resource.",
+          canonical: "https://schooltechhub.com/account/resources"
+        }
+      }
+    },
     support: {
       title: "Need help?",
       description: "Our team is here to support any account changes.",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -1299,6 +1299,86 @@ export const sq = {
       lastLogin: "Hyrja e fundit",
       neverLoggedIn: "Nuk ka ende hyrje të regjistruar"
     },
+    resources: {
+      manageCta: "Menaxho burimet",
+      heading: "Burimet e mia mësimore",
+      subheading: "Përditësoni lidhjet dhe materialet që keni shpërndarë.",
+      seo: {
+        title: "Burimet e mia | SchoolTech Hub",
+        description: "Rishiko dhe përditëso burimet që ke dërguar për komunitetin e mësuesve.",
+        canonical: "https://schooltechhub.com/account/resources"
+      },
+      listTitle: "Burimet tuaja",
+      listDescription: "Rregulloni dukshmërinë, statusin dhe shtoni burime të reja për kolegët.",
+      newCta: "Shto burim",
+      empty: "Ende nuk keni shtuar burime.",
+      emptyCta: "Shto burimin e parë",
+      viewLink: "Hap lidhjen",
+      statusLabel: "Statusi",
+      visibilityLabel: "Dukshmëria",
+      pagination: "Faqja {current} nga {total}",
+      toast: {
+        created: "Burimi u dërgua",
+        updated: "Burimi u përditësua",
+        updateError: "Nuk mundëm të përditësojmë burimin"
+      },
+      status: {
+        draft: "Draft",
+        published: "Publikuar",
+        archived: "Arkivuar"
+      },
+      visibility: {
+        private: "Private",
+        unlisted: "I fshehur",
+        public: "Publike"
+      },
+      form: {
+        title: "Dërgo burim",
+        editTitle: "Përditëso burimin",
+        description: "Ndani burime të besuara me kolegët tuaj.",
+        editDescription: "Përditësoni detajet dhe shënimet për këtë burim.",
+        titleLabel: "Titulli",
+        titlePlaceholder: "Emri i burimit",
+        urlLabel: "Lidhja",
+        descriptionLabel: "Përshkrim i shkurtër",
+        descriptionPlaceholder: "Si i ndihmon ky burim mësuesit?",
+        typeLabel: "Lloji i burimit",
+        typePlaceholder: "p.sh. Video, Model, Artikull",
+        statusLabel: "Statusi",
+        statusPlaceholder: "Zgjidh statusin",
+        visibilityLabel: "Dukshmëria",
+        visibilityPlaceholder: "Zgjidh dukshmërinë",
+        subjectsLabel: "Lëndët",
+        subjectsPlaceholder: "Shtoni një lëndë dhe shtypni Enter",
+        topicsLabel: "Tema",
+        topicsPlaceholder: "Shtoni një temë dhe shtypni Enter",
+        tagsLabel: "Etiketat",
+        tagsPlaceholder: "Shtoni etiketa për kërkim më të lehtë",
+        thumbnailLabel: "Figura paraprake",
+        thumbnailPlaceholder: "https://example.com/preview.jpg",
+        notesLabel: "Shënime didaktike",
+        notesPlaceholder: "Shpjegoni si e përdorni këtë burim",
+        submit: "Ruaj burimin"
+      },
+      new: {
+        heading: "Shto një burim të ri",
+        subheading: "Ndihmo mësuesit e tjerë me materiale gati për klasën.",
+        seo: {
+          title: "Shto burim | SchoolTech Hub",
+          description: "Dërgo një burim të ri që mësuesit të mund ta zbulojnë.",
+          canonical: "https://schooltechhub.com/account/resources/new"
+        }
+      },
+      edit: {
+        heading: "Redakto burimin",
+        subheading: "Sigurohu që informacioni është i saktë para se të shpërndash.",
+        seo: {
+          title: "Redakto {title} | SchoolTech Hub",
+          description: "Përditëso metadata dhe shënimet për këtë burim mësimor.",
+          canonical: "https://schooltechhub.com/account/resources"
+        }
+      }
+    },
     support: {
       title: "Keni nevojë për ndihmë?",
       description: "Ekipi ynë është gati të ndihmojë për çdo ndryshim në llogari.",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -1299,6 +1299,86 @@ export const vi = {
       lastLogin: "Lần đăng nhập gần nhất",
       neverLoggedIn: "Chưa có lần đăng nhập nào"
     },
+    resources: {
+      manageCta: "Quản lý tài nguyên",
+      heading: "Tài nguyên giảng dạy của tôi",
+      subheading: "Theo dõi và cập nhật các liên kết bạn đã chia sẻ.",
+      seo: {
+        title: "Tài nguyên của tôi | SchoolTech Hub",
+        description: "Xem và chỉnh sửa nhanh mọi tài nguyên bạn đã gửi.",
+        canonical: "https://schooltechhub.com/account/resources"
+      },
+      listTitle: "Danh sách tài nguyên",
+      listDescription: "Điều chỉnh quyền hiển thị, trạng thái và thêm tài nguyên mới.",
+      newCta: "Thêm tài nguyên",
+      empty: "Bạn chưa thêm tài nguyên nào.",
+      emptyCta: "Thêm tài nguyên đầu tiên",
+      viewLink: "Mở liên kết",
+      statusLabel: "Trạng thái",
+      visibilityLabel: "Quyền hiển thị",
+      pagination: "Trang {current} trên {total}",
+      toast: {
+        created: "Đã gửi tài nguyên",
+        updated: "Đã cập nhật tài nguyên",
+        updateError: "Không thể cập nhật tài nguyên"
+      },
+      status: {
+        draft: "Bản nháp",
+        published: "Đã xuất bản",
+        archived: "Đã lưu trữ"
+      },
+      visibility: {
+        private: "Riêng tư",
+        unlisted: "Không công khai",
+        public: "Công khai"
+      },
+      form: {
+        title: "Gửi tài nguyên",
+        editTitle: "Cập nhật tài nguyên",
+        description: "Chia sẻ những tài nguyên đáng tin cậy với đồng nghiệp.",
+        editDescription: "Cập nhật thông tin và ghi chú cho tài nguyên này.",
+        titleLabel: "Tiêu đề",
+        titlePlaceholder: "Tên tài nguyên",
+        urlLabel: "Liên kết",
+        descriptionLabel: "Mô tả ngắn",
+        descriptionPlaceholder: "Tài nguyên này giúp giáo viên điều gì?",
+        typeLabel: "Loại tài nguyên",
+        typePlaceholder: "Ví dụ: Video, Mẫu, Bài viết",
+        statusLabel: "Trạng thái",
+        statusPlaceholder: "Chọn trạng thái",
+        visibilityLabel: "Quyền hiển thị",
+        visibilityPlaceholder: "Chọn quyền hiển thị",
+        subjectsLabel: "Môn học",
+        subjectsPlaceholder: "Thêm môn học và nhấn Enter",
+        topicsLabel: "Chủ đề",
+        topicsPlaceholder: "Thêm chủ đề và nhấn Enter",
+        tagsLabel: "Thẻ",
+        tagsPlaceholder: "Thêm thẻ để dễ tìm",
+        thumbnailLabel: "Ảnh xem trước",
+        thumbnailPlaceholder: "https://example.com/preview.jpg",
+        notesLabel: "Ghi chú giảng dạy",
+        notesPlaceholder: "Chia sẻ cách bạn sử dụng tài nguyên này",
+        submit: "Lưu tài nguyên"
+      },
+      new: {
+        heading: "Gửi tài nguyên mới",
+        subheading: "Chia sẻ tài nguyên hữu ích với cộng đồng giáo viên.",
+        seo: {
+          title: "Gửi tài nguyên | SchoolTech Hub",
+          description: "Thêm tài nguyên lớp học để giáo viên khác tham khảo.",
+          canonical: "https://schooltechhub.com/account/resources/new"
+        }
+      },
+      edit: {
+        heading: "Chỉnh sửa tài nguyên",
+        subheading: "Cập nhật thông tin trước khi chia sẻ công khai.",
+        seo: {
+          title: "Chỉnh sửa {title} | SchoolTech Hub",
+          description: "Cập nhật metadata và ghi chú cho tài nguyên này.",
+          canonical: "https://schooltechhub.com/account/resources"
+        }
+      }
+    },
     support: {
       title: "Cần hỗ trợ?",
       description: "Chúng tôi luôn sẵn sàng giúp bạn thay đổi cài đặt tài khoản.",

--- a/supabase/migrations/20251101000000_create_educator_resources.sql
+++ b/supabase/migrations/20251101000000_create_educator_resources.sql
@@ -1,0 +1,161 @@
+-- Create enums for resource workflow
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'resource_status_enum') THEN
+    CREATE TYPE public.resource_status_enum AS ENUM ('draft', 'published', 'archived');
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'resource_visibility_enum') THEN
+    CREATE TYPE public.resource_visibility_enum AS ENUM ('private', 'unlisted', 'public');
+  END IF;
+END $$;
+
+-- Create educator resources table
+CREATE TABLE IF NOT EXISTS public.educator_resources (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id UUID NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  description TEXT,
+  url TEXT NOT NULL,
+  normalized_url TEXT NOT NULL,
+  domain TEXT NOT NULL,
+  favicon_url TEXT,
+  thumbnail_url TEXT,
+  resource_type TEXT,
+  subjects TEXT[] DEFAULT ARRAY[]::TEXT[],
+  topics TEXT[] DEFAULT ARRAY[]::TEXT[],
+  tags TEXT[] DEFAULT ARRAY[]::TEXT[],
+  instructional_notes TEXT,
+  status public.resource_status_enum NOT NULL DEFAULT 'draft',
+  visibility public.resource_visibility_enum NOT NULL DEFAULT 'private',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS educator_resources_normalized_url_idx
+  ON public.educator_resources (normalized_url);
+
+ALTER TABLE public.educator_resources ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'educator_resources_updated_at'
+  ) THEN
+    CREATE TRIGGER educator_resources_updated_at
+      BEFORE UPDATE ON public.educator_resources
+      FOR EACH ROW
+      EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END $$;
+
+-- Policies
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'Public read published resources'
+      AND tablename = 'educator_resources'
+  ) THEN
+    CREATE POLICY "Public read published resources"
+      ON public.educator_resources
+      FOR SELECT
+      USING (visibility = 'public' AND status = 'published');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'Owners read educator resources'
+      AND tablename = 'educator_resources'
+  ) THEN
+    CREATE POLICY "Owners read educator resources"
+      ON public.educator_resources
+      FOR SELECT
+      USING (auth.uid() = owner_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'Owners insert educator resources'
+      AND tablename = 'educator_resources'
+  ) THEN
+    CREATE POLICY "Owners insert educator resources"
+      ON public.educator_resources
+      FOR INSERT
+      WITH CHECK (auth.uid() = owner_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'Owners update educator resources'
+      AND tablename = 'educator_resources'
+  ) THEN
+    CREATE POLICY "Owners update educator resources"
+      ON public.educator_resources
+      FOR UPDATE
+      USING (auth.uid() = owner_id)
+      WITH CHECK (auth.uid() = owner_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'Owners delete educator resources'
+      AND tablename = 'educator_resources'
+  ) THEN
+    CREATE POLICY "Owners delete educator resources"
+      ON public.educator_resources
+      FOR DELETE
+      USING (auth.uid() = owner_id);
+  END IF;
+END $$;
+
+-- Storage bucket for resource assets
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('resource-assets', 'resource-assets', true)
+ON CONFLICT (id) DO NOTHING;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'Public read resource assets'
+      AND tablename = 'objects'
+  ) THEN
+    CREATE POLICY "Public read resource assets"
+      ON storage.objects
+      FOR SELECT
+      USING (bucket_id = 'resource-assets');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'Authenticated upload resource assets'
+      AND tablename = 'objects'
+  ) THEN
+    CREATE POLICY "Authenticated upload resource assets"
+      ON storage.objects
+      FOR INSERT
+      WITH CHECK (bucket_id = 'resource-assets' AND auth.role() = 'authenticated');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'Owners update resource assets'
+      AND tablename = 'objects'
+  ) THEN
+    CREATE POLICY "Owners update resource assets"
+      ON storage.objects
+      FOR UPDATE
+      USING (bucket_id = 'resource-assets' AND (auth.uid() = owner OR owner IS NULL));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'Owners delete resource assets'
+      AND tablename = 'objects'
+  ) THEN
+    CREATE POLICY "Owners delete resource assets"
+      ON storage.objects
+      FOR DELETE
+      USING (bucket_id = 'resource-assets' AND (auth.uid() = owner OR owner IS NULL));
+  END IF;
+END $$;

--- a/types/resources.ts
+++ b/types/resources.ts
@@ -1,0 +1,51 @@
+export type ResourceStatus = "draft" | "published" | "archived";
+export type ResourceVisibility = "private" | "unlisted" | "public";
+
+export interface ResourceRecord {
+  id: string;
+  owner_id: string;
+  title: string;
+  description: string | null;
+  url: string;
+  normalized_url: string;
+  domain: string;
+  favicon_url: string | null;
+  thumbnail_url: string | null;
+  resource_type: string | null;
+  subjects: string[] | null;
+  topics: string[] | null;
+  tags: string[] | null;
+  instructional_notes: string | null;
+  status: ResourceStatus;
+  visibility: ResourceVisibility;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ResourceCard {
+  id: string;
+  title: string;
+  description: string | null;
+  url: string;
+  domain: string;
+  faviconUrl: string | null;
+  thumbnailUrl: string | null;
+  resourceType: string | null;
+  subjects: string[];
+  topics: string[];
+  tags: string[];
+  instructionalNotes: string | null;
+  status: ResourceStatus;
+  visibility: ResourceVisibility;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ResourceListResponse {
+  items: ResourceCard[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+  nextPage: number | null;
+}


### PR DESCRIPTION
## Summary
- add Supabase migration, helper utilities, and API handlers to search, create, and update educator resources with metadata and duplicate protection
- expose typed client helpers plus React Query-backed account forms and lists for managing personal resources with localization
- extend translations, routes, and account entry points alongside unit tests covering resource search and mutations

## Testing
- `npx vitest run api/__tests__/resources.test.ts`
- `npx vitest run api/__tests__/builder/activities.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d0c02502f08331a7da4fe84d624c71