### PR TITLE
Improve lesson preview resource rendering

### DIFF
--- a/src/components/lesson-draft/LessonPreview.tsx
+++ b/src/components/lesson-draft/LessonPreview.tsx
@@ -1,5 +1,11 @@
+import { useEffect, useMemo, useState } from "react";
+
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ResourceCard } from "./ResourceCard";
 import { useLessonDraftStore } from "@/stores/lessonDraft";
+import { getResourcesByIds } from "@/lib/resources";
+import type { Resource } from "@/types/resources";
 
 const getStepDisplayTitle = (title: string) => {
   const trimmed = title.trim();
@@ -8,6 +14,96 @@ const getStepDisplayTitle = (title: string) => {
 
 export const LessonPreview = () => {
   const steps = useLessonDraftStore(state => state.draft.steps);
+  const [resourcesById, setResourcesById] = useState<Record<string, Resource | null>>({});
+
+  const uniqueResourceIds = useMemo(() => {
+    const ids = new Set<string>();
+    steps.forEach(step => {
+      step.resourceIds.forEach(resourceId => {
+        if (typeof resourceId === "string" && resourceId.trim().length > 0) {
+          ids.add(resourceId);
+        }
+      });
+    });
+    return Array.from(ids);
+  }, [steps]);
+
+  useEffect(() => {
+    if (uniqueResourceIds.length === 0) {
+      setResourcesById({});
+      return;
+    }
+
+    setResourcesById(prev => {
+      const next = { ...prev };
+      let changed = false;
+      Object.keys(next).forEach(id => {
+        if (!uniqueResourceIds.includes(id)) {
+          delete next[id];
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [uniqueResourceIds]);
+
+  useEffect(() => {
+    if (uniqueResourceIds.length === 0) {
+      return;
+    }
+
+    const missing = uniqueResourceIds.filter(id => resourcesById[id] === undefined);
+
+    if (missing.length === 0) {
+      return;
+    }
+
+    let isCancelled = false;
+
+    getResourcesByIds(missing)
+      .then(fetched => {
+        if (isCancelled) {
+          return;
+        }
+
+        setResourcesById(prev => {
+          const next = { ...prev };
+          const receivedIds = new Set<string>();
+
+          fetched.forEach(resource => {
+            next[resource.id] = resource;
+            receivedIds.add(resource.id);
+          });
+
+          missing.forEach(id => {
+            if (!receivedIds.has(id)) {
+              next[id] = null;
+            }
+          });
+
+          return next;
+        });
+      })
+      .catch(error => {
+        console.error(error);
+        if (isCancelled) {
+          return;
+        }
+        setResourcesById(prev => {
+          const next = { ...prev };
+          missing.forEach(id => {
+            if (!(id in next)) {
+              next[id] = null;
+            }
+          });
+          return next;
+        });
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [uniqueResourceIds, resourcesById]);
 
   return (
     <Card aria-labelledby="lesson-draft-preview-heading">
@@ -26,27 +122,70 @@ export const LessonPreview = () => {
           </p>
         ) : (
           <ol className="space-y-4" aria-live="polite">
-            {steps.map((step, index) => (
-              <li
-                key={step.id}
-                className="space-y-2 rounded-lg border border-border/70 bg-background/80 p-4"
-                data-testid={`lesson-draft-preview-step-${index + 1}`}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <h3 className="text-base font-semibold text-foreground">
-                    Step {index + 1}: {getStepDisplayTitle(step.title)}
-                  </h3>
-                  <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    {step.resourceIds.length} resource{step.resourceIds.length === 1 ? "" : "s"}
-                  </span>
-                </div>
-                {step.notes ? (
-                  <p className="whitespace-pre-wrap text-sm text-muted-foreground">{step.notes}</p>
-                ) : (
-                  <p className="text-xs text-muted-foreground">No notes added for this step yet.</p>
-                )}
-              </li>
-            ))}
+            {steps.map((step, index) => {
+              const trimmedNotes = step.notes?.trim() ?? "";
+              const hasNotes = trimmedNotes.length > 0;
+              const hasResourceIds = step.resourceIds.length > 0;
+              const resourceCountLabel = step.resourceIds.length;
+
+              const hasResolvedResources = step.resourceIds.some(id => Boolean(resourcesById[id]));
+              const shouldRenderResources = hasResourceIds && (hasResolvedResources || step.resourceIds.some(id => resourcesById[id] === undefined));
+
+              return (
+                <li
+                  key={step.id}
+                  className="space-y-3 rounded-lg border border-border/70 bg-background/80 p-4"
+                  data-testid={`lesson-draft-preview-step-${index + 1}`}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <h3 className="text-base font-semibold text-foreground">
+                      Step {index + 1}: {getStepDisplayTitle(step.title)}
+                    </h3>
+                    {hasResourceIds ? (
+                      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {resourceCountLabel} resource{resourceCountLabel === 1 ? "" : "s"}
+                      </span>
+                    ) : null}
+                  </div>
+
+                  {hasNotes ? (
+                    <p className="whitespace-pre-wrap text-sm text-muted-foreground">{trimmedNotes}</p>
+                  ) : null}
+
+                  {shouldRenderResources ? (
+                    <div className="space-y-3">
+                      {step.resourceIds.map(resourceId => {
+                        const resource = resourcesById[resourceId];
+                        if (resource === undefined) {
+                          return (
+                            <div
+                              key={`${step.id}-${resourceId}-skeleton`}
+                              className="flex gap-3 rounded-lg border border-dashed border-border/60 bg-muted/40 p-3"
+                            >
+                              <Skeleton className="h-16 w-24 rounded-md" />
+                              <div className="flex-1 space-y-2">
+                                <Skeleton className="h-4 w-3/4" />
+                                <Skeleton className="h-3 w-2/3" />
+                                <div className="flex gap-2">
+                                  <Skeleton className="h-4 w-16 rounded-full" />
+                                  <Skeleton className="h-4 w-16 rounded-full" />
+                                </div>
+                              </div>
+                            </div>
+                          );
+                        }
+
+                        if (resource === null) {
+                          return null;
+                        }
+
+                        return <ResourceCard key={`${step.id}-${resource.id}`} resource={resource} />;
+                      })}
+                    </div>
+                  ) : null}
+                </li>
+              );
+            })}
           </ol>
         )}
       </CardContent>

--- a/src/components/lesson-draft/ResourceCard.tsx
+++ b/src/components/lesson-draft/ResourceCard.tsx
@@ -1,0 +1,66 @@
+import { Badge } from "@/components/ui/badge";
+import type { Resource } from "@/types/resources";
+
+interface ResourceCardProps {
+  resource: Resource;
+}
+
+const formatMetadata = (resource: Resource) => {
+  const metadata: string[] = [];
+  if (resource.type?.trim()) {
+    metadata.push(resource.type.trim());
+  }
+  if (resource.subject?.trim()) {
+    metadata.push(resource.subject.trim());
+  }
+  if (resource.stage?.trim()) {
+    metadata.push(resource.stage.trim());
+  }
+  return metadata;
+};
+
+export const ResourceCard = ({ resource }: ResourceCardProps) => {
+  const metadata = formatMetadata(resource);
+  const tags = resource.tags?.filter(tag => tag.trim().length > 0).slice(0, 4) ?? [];
+
+  return (
+    <article className="flex gap-3 rounded-lg border border-border/70 bg-background/80 p-3 shadow-sm">
+      <div className="h-16 w-24 flex-shrink-0 overflow-hidden rounded-md bg-muted">
+        {resource.thumbnail_url ? (
+          <img
+            src={resource.thumbnail_url}
+            alt=""
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-[11px] text-muted-foreground">
+            No preview
+          </div>
+        )}
+      </div>
+      <div className="min-w-0 flex-1 space-y-2">
+        <p className="line-clamp-2 text-sm font-semibold text-foreground">{resource.title}</p>
+        {resource.description ? (
+          <p className="line-clamp-2 text-xs text-muted-foreground">{resource.description}</p>
+        ) : null}
+        {metadata.length || tags.length ? (
+          <div className="flex flex-wrap gap-1 text-xs text-muted-foreground">
+            {metadata.map(item => (
+              <Badge key={`meta-${item}`} variant="outline">
+                {item}
+              </Badge>
+            ))}
+            {tags.map(tag => (
+              <Badge key={`tag-${tag}`} variant="secondary" className="rounded-full">
+                #{tag}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </article>
+  );
+};
+
+export default ResourceCard;


### PR DESCRIPTION
## Summary
- batch lesson preview resource fetching and cache lookups to avoid duplicate Supabase calls
- render attached resources with a dedicated ResourceCard component and skeleton placeholders while loading
- add a helper to load multiple resources by id so the preview stays in sync with step attachments

## Testing
- `npm run lint`
- `npm run test` *(fails: vitest cannot resolve the `zustand` import from src/stores/lessonDraft.ts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d12ee3ab3c83318c6d4700908d37a6