### PR TITLE
feat: add resources data access layer

### DIFF
--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -1,0 +1,268 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { Resource, ResourceCreateInput, ResourceUpdateInput } from "@/types/resources";
+
+const RESOURCE_SELECT =
+  "id,title,description,url,type,subject,stage,tags,thumbnail_url,created_by,created_at,is_active";
+const DEFAULT_PAGE_SIZE = 20;
+
+/**
+ * Error wrapper used for all resource data access layer failures.
+ */
+export class ResourceDataError extends Error {
+  declare cause?: unknown;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    const causeMessage =
+      options?.cause && typeof options.cause === "object" && "message" in options.cause
+        ? String((options.cause as { message?: unknown }).message ?? "")
+        : undefined;
+
+    super(causeMessage ? `${message} (${causeMessage})` : message);
+    this.name = "ResourceDataError";
+    if (options?.cause !== undefined) {
+      (this as { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+/**
+ * Search filters supported by {@link searchResources}.
+ */
+export interface ResourceSearchOptions {
+  /** Free-form search query. */
+  q?: string;
+  /** Filter by one or more resource types. */
+  types?: string[];
+  /** Filter by one or more subjects. */
+  subjects?: string[];
+  /** Filter by one or more stages/grade levels. */
+  stages?: string[];
+  /** Filter by matching tags (overlap). */
+  tags?: string[];
+  /** Page number to request, defaults to `1`. */
+  page?: number;
+  /** Page size to request, defaults to `20`. */
+  pageSize?: number;
+}
+
+/**
+ * Normalises potentially user-provided filter values by trimming whitespace and removing empties.
+ */
+function sanitizeFilterValues(values?: string[]): string[] {
+  if (!values?.length) {
+    return [];
+  }
+
+  const trimmed = values.map(value => value.trim()).filter(Boolean);
+  return Array.from(new Set(trimmed));
+}
+
+/**
+ * Normalises tags before persistence by trimming whitespace and removing duplicates.
+ */
+function sanitizeTagsForPersistence(tags: string[] | null | undefined): string[] | undefined {
+  if (tags === undefined) {
+    return undefined;
+  }
+
+  const cleaned = (tags ?? []).map(tag => tag.trim()).filter(Boolean);
+  return Array.from(new Set(cleaned));
+}
+
+/** Escapes wildcard characters for an ILIKE clause. */
+function escapeForIlike(value: string): string {
+  return value.replace(/[%_]/g, match => `\\${match}`);
+}
+
+/** Escapes commas so values can be safely used within a Supabase `or` clause. */
+function escapeForOr(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/,/g, "\\,");
+}
+
+/**
+ * Simplifies the search term for the websearch full-text operator.
+ */
+function normaliseWebsearchTerm(value: string): string {
+  return value.replace(/[':!&|()]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Ensures the current request is authenticated and returns the active user id.
+ */
+async function requireUserId(action: string): Promise<string> {
+  const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+
+  if (sessionError) {
+    throw new ResourceDataError("Unable to verify authentication state.", { cause: sessionError });
+  }
+
+  const userId = sessionData.session?.user.id;
+
+  if (!userId) {
+    throw new ResourceDataError(`You must be signed in to ${action}.`);
+  }
+
+  return userId;
+}
+
+/**
+ * Performs a paginated query against the `resources` table, applying optional filters.
+ *
+ * The search term performs a web-style full-text search against titles, an `ILIKE` match against
+ * descriptions, and ensures that at least one tag overlaps with the query.
+ */
+export async function searchResources(options: ResourceSearchOptions = {}): Promise<{ items: Resource[]; total: number }> {
+  const pageSize = Math.max(1, options.pageSize ?? DEFAULT_PAGE_SIZE);
+  const page = Math.max(1, options.page ?? 1);
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
+
+  let query = supabase
+    .from("resources")
+    .select<Resource>(RESOURCE_SELECT, { count: "exact" })
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  query = query.eq("is_active", true);
+
+  const types = sanitizeFilterValues(options.types);
+  if (types.length) {
+    query = query.in("type", types);
+  }
+
+  const subjects = sanitizeFilterValues(options.subjects);
+  if (subjects.length) {
+    query = query.in("subject", subjects);
+  }
+
+  const stages = sanitizeFilterValues(options.stages);
+  if (stages.length) {
+    query = query.in("stage", stages);
+  }
+
+  const tags = sanitizeFilterValues(options.tags);
+  if (tags.length) {
+    query = query.overlaps("tags", tags);
+  }
+
+  const searchTerm = options.q?.trim();
+  if (searchTerm) {
+    const normalised = normaliseWebsearchTerm(searchTerm);
+    if (normalised) {
+      const orFilters = [`title.wfts.${escapeForOr(normalised)}`];
+      const escapedIlike = escapeForIlike(searchTerm);
+      orFilters.push(`title.ilike.%${escapedIlike}%`);
+      orFilters.push(`description.ilike.%${escapedIlike}%`);
+
+      const tagValue = searchTerm.replace(/[{}]/g, "").trim();
+      if (tagValue) {
+        const escapedTag = escapeForOr(tagValue.replace(/"/g, "\\\""));
+        orFilters.push(`tags.ov.{\"${escapedTag}\"}`);
+      }
+
+      query = query.or(orFilters.join(","));
+    }
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    throw new ResourceDataError("Unable to search resources.", { cause: error });
+  }
+
+  return {
+    items: data ?? [],
+    total: count ?? (data?.length ?? 0),
+  };
+}
+
+/**
+ * Retrieves a single resource by its identifier.
+ */
+export async function getResourceById(id: string): Promise<Resource | null> {
+  const { data, error } = await supabase
+    .from("resources")
+    .select<Resource>(RESOURCE_SELECT)
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new ResourceDataError("Unable to load the requested resource.", { cause: error });
+  }
+
+  return data ?? null;
+}
+
+/**
+ * Creates a new resource owned by the authenticated user.
+ */
+export async function createResource(data: ResourceCreateInput): Promise<Resource> {
+  const userId = await requireUserId("create a resource");
+
+  const tags = sanitizeTagsForPersistence(data.tags);
+
+  const insertPayload: Record<string, unknown> = {
+    title: data.title,
+    description: data.description ?? null,
+    url: data.url,
+    type: data.type,
+    subject: data.subject ?? null,
+    stage: data.stage ?? null,
+    thumbnail_url: data.thumbnail_url ?? null,
+    created_by: userId,
+    is_active: data.is_active ?? true,
+  };
+
+  if (tags !== undefined) {
+    insertPayload.tags = tags;
+  }
+
+  const { data: created, error } = await supabase
+    .from("resources")
+    .insert(insertPayload)
+    .select<Resource>(RESOURCE_SELECT)
+    .single();
+
+  if (error || !created) {
+    throw new ResourceDataError("Unable to create resource.", { cause: error });
+  }
+
+  return created;
+}
+
+/**
+ * Updates a resource owned by the authenticated user.
+ */
+export async function updateResource(id: string, data: ResourceUpdateInput): Promise<Resource> {
+  const userId = await requireUserId("update a resource");
+
+  const updatePayload: Record<string, unknown> = {};
+
+  if (data.title !== undefined) updatePayload.title = data.title;
+  if (data.url !== undefined) updatePayload.url = data.url;
+  if (data.description !== undefined) updatePayload.description = data.description ?? null;
+  if (data.type !== undefined) updatePayload.type = data.type;
+  if (data.subject !== undefined) updatePayload.subject = data.subject ?? null;
+  if (data.stage !== undefined) updatePayload.stage = data.stage ?? null;
+  if (data.thumbnail_url !== undefined) updatePayload.thumbnail_url = data.thumbnail_url ?? null;
+  if (data.is_active !== undefined) updatePayload.is_active = data.is_active;
+
+  if (data.tags !== undefined) {
+    const tags = sanitizeTagsForPersistence(data.tags);
+    updatePayload.tags = tags;
+  }
+
+  const { data: updated, error } = await supabase
+    .from("resources")
+    .update(updatePayload)
+    .eq("id", id)
+    .eq("created_by", userId)
+    .select<Resource>(RESOURCE_SELECT)
+    .single();
+
+  if (error || !updated) {
+    throw new ResourceDataError("Unable to update resource.", { cause: error });
+  }
+
+  return updated;
+}

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared representation of a resource stored within the Supabase `public.resources` table.
+ */
+export interface Resource {
+  /** Primary identifier for the resource record. */
+  id: string;
+  /** Short descriptive title for the resource. */
+  title: string;
+  /** Optional longer-form description of the resource contents. */
+  description: string | null;
+  /** Absolute or storage-backed URL pointing to the resource asset. */
+  url: string;
+  /** Resource classification (e.g. worksheet, video, ppt, offline). */
+  type: string;
+  /** Subject association such as Math, Science, or Social Studies. */
+  subject: string | null;
+  /** Target learning stage or grade. */
+  stage: string | null;
+  /** Tags used for categorisation and filtering. */
+  tags: string[];
+  /** Optional thumbnail or preview image for the resource. */
+  thumbnail_url: string | null;
+  /** Identifier of the creating user, if tracked. */
+  created_by: string | null;
+  /** Timestamp when the record was created (ISO 8601). */
+  created_at: string;
+  /** Indicates whether the resource is currently visible to users. */
+  is_active: boolean;
+}
+
+/**
+ * Attributes accepted when creating a new resource entry.
+ */
+export interface ResourceCreateInput {
+  title: string;
+  description?: string | null;
+  url: string;
+  type: string;
+  subject?: string | null;
+  stage?: string | null;
+  tags?: string[];
+  thumbnail_url?: string | null;
+  is_active?: boolean;
+}
+
+/**
+ * Attributes that may be updated on an existing resource entry.
+ */
+export interface ResourceUpdateInput {
+  title?: string;
+  description?: string | null;
+  url?: string;
+  type?: string;
+  subject?: string | null;
+  stage?: string | null;
+  tags?: string[];
+  thumbnail_url?: string | null;
+  is_active?: boolean;
+}

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Resource } from "@/types/resources";
+import { searchResources } from "@/lib/resources";
+
+const baseResources: Resource[] = [
+  {
+    id: "11111111-1111-4111-8111-111111111111",
+    title: "Math Morning Worksheet",
+    description: "Daily numeracy warm-up worksheet for early learners.",
+    url: "storage://resources/math-morning-worksheet.pdf",
+    type: "worksheet",
+    subject: "Math",
+    stage: "Stage 1",
+    tags: ["numeracy", "morning-routine"],
+    thumbnail_url: "https://cdn.example.com/thumbnails/math-morning.png",
+    created_by: null,
+    created_at: "2024-01-01T00:00:00.000Z",
+    is_active: true,
+  },
+  {
+    id: "22222222-2222-4222-8222-222222222222",
+    title: "Phonics Song Video",
+    description: "Animated video introducing consonant blends.",
+    url: "https://videos.example.com/phonics-song",
+    type: "video",
+    subject: "Phonics",
+    stage: "Stage 2",
+    tags: ["phonics", "listening", "music"],
+    thumbnail_url: "https://cdn.example.com/thumbnails/phonics-song.png",
+    created_by: null,
+    created_at: "2024-01-02T00:00:00.000Z",
+    is_active: true,
+  },
+  {
+    id: "33333333-3333-4333-8333-333333333333",
+    title: "Science Lab Picture Cards",
+    description: "Printable picture cards for lab safety equipment.",
+    url: "storage://resources/science-lab-cards.zip",
+    type: "picture",
+    subject: "Science",
+    stage: "Stage 3",
+    tags: ["lab", "safety", "visual"],
+    thumbnail_url: "https://cdn.example.com/thumbnails/science-lab.png",
+    created_by: null,
+    created_at: "2024-01-03T00:00:00.000Z",
+    is_active: true,
+  },
+  {
+    id: "44444444-4444-4444-8444-444444444444",
+    title: "History Presentation Deck",
+    description: "Slides covering early explorers with discussion prompts.",
+    url: "https://cdn.example.com/presentations/history-explorers.pptx",
+    type: "ppt",
+    subject: "Social Studies",
+    stage: "Stage 4",
+    tags: ["exploration", "discussion", "project"],
+    thumbnail_url: "https://cdn.example.com/thumbnails/history-explorers.png",
+    created_by: null,
+    created_at: "2024-01-04T00:00:00.000Z",
+    is_active: true,
+  },
+];
+
+type QueryFilters = {
+  types: string[] | null;
+  subjects: string[] | null;
+  stages: string[] | null;
+  tags: string[] | null;
+  searchTerm: string | null;
+  range: { from: number; to: number };
+  onlyActive: boolean;
+};
+
+function applyFilters(filters: QueryFilters, data: Resource[]): Resource[] {
+  const { types, subjects, stages, tags, searchTerm } = filters;
+  const search = searchTerm?.toLowerCase() ?? null;
+
+  return data.filter(resource => {
+    if (filters.onlyActive && !resource.is_active) return false;
+    if (types && !types.includes(resource.type)) return false;
+    if (subjects && (!resource.subject || !subjects.includes(resource.subject))) return false;
+    if (stages && (!resource.stage || !stages.includes(resource.stage))) return false;
+    if (tags && !tags.some(tag => resource.tags.includes(tag))) return false;
+
+    if (search) {
+      const inTitle = resource.title.toLowerCase().includes(search);
+      const inDescription = (resource.description ?? "").toLowerCase().includes(search);
+      const inTags = resource.tags.some(tag => tag.toLowerCase().includes(search));
+      if (!inTitle && !inDescription && !inTags) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+type BuilderState = QueryFilters & {
+  includeCount: boolean;
+};
+
+function decodeIlikeTerm(expression: string): string | null {
+  const descriptionMatch = expression.match(/description\.ilike\.%([^%]+)%/);
+  if (descriptionMatch) {
+    return descriptionMatch[1].replace(/\\\\/g, "");
+  }
+
+  const titleMatch = expression.match(/title\.ilike\.%([^%]+)%/);
+  if (titleMatch) {
+    return titleMatch[1].replace(/\\\\/g, "");
+  }
+
+  return null;
+}
+
+vi.mock("@/integrations/supabase/client", () => {
+  let dataset: Resource[] = [];
+
+  function createBuilder() {
+    const state: BuilderState = {
+      types: null,
+      subjects: null,
+      stages: null,
+      tags: null,
+      searchTerm: null,
+      range: { from: 0, to: dataset.length - 1 },
+      onlyActive: false,
+      includeCount: false,
+    };
+
+    const builder = {
+      select(_columns: string, options?: { count?: "exact" | null }) {
+        state.includeCount = options?.count === "exact";
+        return builder;
+      },
+      order() {
+        return builder;
+      },
+      range(from: number, to: number) {
+        state.range = { from, to };
+        return builder;
+      },
+      eq(column: string, value: unknown) {
+        if (column === "is_active") {
+          state.onlyActive = Boolean(value);
+        }
+        return builder;
+      },
+      in(column: string, values: string[]) {
+        if (column === "type") state.types = values;
+        if (column === "subject") state.subjects = values;
+        if (column === "stage") state.stages = values;
+        return builder;
+      },
+      overlaps(column: string, values: string[]) {
+        if (column === "tags") state.tags = values;
+        return builder;
+      },
+      or(expression: string) {
+        const parts = expression.split(",");
+        for (const part of parts) {
+          const term = decodeIlikeTerm(part);
+          if (term) {
+            state.searchTerm = term;
+            break;
+          }
+        }
+        return builder;
+      },
+      async execute() {
+        const filtered = applyFilters(state, dataset);
+        const items = filtered.slice(state.range.from, state.range.to + 1);
+
+        return {
+          data: items,
+          error: null,
+          count: state.includeCount ? filtered.length : null,
+        };
+      },
+      then<TResult1 = unknown, TResult2 = unknown>(
+        onFulfilled?: ((value: Awaited<ReturnType<typeof builder.execute>>) => TResult1 | PromiseLike<TResult1>) | null,
+        onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+      ) {
+        return builder.execute().then(onFulfilled, onRejected);
+      },
+    };
+
+    return builder;
+  }
+
+  return {
+    supabase: {
+      from(table: string) {
+        if (table !== "resources") {
+          throw new Error(`Unexpected table: ${table}`);
+        }
+        return createBuilder();
+      },
+      auth: {
+        async getSession() {
+          return { data: { session: { user: { id: "user-123" } } }, error: null };
+        },
+      },
+      __setData(newData: Resource[]) {
+        dataset = newData;
+      },
+    },
+  };
+});
+
+interface SupabaseClientMock {
+  __setData: (data: Resource[]) => void;
+  from: (table: string) => unknown;
+  auth: {
+    getSession: () => Promise<{ data: { session: { user: { id: string } } }; error: null }>;
+  };
+}
+
+const { supabase } = (await import("@/integrations/supabase/client")) as { supabase: SupabaseClientMock };
+
+describe("resources data access", () => {
+  beforeEach(() => {
+    const copy = JSON.parse(JSON.stringify(baseResources)) as Resource[];
+    supabase.__setData(copy);
+  });
+
+  it("retrieves paginated resources", async () => {
+    const result = await searchResources({ pageSize: 2 });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.total).toBe(baseResources.length);
+  });
+
+  it("filters by search term across title, description, and tags", async () => {
+    const result = await searchResources({ q: "science" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.id).toBe("33333333-3333-4333-8333-333333333333");
+  });
+
+  it("filters by resource type", async () => {
+    const result = await searchResources({ types: ["video"] });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.type).toBe("video");
+  });
+
+  it("filters by overlapping tags", async () => {
+    const result = await searchResources({ tags: ["discussion"] });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.title).toBe("History Presentation Deck");
+  });
+});


### PR DESCRIPTION
## Summary
- add strongly-typed resource shapes for the shared Supabase table
- implement a Supabase-backed resources data access layer with search, CRUD helpers, and rich error messaging
- cover search behaviour with unit tests that simulate Supabase filtering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d10dc4a944833182986f7348686f84