### PR TITLE
feat(builder): add step editor UI with preview

### DIFF
--- a/src/components/lesson-draft/LessonPreview.tsx
+++ b/src/components/lesson-draft/LessonPreview.tsx
@@ -1,0 +1,55 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useLessonDraftStore } from "@/stores/lessonDraft";
+
+const getStepDisplayTitle = (title: string) => {
+  const trimmed = title.trim();
+  return trimmed.length > 0 ? trimmed : "New step";
+};
+
+export const LessonPreview = () => {
+  const steps = useLessonDraftStore(state => state.draft.steps);
+
+  return (
+    <Card aria-labelledby="lesson-draft-preview-heading">
+      <CardHeader>
+        <CardTitle id="lesson-draft-preview-heading" className="text-xl">
+          Lesson preview
+        </CardTitle>
+        <CardDescription>
+          See how your steps and notes will appear when you publish your plan.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {steps.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border/80 bg-muted/40 p-6 text-sm text-muted-foreground">
+            Add learning steps to generate a live preview of your lesson.
+          </p>
+        ) : (
+          <ol className="space-y-4" aria-live="polite">
+            {steps.map((step, index) => (
+              <li
+                key={step.id}
+                className="space-y-2 rounded-lg border border-border/70 bg-background/80 p-4"
+                data-testid={`lesson-draft-preview-step-${index + 1}`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <h3 className="text-base font-semibold text-foreground">
+                    Step {index + 1}: {getStepDisplayTitle(step.title)}
+                  </h3>
+                  <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {step.resourceIds.length} resource{step.resourceIds.length === 1 ? "" : "s"}
+                  </span>
+                </div>
+                {step.notes ? (
+                  <p className="whitespace-pre-wrap text-sm text-muted-foreground">{step.notes}</p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">No notes added for this step yet.</p>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/lesson-draft/StepEditor.tsx
+++ b/src/components/lesson-draft/StepEditor.tsx
@@ -1,0 +1,296 @@
+import { useEffect, useMemo, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { LessonStep } from "@/stores/lessonDraft";
+import { useLessonDraftStore } from "@/stores/lessonDraft";
+
+interface StepEditorProps {
+  onRequestResourceSearch: (stepId: string) => void;
+  activeResourceStepId: string | null;
+  isResourceSearchOpen: boolean;
+}
+
+interface StepFormProps {
+  step: LessonStep;
+  index: number;
+  onRename: (stepId: string, value: string) => void;
+  onCommitName: (stepId: string) => void;
+  onRemove: (stepId: string) => void;
+  onUpdateNotes: (stepId: string, value: string) => void;
+  onRequestResources: (stepId: string) => void;
+  isResourceSearchOpen: boolean;
+  isResourceSearchOpenForStep: boolean;
+}
+
+const STEP_TITLE_LIMIT = 80;
+
+const getStepDisplayTitle = (title: string) => {
+  const trimmed = title.trim();
+  return trimmed.length > 0 ? trimmed : "New step";
+};
+
+const StepForm = ({
+  step,
+  index,
+  onRename,
+  onCommitName,
+  onRemove,
+  onUpdateNotes,
+  onRequestResources,
+  isResourceSearchOpen,
+  isResourceSearchOpenForStep,
+}: StepFormProps) => {
+  const [isTitleTouched, setIsTitleTouched] = useState(false);
+
+  const trimmedTitle = step.title.trim();
+  const showTitleError = isTitleTouched && trimmedTitle.length === 0;
+  const remainingCharacters = Math.max(0, STEP_TITLE_LIMIT - step.title.length);
+  const helperId = `step-${step.id}-title-help`;
+
+  useEffect(() => {
+    if (isTitleTouched && trimmedTitle.length > 0) {
+      setIsTitleTouched(false);
+    }
+  }, [isTitleTouched, trimmedTitle]);
+
+  const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextValue = event.target.value.slice(0, STEP_TITLE_LIMIT);
+    setIsTitleTouched(true);
+    onRename(step.id, nextValue);
+  };
+
+  const handleTitleBlur = () => {
+    onCommitName(step.id);
+  };
+
+  const handleNotesChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    onUpdateNotes(step.id, event.target.value);
+  };
+
+  const handleResourceFocus = () => {
+    if (!isResourceSearchOpen || !isResourceSearchOpenForStep) {
+      onRequestResources(step.id);
+    }
+  };
+
+  const handleResourceKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onRequestResources(step.id);
+    }
+  };
+
+  const resourceSummary = step.resourceIds.length
+    ? `${step.resourceIds.length} resource${step.resourceIds.length === 1 ? "" : "s"} added`
+    : "";
+
+  return (
+    <section
+      className="space-y-4 rounded-lg border border-border/60 bg-background/80 p-4"
+      aria-labelledby={`step-${step.id}-label`}
+      data-testid={`lesson-draft-step-${index + 1}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="space-y-1">
+          <p
+            id={`step-${step.id}-label`}
+            className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Step {index + 1}
+          </p>
+          <p className="text-base font-semibold text-foreground">{getStepDisplayTitle(step.title)}</p>
+        </div>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={`Remove step ${index + 1}`}
+            >
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Remove this step?</AlertDialogTitle>
+              <AlertDialogDescription>
+                “{getStepDisplayTitle(step.title)}” will be removed from your lesson plan.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={() => onRemove(step.id)}>Remove step</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`step-${step.id}-title`}>Step {index + 1} title</Label>
+        <Input
+          id={`step-${step.id}-title`}
+          data-testid={`lesson-draft-step-${index + 1}-title`}
+          value={step.title}
+          onChange={handleTitleChange}
+          onBlur={handleTitleBlur}
+          aria-invalid={showTitleError}
+          aria-describedby={helperId}
+          maxLength={STEP_TITLE_LIMIT}
+        />
+        <p
+          id={helperId}
+          className={`text-sm ${showTitleError ? "text-destructive" : "text-muted-foreground"}`}
+        >
+          {showTitleError
+            ? "Each step needs a title. Try something descriptive."
+            : `${remainingCharacters} characters remaining`}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`step-${step.id}-notes`}>Step {index + 1} notes (optional)</Label>
+        <Textarea
+          id={`step-${step.id}-notes`}
+          value={step.notes ?? ""}
+          onChange={handleNotesChange}
+          placeholder="Add facilitation notes, differentiation strategies, or reminders..."
+          rows={3}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`step-${step.id}-resources`}>Step {index + 1} resources</Label>
+        <Input
+          id={`step-${step.id}-resources`}
+          value={resourceSummary}
+          placeholder="Add resources"
+          onFocus={handleResourceFocus}
+          onClick={handleResourceFocus}
+          onKeyDown={handleResourceKeyDown}
+          readOnly
+          role="combobox"
+          aria-haspopup="dialog"
+          aria-expanded={isResourceSearchOpenForStep}
+          aria-controls="lesson-draft-resource-search"
+        />
+        <p className="text-sm text-muted-foreground">
+          Search our library to attach links, files, or activities to this step.
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export const StepEditor = ({
+  onRequestResourceSearch,
+  activeResourceStepId,
+  isResourceSearchOpen,
+}: StepEditorProps) => {
+  const steps = useLessonDraftStore(state => state.draft.steps);
+  const addStep = useLessonDraftStore(state => state.addStep);
+  const renameStep = useLessonDraftStore(state => state.renameStep);
+  const removeStep = useLessonDraftStore(state => state.removeStep);
+  const setStepNotes = useLessonDraftStore(state => state.setStepNotes);
+
+  const [pendingFocusStepId, setPendingFocusStepId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!pendingFocusStepId) {
+      return;
+    }
+
+    const input = document.getElementById(`step-${pendingFocusStepId}-title`) as HTMLInputElement | null;
+    if (input) {
+      input.focus();
+      input.select();
+      setPendingFocusStepId(null);
+    }
+  }, [pendingFocusStepId, steps]);
+
+  const handleAddStep = () => {
+    const step = addStep();
+    setPendingFocusStepId(step.id);
+  };
+
+  const handleCommitName = (stepId: string) => {
+    const step = steps.find(item => item.id === stepId);
+    if (!step) {
+      return;
+    }
+    const trimmed = step.title.trim();
+    if (trimmed.length === 0) {
+      renameStep(stepId, "New step");
+      return;
+    }
+    if (trimmed !== step.title) {
+      renameStep(stepId, trimmed);
+    }
+  };
+
+  const orderedSteps = useMemo(() => steps.map((step, index) => ({ step, index })), [steps]);
+
+  return (
+    <Card aria-labelledby="lesson-draft-step-editor-heading">
+      <CardHeader className="flex flex-col gap-4 border-b border-border/60 pb-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <CardTitle id="lesson-draft-step-editor-heading" className="text-xl">
+            Step editor
+          </CardTitle>
+          <CardDescription>
+            Build your learning sequence and capture teacher-facing notes for each moment.
+          </CardDescription>
+        </div>
+        <Button type="button" onClick={handleAddStep} data-testid="lesson-draft-add-step">
+          <Plus className="mr-2 h-4 w-4" aria-hidden="true" /> Add step
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {orderedSteps.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border/80 bg-muted/40 p-6 text-sm text-muted-foreground">
+            No steps yet. Use the “Add step” button to start outlining your lesson.
+          </p>
+        ) : (
+          <div className="space-y-6">
+            {orderedSteps.map(({ step, index }) => (
+              <StepForm
+                key={step.id}
+                step={step}
+                index={index}
+                onRename={renameStep}
+                onCommitName={handleCommitName}
+                onRemove={removeStep}
+                onUpdateNotes={setStepNotes}
+                onRequestResources={onRequestResourceSearch}
+                isResourceSearchOpen={isResourceSearchOpen}
+                isResourceSearchOpenForStep={isResourceSearchOpen && activeResourceStepId === step.id}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/pages/Builder.tsx
+++ b/src/pages/Builder.tsx
@@ -1,13 +1,76 @@
+import { useCallback, useState } from "react";
+
 import { SEO } from "@/components/SEO";
-import LessonBuilder from "@/features/builder/components/LessonBuilder";
+import { LessonPreview } from "@/components/lesson-draft/LessonPreview";
+import { StepEditor } from "@/components/lesson-draft/StepEditor";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 const BuilderPage = () => {
+  const [isResourceSearchOpen, setIsResourceSearchOpen] = useState(false);
+  const [resourceSearchStepId, setResourceSearchStepId] = useState<string | null>(null);
+
+  const handleRequestResourceSearch = useCallback((stepId: string) => {
+    setResourceSearchStepId(stepId);
+    setIsResourceSearchOpen(true);
+  }, []);
+
+  const handleResourceDialogChange = useCallback((open: boolean) => {
+    setIsResourceSearchOpen(open);
+    if (!open) {
+      setResourceSearchStepId(null);
+    }
+  }, []);
+
   return (
     <div className="min-h-screen bg-muted/20 py-10">
-      <SEO title="Lesson Builder" description="Design tech-rich lessons with favorites, collections, and offline fallbacks." />
-      <main className="container mx-auto">
-        <LessonBuilder />
+      <SEO
+        title="Lesson Builder"
+        description="Design each step of your lesson and watch the live preview update in real time."
+      />
+      <main className="container mx-auto space-y-10">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">Lesson draft builder</h1>
+          <p className="max-w-2xl text-muted-foreground">
+            Capture the flow of your lesson, keep notes for yourself, and prepare the resources students will need.
+          </p>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr),minmax(0,1fr)]">
+          <StepEditor
+            onRequestResourceSearch={handleRequestResourceSearch}
+            activeResourceStepId={resourceSearchStepId}
+            isResourceSearchOpen={isResourceSearchOpen}
+          />
+          <LessonPreview />
+        </div>
       </main>
+
+      <Dialog open={isResourceSearchOpen} onOpenChange={handleResourceDialogChange}>
+        <DialogContent id="lesson-draft-resource-search">
+          <DialogHeader>
+            <DialogTitle>Search resources</DialogTitle>
+            <DialogDescription>
+              Resource search is coming soon. You&apos;ll be able to browse and attach classroom materials in the next update.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="secondary">
+                Close
+              </Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/src/pages/__tests__/Builder.test.tsx
+++ b/src/pages/__tests__/Builder.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import BuilderPage from "../Builder";
+import { createEmptyLessonDraft, useLessonDraftStore } from "@/stores/lessonDraft";
+import { HelmetProvider } from "react-helmet-async";
+
+describe("Lesson draft builder", () => {
+  beforeEach(() => {
+    useLessonDraftStore.setState({ draft: createEmptyLessonDraft() });
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("creates steps and mirrors them in the preview", async () => {
+    const user = userEvent.setup();
+    render(
+      <HelmetProvider>
+        <BuilderPage />
+      </HelmetProvider>,
+    );
+
+    const addButton = screen.getByRole("button", { name: /add step/i });
+    await user.click(addButton);
+
+    const titleInput = await screen.findByLabelText(/step 1 title/i);
+    expect(titleInput).toHaveValue("New step");
+
+    await user.clear(titleInput);
+    await user.type(titleInput, "Warm-up discussion");
+
+    const previewItem = await screen.findByTestId("lesson-draft-preview-step-1");
+    expect(previewItem).toHaveTextContent("Warm-up discussion");
+
+    const notesField = screen.getByLabelText(/step 1 notes/i);
+    await user.type(notesField, "Greet students and introduce the prompt.");
+
+    expect(previewItem).toHaveTextContent("Greet students");
+  });
+
+  it("restores default title when left blank", async () => {
+    const user = userEvent.setup();
+    render(
+      <HelmetProvider>
+        <BuilderPage />
+      </HelmetProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add step/i }));
+
+    const titleInput = await screen.findByLabelText(/step 1 title/i);
+    await user.clear(titleInput);
+
+    const helper = await screen.findByText(/each step needs a title/i);
+    expect(helper).toBeInTheDocument();
+
+    titleInput.blur();
+
+    const previewItem = await screen.findByTestId("lesson-draft-preview-step-1");
+    expect(previewItem).toHaveTextContent("New step");
+  });
+
+  it("removes a step after confirmation", async () => {
+    const user = userEvent.setup();
+    render(
+      <HelmetProvider>
+        <BuilderPage />
+      </HelmetProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add step/i }));
+
+    const removeButton = await screen.findByRole("button", { name: /remove step 1/i });
+    await user.click(removeButton);
+
+    const dialog = await screen.findByRole("alertdialog");
+    const confirmButton = within(dialog).getByRole("button", { name: /remove step/i });
+    await user.click(confirmButton);
+
+    expect(screen.queryByTestId("lesson-draft-step-1")).not.toBeInTheDocument();
+    expect(screen.getByText(/no steps yet/i)).toBeInTheDocument();
+  });
+
+  it("opens the resource search modal when focusing the input", async () => {
+    const user = userEvent.setup();
+    render(
+      <HelmetProvider>
+        <BuilderPage />
+      </HelmetProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add step/i }));
+
+    const resourceInput = await screen.findByLabelText(/step 1 resources/i);
+    resourceInput.focus();
+
+    const dialog = await screen.findByRole("dialog", { name: /search resources/i });
+    expect(dialog).toBeInTheDocument();
+
+    const [closeButton] = within(dialog).getAllByRole("button", { name: /close/i });
+    await user.click(closeButton);
+
+    expect(screen.queryByRole("dialog", { name: /search resources/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/stores/lessonDraft.ts
+++ b/src/stores/lessonDraft.ts
@@ -32,6 +32,7 @@ type LessonDraftStore = {
   addStep: () => LessonStep;
   renameStep: (stepId: string, title: string) => void;
   removeStep: (stepId: string) => void;
+  setStepNotes: (stepId: string, notes: string) => void;
   attachResource: (stepId: string, resourceId: string) => void;
   detachResource: (stepId: string, resourceId: string) => void;
   resetDraft: () => void;
@@ -164,6 +165,21 @@ export const useLessonDraftStore = create<LessonDraftStore>()((set, get) => ({
             ? {
                 ...step,
                 title,
+              }
+            : step,
+        ),
+      },
+    }));
+  },
+  setStepNotes: (stepId, notes) => {
+    set((state) => ({
+      draft: {
+        ...state.draft,
+        steps: state.draft.steps.map((step) =>
+          step.id === stepId
+            ? {
+                ...step,
+                notes: notes.trim().length > 0 ? notes : undefined,
               }
             : step,
         ),


### PR DESCRIPTION
## Summary
- build dedicated step editor and preview panes for the lesson draft workflow
- wire the builder page to the lesson draft store with a placeholder resource search dialog
- extend the draft store with step notes handling and add UI regression tests for the new flow

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d1170bfd7083319fa350c8e3d96c48