### PR TITLE
Add live lesson preview and improve resource search

### DIFF
--- a/src/features/builder/components/LessonBuilder.tsx
+++ b/src/features/builder/components/LessonBuilder.tsx
@@ -11,14 +11,18 @@ import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 
 import { StepCard } from "./StepCard";
+import { ActivitySearchPanel } from "./ActivitySearchPanel";
 import { BuilderProvider, useBuilder } from "../context/BuilderContext";
+import type { BuilderActivitySummary } from "../types";
 import { useAutosave } from "../hooks/useAutosave";
 import { fetchLinkStatuses, type LinkHealthStatus } from "../api/linkHealth";
 import { BuilderCommandPalette } from "./command/BuilderCommandPalette";
 import { ExportMenu } from "./export/ExportMenu";
+import { LessonPreview } from "./LessonPreview";
 
 const BuilderShell = () => {
   const { state, setState, addStep, duplicateStep, removeStep, reorderSteps } = useBuilder();
+  const [activeActivity, setActiveActivity] = useState<BuilderActivitySummary | null>(null);
   const [linkLookup, setLinkLookup] = useState<Record<string, LinkHealthStatus>>({});
   const [autosaveStatus, setAutosaveStatus] = useState<"idle" | "saving" | "saved">("idle");
   const [profileId, setProfileId] = useState<string | null>(null);
@@ -31,7 +35,13 @@ const BuilderShell = () => {
 
     const loadProfile = async () => {
       try {
-        const { data } = await supabase.auth.getUser();
+        const authClient = supabase.auth;
+        if (!authClient?.getUser) {
+          setProfileId(null);
+          return;
+        }
+
+        const { data } = await authClient.getUser();
         if (!active) return;
 
         const user = data?.user ?? null;
@@ -115,6 +125,32 @@ const BuilderShell = () => {
 
   const handleDrop = (fromId: string, toId: string) => {
     reorderSteps(fromId, toId);
+  };
+
+  const handleActivitySelect = (activity: BuilderActivitySummary) => {
+    setActiveActivity(activity);
+    setState(prev => ({
+      ...prev,
+      stage: activity.schoolStages[0] ?? prev.stage,
+      subject: activity.subjects[0] ?? prev.subject,
+      title: prev.title === "Untitled Lesson" ? activity.name : prev.title,
+      steps: prev.steps.map((step, index) =>
+        index === 0
+          ? {
+              ...step,
+              title:
+                step.title.trim().length === 0 || step.title.trim().toLowerCase() === "new step"
+                  ? activity.name
+                  : step.title,
+              learningGoals:
+                step.learningGoals.trim().length > 0
+                  ? step.learningGoals
+                  : activity.description ?? step.learningGoals,
+              deliveryMode: activity.delivery ?? step.deliveryMode,
+            }
+          : step,
+      ),
+    }));
   };
 
   const handleLogoUpload = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -207,174 +243,195 @@ const BuilderShell = () => {
   }, [lessonMetadata.date]);
 
   return (
-    <div className="flex h-full min-h-[80vh] flex-col gap-6">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Lesson builder</h1>
-          <p className="text-sm text-muted-foreground">
-            Assemble a tech-integrated lesson in minutes. Drag steps, open the command palette (⌘/Ctrl+K), and export teacher or
-            student views.
-          </p>
+    <>
+      <div className="grid gap-6 xl:grid-cols-[360px_minmax(0,1fr)_420px] lg:grid-cols-[360px_minmax(0,1fr)]">
+        <div className="space-y-4">
+          <ActivitySearchPanel
+            activeActivitySlug={activeActivity?.slug ?? null}
+            onSelectActivity={handleActivitySelect}
+          />
         </div>
-        <div className="flex items-center gap-3">
-          <ExportMenu state={state} linkLookup={linkLookup} />
-          <span className="text-xs text-muted-foreground" data-testid="autosave-status">
-            {autosaveStatus === "saving" ? "Saving..." : autosaveStatus === "saved" ? "Saved" : "Auto-save ready"}
-          </span>
+
+        <div className="flex h-full min-h-[80vh] flex-col gap-6">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">Lesson builder</h1>
+              <p className="text-sm text-muted-foreground">
+                Assemble a tech-integrated lesson in minutes. Drag steps, open the command palette (⌘/Ctrl+K), and export teacher
+                or student views.
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              <ExportMenu state={state} linkLookup={linkLookup} />
+              <span className="text-xs text-muted-foreground" data-testid="autosave-status">
+                {autosaveStatus === "saving" ? "Saving..." : autosaveStatus === "saved" ? "Saved" : "Auto-save ready"}
+              </span>
+            </div>
+          </div>
+
+          <Card className="border-none bg-background">
+            <CardHeader className="border-b border-border/60">
+              <CardTitle className="text-2xl font-semibold">Lesson blueprint</CardTitle>
+              <div className="grid gap-3 md:grid-cols-3">
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="lesson-title-input">
+                    Lesson title
+                  </label>
+                  <Input
+                    id="lesson-title-input"
+                    value={state.title}
+                    onChange={event => setState(prev => ({ ...prev, title: event.target.value }))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="lesson-stage-input">
+                    Stage
+                  </label>
+                  <Input
+                    id="lesson-stage-input"
+                    value={state.stage}
+                    onChange={event => setState(prev => ({ ...prev, stage: event.target.value }))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="lesson-subject-input">
+                    Subject
+                  </label>
+                  <Input
+                    id="lesson-subject-input"
+                    value={state.subject}
+                    onChange={event => setState(prev => ({ ...prev, subject: event.target.value }))}
+                  />
+                </div>
+              </div>
+
+              <Textarea
+                id="lesson-objective-textarea"
+                value={state.objective}
+                onChange={event => setState(prev => ({ ...prev, objective: event.target.value }))}
+                placeholder="What will students accomplish?"
+                rows={3}
+              />
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="lesson-logo-input">
+                    School logo
+                  </label>
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+                    <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-md border border-dashed border-border bg-muted/40">
+                      {state.schoolLogoUrl ? (
+                        <img src={state.schoolLogoUrl} alt="School logo" className="h-full w-full object-contain" />
+                      ) : (
+                        <span className="px-2 text-center text-xs text-muted-foreground">Upload logo</span>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={isUploadingLogo || (!profileId && typeof window !== "undefined")}
+                      >
+                        {isUploadingLogo ? "Uploading..." : state.schoolLogoUrl ? "Replace logo" : "Upload logo"}
+                      </Button>
+                      {state.schoolLogoUrl ? (
+                        <Button type="button" variant="ghost" size="sm" onClick={handleLogoRemove} disabled={isUploadingLogo}>
+                          Remove
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
+                  <input
+                    id="lesson-logo-input"
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleLogoUpload}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {profileId ? "Saved to your profile for future lessons." : "Sign in to save your logo for future plans."}
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="lesson-date-input">
+                    Lesson date
+                  </label>
+                  <Input
+                    id="lesson-date-input"
+                    type="date"
+                    value={state.lessonDate}
+                    onChange={event => setState(prev => ({ ...prev, lessonDate: event.target.value }))}
+                  />
+                </div>
+              </div>
+
+              <div className="text-xs text-muted-foreground">
+                {lessonMetadata.steps} steps • Stage: {lessonMetadata.stage || "Choose"} • Subject: {lessonMetadata.subject || "Pick"}
+                {formattedDate ? ` • Date: ${formattedDate}` : ""}
+              </div>
+            </CardHeader>
+
+            <CardContent className="p-0">
+              <Tabs defaultValue="steps">
+                <TabsList className="border-b border-border bg-muted/30 px-6 py-2">
+                  <TabsTrigger value="steps">Steps</TabsTrigger>
+                  <TabsTrigger value="notes">Notes</TabsTrigger>
+                </TabsList>
+                <TabsContent value="steps" className="p-0">
+                  <ScrollArea className="h-[65vh]">
+                    <div className="space-y-4 p-6">
+                      {state.steps.map((step, index) => (
+                        <StepCard
+                          key={step.id}
+                          index={index}
+                          step={step}
+                          healthLookup={linkLookup}
+                          onChange={handleStepChange}
+                          onRemove={removeStep}
+                          onDuplicate={duplicateStep}
+                          onDragStart={() => undefined}
+                          onDrop={(fromId, toId) => handleDrop(fromId, toId)}
+                        />
+                      ))}
+                      <Button type="button" variant="outline" onClick={addStep} className="w-full" data-testid="add-step">
+                        <Plus className="mr-2 h-4 w-4" /> Add step
+                      </Button>
+                    </div>
+                  </ScrollArea>
+                </TabsContent>
+                <TabsContent value="notes" className="p-6">
+                  <Textarea
+                    rows={10}
+                    placeholder="Add facilitator notes, differentiation options, or reflections to revisit later."
+                  />
+                </TabsContent>
+              </Tabs>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="hidden xl:block xl:sticky xl:top-24">
+          <LessonPreview state={state} />
         </div>
       </div>
 
-      <Card className="border-none bg-background">
-        <CardHeader className="border-b border-border/60">
-          <CardTitle className="text-2xl font-semibold">Lesson blueprint</CardTitle>
-          <div className="grid gap-3 md:grid-cols-3">
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="lesson-title-input">
-                Lesson title
-              </label>
-              <Input
-                id="lesson-title-input"
-                value={state.title}
-                onChange={event => setState(prev => ({ ...prev, title: event.target.value }))}
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="lesson-stage-input">
-                Stage
-              </label>
-              <Input
-                id="lesson-stage-input"
-                value={state.stage}
-                onChange={event => setState(prev => ({ ...prev, stage: event.target.value }))}
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="lesson-subject-input">
-                Subject
-              </label>
-              <Input
-                id="lesson-subject-input"
-                value={state.subject}
-                onChange={event => setState(prev => ({ ...prev, subject: event.target.value }))}
-              />
-            </div>
-          </div>
-
-          <Textarea
-            id="lesson-objective-textarea"
-            value={state.objective}
-            onChange={event => setState(prev => ({ ...prev, objective: event.target.value }))}
-            placeholder="What will students accomplish?"
-            rows={3}
-          />
-
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="lesson-logo-input">
-                School logo
-              </label>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-                <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-md border border-dashed border-border bg-muted/40">
-                  {state.schoolLogoUrl ? (
-                    <img src={state.schoolLogoUrl} alt="School logo" className="h-full w-full object-contain" />
-                  ) : (
-                    <span className="px-2 text-center text-xs text-muted-foreground">Upload logo</span>
-                  )}
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={isUploadingLogo || (!profileId && typeof window !== "undefined")}
-                  >
-                    {isUploadingLogo ? "Uploading..." : state.schoolLogoUrl ? "Replace logo" : "Upload logo"}
-                  </Button>
-                  {state.schoolLogoUrl ? (
-                    <Button type="button" variant="ghost" size="sm" onClick={handleLogoRemove} disabled={isUploadingLogo}>
-                      Remove
-                    </Button>
-                  ) : null}
-                </div>
-              </div>
-              <input
-                id="lesson-logo-input"
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={handleLogoUpload}
-              />
-              <p className="text-xs text-muted-foreground">
-                {profileId ? "Saved to your profile for future lessons." : "Sign in to save your logo for future plans."}
-              </p>
-            </div>
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="lesson-date-input">
-                Lesson date
-              </label>
-              <Input
-                id="lesson-date-input"
-                type="date"
-                value={state.lessonDate}
-                onChange={event => setState(prev => ({ ...prev, lessonDate: event.target.value }))}
-              />
-            </div>
-          </div>
-
-          <div className="text-xs text-muted-foreground">
-            {lessonMetadata.steps} steps • Stage: {lessonMetadata.stage || "Choose"} • Subject: {lessonMetadata.subject || "Pick"}
-            {formattedDate ? ` • Date: ${formattedDate}` : ""}
-          </div>
-        </CardHeader>
-
-        <CardContent className="p-0">
-          <Tabs defaultValue="steps">
-            <TabsList className="border-b border-border bg-muted/30 px-6 py-2">
-              <TabsTrigger value="steps">Steps</TabsTrigger>
-              <TabsTrigger value="notes">Notes</TabsTrigger>
-            </TabsList>
-            <TabsContent value="steps" className="p-0">
-              <ScrollArea className="h-[65vh]">
-                <div className="space-y-4 p-6">
-                  {state.steps.map((step, index) => (
-                    <StepCard
-                      key={step.id}
-                      index={index}
-                      step={step}
-                      healthLookup={linkLookup}
-                      onChange={handleStepChange}
-                      onRemove={removeStep}
-                      onDuplicate={duplicateStep}
-                      onDragStart={() => undefined}
-                      onDrop={(fromId, toId) => handleDrop(fromId, toId)}
-                    />
-                  ))}
-                  <Button type="button" variant="outline" onClick={addStep} className="w-full" data-testid="add-step">
-                    <Plus className="mr-2 h-4 w-4" /> Add step
-                  </Button>
-                </div>
-              </ScrollArea>
-            </TabsContent>
-            <TabsContent value="notes" className="p-6">
-              <Textarea
-                rows={10}
-                placeholder="Add facilitator notes, differentiation options, or reflections to revisit later."
-              />
-            </TabsContent>
-          </Tabs>
-        </CardContent>
-      </Card>
+      <div className="xl:hidden">
+        <LessonPreview state={state} />
+      </div>
 
       <BuilderCommandPalette
         onAddStep={addStep}
         onDuplicateStep={() => duplicateStep(state.steps[state.steps.length - 1]?.id ?? "")}
         onFocusSearch={() =>
-          document.querySelector<HTMLButtonElement>("button[data-builder-resource-search]")?.focus()
+          document
+            .querySelector<HTMLInputElement>("input[placeholder='Search by keyword, skill, or tool...']")
+            ?.focus()
         }
       />
-    </div>
+    </>
   );
 };
 

--- a/src/features/builder/components/LessonPreview.tsx
+++ b/src/features/builder/components/LessonPreview.tsx
@@ -1,0 +1,206 @@
+import { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+
+import type { BuilderState, BuilderStep } from "../types";
+
+interface LessonPreviewProps {
+  state: BuilderState;
+}
+
+const hasStepDetails = (step: BuilderStep) => {
+  const normalizedTitle = step.title.trim().toLowerCase();
+  const hasCustomTitle = normalizedTitle.length > 0 && normalizedTitle !== "new step";
+  const hasLearningGoals = step.learningGoals.trim().length > 0;
+  const hasDuration = step.duration.trim().length > 0;
+  const hasNotes = step.notes.trim().length > 0;
+  const hasResources = step.resources.length > 0;
+  const hasCustomGrouping = step.grouping.trim().length > 0 && step.grouping !== "Whole Class";
+  const hasCustomDelivery = step.deliveryMode.trim().length > 0 && step.deliveryMode !== "In-person";
+  return (
+    hasCustomTitle ||
+    hasLearningGoals ||
+    hasDuration ||
+    hasNotes ||
+    hasResources ||
+    hasCustomGrouping ||
+    hasCustomDelivery
+  );
+};
+
+export const LessonPreview = ({ state }: LessonPreviewProps) => {
+  const formattedDate = useMemo(() => {
+    if (!state.lessonDate) return null;
+    try {
+      const parsed = new Date(state.lessonDate);
+      if (Number.isNaN(parsed.getTime())) {
+        return state.lessonDate;
+      }
+      return new Intl.DateTimeFormat(undefined, {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      }).format(parsed);
+    } catch (error) {
+      console.error(error);
+      return state.lessonDate;
+    }
+  }, [state.lessonDate]);
+
+  const metadata = [
+    state.stage.trim().length ? { label: "Stage", value: state.stage } : null,
+    state.subject.trim().length ? { label: "Subject", value: state.subject } : null,
+    formattedDate ? { label: "Date", value: formattedDate } : null,
+  ].filter((item): item is { label: string; value: string } => Boolean(item));
+
+  const stepsWithContent = state.steps.filter(hasStepDetails);
+  const hasContent =
+    (state.title && state.title.trim().length > 0 && state.title.trim() !== "Untitled Lesson") ||
+    state.objective.trim().length > 0 ||
+    metadata.length > 0 ||
+    stepsWithContent.length > 0 ||
+    state.schoolLogoUrl;
+
+  return (
+    <Card className="border-border/70 bg-background">
+      <CardHeader>
+        <CardTitle className="text-xl font-semibold">Live lesson preview</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Updates instantly as you add lesson details. Empty fields are hidden from this view.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {!hasContent ? (
+          <p className="text-sm text-muted-foreground">
+            Begin filling in your lesson details to see a formatted preview for teachers.
+          </p>
+        ) : (
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <div className="space-y-3">
+                <div className="flex items-start gap-3">
+                  {state.schoolLogoUrl ? (
+                    <div className="mt-1 h-14 w-14 flex-shrink-0 overflow-hidden rounded-md border border-border/60 bg-muted/40">
+                      <img src={state.schoolLogoUrl} alt="School logo" className="h-full w-full object-contain" />
+                    </div>
+                  ) : null}
+                  <div className="space-y-2">
+                    <h2 className="text-2xl font-bold leading-tight text-foreground">
+                      {state.title.trim() || "Untitled lesson"}
+                    </h2>
+                    {state.objective.trim().length ? (
+                      <p className="text-sm text-muted-foreground">{state.objective.trim()}</p>
+                    ) : null}
+                  </div>
+                </div>
+                {metadata.length ? (
+                  <div className="flex flex-wrap gap-2">
+                    {metadata.map(item => (
+                      <Badge key={item.label} variant="secondary">
+                        {item.label}: {item.value}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+
+            {stepsWithContent.length ? (
+              <div className="space-y-4">
+                <h3 className="text-lg font-semibold">Lesson structure</h3>
+                <div className="space-y-4">
+                  {stepsWithContent.map((step, index) => {
+                    const badges: string[] = [];
+                    if (step.duration.trim().length) {
+                      badges.push(`Duration: ${step.duration.trim()}`);
+                    }
+                    if (step.grouping.trim().length) {
+                      badges.push(step.grouping.trim());
+                    }
+                    if (step.deliveryMode.trim().length) {
+                      badges.push(step.deliveryMode.trim());
+                    }
+
+                    return (
+                      <div key={step.id} className="space-y-4 rounded-lg border border-border/70 bg-background/60 p-4">
+                        <div className="space-y-3">
+                          <div className="flex flex-wrap items-start justify-between gap-2">
+                            <div>
+                              <h4 className="text-base font-semibold text-foreground">
+                                {step.title.trim() || `Step ${index + 1}`}
+                              </h4>
+                              {step.learningGoals.trim().length ? (
+                                <p className="text-sm text-muted-foreground">{step.learningGoals.trim()}</p>
+                              ) : null}
+                            </div>
+                            {badges.length ? (
+                              <div className="flex flex-wrap gap-2 text-xs">
+                                {badges.map(value => (
+                                  <Badge key={value} variant="outline">
+                                    {value}
+                                  </Badge>
+                                ))}
+                              </div>
+                            ) : null}
+                          </div>
+                        </div>
+
+                        {step.resources.length ? (
+                          <div className="space-y-3">
+                            <p className="text-sm font-medium text-foreground">Resources</p>
+                            <div className="space-y-3">
+                              {step.resources.map(resource => (
+                                <div
+                                  key={resource.id}
+                                  className="space-y-2 rounded-md border border-border/60 bg-background/60 p-3"
+                                >
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <p className="text-sm font-semibold text-foreground">{resource.title}</p>
+                                    {resource.resourceType ? (
+                                      <Badge variant="secondary">{resource.resourceType}</Badge>
+                                    ) : null}
+                                    {resource.format ? <Badge variant="outline">{resource.format}</Badge> : null}
+                                  </div>
+                                  {resource.description ? (
+                                    <p className="text-xs text-muted-foreground">{resource.description}</p>
+                                  ) : null}
+                                  <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                                    {resource.subject ? <Badge variant="outline">{resource.subject}</Badge> : null}
+                                    {resource.gradeLevel ? <Badge variant="outline">{resource.gradeLevel}</Badge> : null}
+                                    {resource.tags.map(tag => (
+                                      <Badge key={tag} variant="secondary">
+                                        #{tag}
+                                      </Badge>
+                                    ))}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : null}
+
+                        {step.notes.trim().length ? (
+                          <div className="rounded-md bg-muted/50 p-3">
+                            <p className="text-xs font-semibold uppercase text-muted-foreground">Offline fallback</p>
+                            <p className="text-sm text-muted-foreground">{step.notes.trim()}</p>
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+
+            {stepsWithContent.length && state.steps.some(step => step.resources.length) ? (
+              <Separator />
+            ) : null}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default LessonPreview;

--- a/src/features/builder/components/ResourceSearchDialog.tsx
+++ b/src/features/builder/components/ResourceSearchDialog.tsx
@@ -32,10 +32,20 @@ export const ResourceSearchDialog = ({ open, onOpenChange, onSelect }: ResourceS
   const [gradeLevel, setGradeLevel] = useState("");
   const [format, setFormat] = useState("");
   const [creator, setCreator] = useState("");
+  const [tagQuery, setTagQuery] = useState("");
   const [results, setResults] = useState<ResourceCard[]>([]);
   const [loading, setLoading] = useState(false);
 
   const debouncedQuery = useDebouncedValue(query, 300);
+  const debouncedTags = useDebouncedValue(tagQuery, 300);
+  const parsedTags = useMemo(
+    () =>
+      debouncedTags
+        .split(",")
+        .map(tag => tag.trim())
+        .filter(Boolean),
+    [debouncedTags],
+  );
 
   useEffect(() => {
     if (!open) {
@@ -51,6 +61,7 @@ export const ResourceSearchDialog = ({ open, onOpenChange, onSelect }: ResourceS
       subject: subject || undefined,
       gradeLevel: gradeLevel || undefined,
       format: format || undefined,
+      tags: parsedTags.length ? parsedTags : undefined,
       limit: 40,
     })
       .then(response => {
@@ -73,7 +84,7 @@ export const ResourceSearchDialog = ({ open, onOpenChange, onSelect }: ResourceS
     return () => {
       active = false;
     };
-  }, [open, debouncedQuery, resourceType, subject, gradeLevel, format, toast]);
+  }, [open, debouncedQuery, resourceType, subject, gradeLevel, format, parsedTags, toast]);
 
   useEffect(() => {
     if (!open) {
@@ -83,6 +94,7 @@ export const ResourceSearchDialog = ({ open, onOpenChange, onSelect }: ResourceS
       setGradeLevel("");
       setFormat("");
       setCreator("");
+      setTagQuery("");
       setResults([]);
     }
   }, [open]);
@@ -132,6 +144,20 @@ export const ResourceSearchDialog = ({ open, onOpenChange, onSelect }: ResourceS
                 onChange={event => setCreator(event.target.value)}
                 placeholder="Filter by educator name"
               />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="resource-tags">
+                Tags
+              </label>
+              <Input
+                id="resource-tags"
+                value={tagQuery}
+                onChange={event => setTagQuery(event.target.value)}
+                placeholder="Filter by tags (comma separated)"
+              />
+              <p className="text-xs text-muted-foreground">
+                Match resources that include any of the tags you list.
+              </p>
             </div>
             <div className="space-y-2">
               <label className="text-xs font-semibold uppercase text-muted-foreground">Resource type</label>

--- a/src/features/builder/components/StepCard.tsx
+++ b/src/features/builder/components/StepCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { ExternalLink, GripVertical, Link2, MoreVertical, ShieldAlert, Trash2 } from "lucide-react";
+import { ExternalLink, GripVertical, MoreVertical, Search, ShieldAlert, Trash2 } from "lucide-react";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -68,7 +68,8 @@ export const StepCard = ({
     });
 
     const existing = step.resources.filter(item => item.resourceId !== resource.id);
-    const shouldRenameStep = existing.length === 0 && (!step.title || step.title === "New Step");
+    const normalizedTitle = step.title.trim().toLowerCase();
+    const shouldRenameStep = existing.length === 0 && (!step.title || normalizedTitle === "new step");
 
     onChange(step.id, {
       resources: [...existing, mapped],
@@ -105,7 +106,7 @@ export const StepCard = ({
         <div className="flex flex-1 flex-col gap-1">
           <CardTitle className="flex items-center gap-2 text-lg">
             <GripVertical className="h-4 w-4 cursor-grab text-muted-foreground" aria-hidden />
-            Step {index + 1}: {step.title}
+            {step.title.trim() || "New step"}
             {unhealthyResources.length ? (
               <TooltipProvider>
                 <Tooltip>
@@ -162,7 +163,7 @@ export const StepCard = ({
         <div className="grid gap-4 md:grid-cols-3">
           <div className="space-y-2">
             <label className="text-sm font-medium" htmlFor={`step-${step.id}-title`}>
-              Step title
+              Title
             </label>
             <Input
               id={`step-${step.id}-title`}
@@ -218,23 +219,21 @@ export const StepCard = ({
         </div>
 
         <div className="space-y-3">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div>
-              <p className="text-sm font-medium">Resources</p>
-              <p className="text-xs text-muted-foreground">
-                Search classroom-ready materials with embedded instructional notes.
-              </p>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setIsSearchOpen(true)}
-              data-builder-resource-search
-            >
-              <Link2 className="mr-2 h-4 w-4" /> Search resources
-            </Button>
+          <div className="space-y-1">
+            <p className="text-sm font-medium">Resources</p>
+            <p className="text-xs text-muted-foreground">
+              Search classroom-ready materials with embedded instructional notes.
+            </p>
           </div>
+          <button
+            type="button"
+            onClick={() => setIsSearchOpen(true)}
+            className="group flex w-full items-center gap-2 rounded-md border border-dashed border-border/70 px-3 py-2 text-sm text-muted-foreground transition hover:border-primary hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            data-builder-resource-search
+          >
+            <Search className="h-4 w-4 text-muted-foreground transition group-hover:text-foreground" />
+            <span className="flex-1 text-left">Search by title or tag to add a resource</span>
+          </button>
           <div className="space-y-4">
             {step.resources.length === 0 ? (
               <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
@@ -312,13 +311,13 @@ export const StepCard = ({
 
         <div className="space-y-2">
           <label className="text-sm font-medium" htmlFor={`step-${step.id}-notes`}>
-            Additional teacher notes
+            Offline fallback (teacher only)
           </label>
           <Textarea
             id={`step-${step.id}-notes`}
             value={step.notes}
             onChange={event => handleFieldChange("notes", event.target.value)}
-            placeholder="Add differentiation ideas, questions to ask, or reminders for yourself."
+            placeholder="Describe the analog or no-tech alternative for this step."
             rows={3}
           />
         </div>

--- a/src/features/builder/utils/exporters.ts
+++ b/src/features/builder/utils/exporters.ts
@@ -1,12 +1,22 @@
 import type { BuilderState } from "../types";
 import type { LinkHealthStatus } from "../api/linkHealth";
 
-const formatStep = (index: number, step: BuilderState["steps"][number]) => {
+const formatStep = (
+  index: number,
+  step: BuilderState["steps"][number],
+  options: { includeOffline?: boolean } = {},
+) => {
+  const { includeOffline = false } = options;
   const lines = [`${index + 1}. ${step.title}${step.duration ? ` (${step.duration})` : ""}`];
   if (step.learningGoals) lines.push(`Learning goals: ${step.learningGoals}`);
   if (step.grouping) lines.push(`Grouping: ${step.grouping}`);
   if (step.deliveryMode) lines.push(`Delivery: ${step.deliveryMode}`);
-  if (step.notes) lines.push(`Teacher notes: ${step.notes}`);
+  if (includeOffline) {
+    const fallback = step.notes?.trim();
+    lines.push(
+      `Offline fallback: ${fallback && fallback.length ? fallback : "Plan an analog alternative if technology is unavailable."}`,
+    );
+  }
   if (step.resources.length) {
     lines.push("Resources:");
     for (const resource of step.resources) {
@@ -36,7 +46,7 @@ export const generateTeacherExport = (state: BuilderState, linkLookup: Record<st
     }
   });
 
-  const steps = state.steps.map((step, index) => formatStep(index, step)).join("\n\n");
+  const steps = state.steps.map((step, index) => formatStep(index, step, { includeOffline: true })).join("\n\n");
 
   return [header, warnings.length ? "Link warnings:\n" + warnings.join("\n") : null, "Steps:", steps]
     .filter(Boolean)
@@ -46,7 +56,7 @@ export const generateTeacherExport = (state: BuilderState, linkLookup: Record<st
 export const generateStudentExport = (state: BuilderState) => {
   const header = `Lesson: ${state.title}`;
   const steps = state.steps
-    .map((step, index) => formatStep(index, step))
+    .map((step, index) => formatStep(index, step, { includeOffline: false }))
     .join("\n\n");
   return [header, "Steps:", steps].join("\n\n");
 };

--- a/src/features/builder/utils/stepFactories.ts
+++ b/src/features/builder/utils/stepFactories.ts
@@ -10,7 +10,7 @@ export const createResourceLink = (
 
 export const createEmptyStep = (): BuilderStep => ({
   id: nanoid(),
-  title: "New Step",
+  title: "New step",
   learningGoals: "",
   duration: "",
   grouping: "Whole Class",


### PR DESCRIPTION
## Summary
* Added an Activity Search column, live lesson preview panel, and Supabase auth guard to the builder shell layout so the UI now shows search, form, and preview together.
* Replaced the resource “Search resources” button with a trigger styled as a search bar, renamed the title label, and retitled the notes area to “Offline fallback (teacher only).”
* Introduced a LessonPreview component that renders a real-time snapshot of metadata, steps, resources, and offline fallbacks.
* Expanded the resource search dialog with tag filtering and cleared state on close.
* Updated resource API search to include tag matching inside the OR clause.
* Renamed the default new-step title text to “New step.”
* Ensured teacher exports always show an “Offline fallback” line (with a placeholder) while student exports omit it.

## Testing
* npm run lint
* npm run test -- LessonBuilder

------
https://chatgpt.com/codex/tasks/task_e_68d0f0bbf2548331a4080d180c2ca2f5