### PR TITLE
Improve resource UX and lesson preview layout

### DIFF
--- a/src/components/lesson-draft/LessonPreview.tsx
+++ b/src/components/lesson-draft/LessonPreview.tsx
@@ -12,7 +12,11 @@ const getStepDisplayTitle = (title: string) => {
   return trimmed.length > 0 ? trimmed : "New step";
 };
 
-export const LessonPreview = () => {
+type LessonPreviewProps = {
+  headingId?: string;
+};
+
+export const LessonPreview = ({ headingId = "lesson-draft-preview-heading" }: LessonPreviewProps) => {
   const steps = useLessonDraftStore(state => state.draft.steps);
   const [resourcesById, setResourcesById] = useState<Record<string, Resource | null>>({});
 
@@ -106,9 +110,9 @@ export const LessonPreview = () => {
   }, [uniqueResourceIds, resourcesById]);
 
   return (
-    <Card aria-labelledby="lesson-draft-preview-heading">
+    <Card aria-labelledby={headingId}>
       <CardHeader>
-        <CardTitle id="lesson-draft-preview-heading" className="text-xl">
+        <CardTitle id={headingId} className="text-xl">
           Lesson preview
         </CardTitle>
         <CardDescription>

--- a/src/components/lesson-draft/ResourceCard.tsx
+++ b/src/components/lesson-draft/ResourceCard.tsx
@@ -61,19 +61,23 @@ export const ResourceCard = ({
 
   const content = (
     <div className={cn("min-w-0 flex-1 space-y-2", isVertical && "min-w-full")}>
-      <p className="line-clamp-2 text-sm font-semibold text-foreground">{resource.title}</p>
+      <p className="line-clamp-2 break-words text-sm font-semibold text-foreground">{resource.title}</p>
       {resource.description ? (
         <p className="line-clamp-2 text-xs text-muted-foreground">{resource.description}</p>
       ) : null}
       {metadata.length || tags.length ? (
         <div className="flex flex-wrap gap-1 text-xs text-muted-foreground">
           {metadata.map(item => (
-            <Badge key={`meta-${item}`} variant="outline">
+            <Badge key={`meta-${item}`} variant="outline" className="max-w-full break-words whitespace-normal">
               {item}
             </Badge>
           ))}
           {tags.map(tag => (
-            <Badge key={`tag-${tag}`} variant="secondary" className="rounded-full">
+            <Badge
+              key={`tag-${tag}`}
+              variant="secondary"
+              className="max-w-full break-words whitespace-normal rounded-full"
+            >
               #{tag}
             </Badge>
           ))}

--- a/src/pages/resources/index.tsx
+++ b/src/pages/resources/index.tsx
@@ -421,6 +421,7 @@ const ResourcesPage = () => {
                   <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
                     id="resource-search"
+                    type="search"
                     value={filters.searchValue}
                     onChange={event =>
                       setFilters(current => ({ ...current, searchValue: event.target.value }))
@@ -514,7 +515,7 @@ const ResourcesPage = () => {
 
           <section className="space-y-6">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm text-muted-foreground">
+              <p className="text-sm text-muted-foreground" role="status" aria-live="polite">
                 Showing {sortedResources.length} resource{sortedResources.length === 1 ? "" : "s"}
                 {data?.pages?.[0]?.total ? ` of ${data.pages[0].total}` : ""}
               </p>
@@ -537,14 +538,24 @@ const ResourcesPage = () => {
             </div>
 
             {isError ? (
-              <div className="flex flex-col items-center gap-4 rounded-3xl border border-dashed border-destructive/40 bg-destructive/5 p-12 text-center text-destructive">
+              <div
+                className="flex flex-col items-center gap-4 rounded-3xl border border-dashed border-destructive/40 bg-destructive/5 p-12 text-center text-destructive"
+                role="alert"
+                aria-live="assertive"
+              >
                 <p className="text-base font-medium">We couldn&apos;t load resources right now.</p>
                 <Button type="button" variant="outline" onClick={() => refetch()}>
                   Try again
                 </Button>
               </div>
             ) : isInitialLoading ? (
-              <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+              <div
+                className="grid gap-6 md:grid-cols-2 xl:grid-cols-3"
+                role="status"
+                aria-live="polite"
+                aria-busy="true"
+              >
+                <span className="sr-only">Loading resources…</span>
                 {Array.from({ length: 6 }).map((_, index) => (
                   <Card key={index} className="overflow-hidden border shadow-sm">
                     <Skeleton className="aspect-video w-full" />
@@ -561,7 +572,11 @@ const ResourcesPage = () => {
                 ))}
               </div>
             ) : sortedResources.length === 0 ? (
-              <div className="flex flex-col items-center gap-4 rounded-3xl border border-dashed p-12 text-center">
+              <div
+                className="flex flex-col items-center gap-4 rounded-3xl border border-dashed p-12 text-center"
+                role="status"
+                aria-live="polite"
+              >
                 <p className="text-lg font-semibold">No resources match your filters yet.</p>
                 <p className="max-w-md text-sm text-muted-foreground">
                   Try removing some filters or searching for a different keyword to explore more of the library.
@@ -571,7 +586,10 @@ const ResourcesPage = () => {
                 </Button>
               </div>
             ) : (
-              <div className={cn(view === "grid" ? "grid gap-6 md:grid-cols-2 xl:grid-cols-3" : "space-y-4")}>
+              <div
+                className={cn(view === "grid" ? "grid gap-6 md:grid-cols-2 xl:grid-cols-3" : "space-y-4")}
+                aria-busy={isFetchingNextPage}
+              >
                 {sortedResources.map(resource => (
                   <ResourceCardView
                     key={resource.id}


### PR DESCRIPTION
## Summary
- add accessibility upgrades to the lesson draft resource search modal including escape-to-close, focus management, and resilient tag rendering
- make the lesson preview sticky on desktop, expose it as a mobile sheet drawer, and allow overriding its heading id to avoid duplicates
- enhance the public resources page with semantic loading/empty states, search input tweaks, and better wrapping for long titles and tags

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d14a03501c83318b55c81b2663e88c