### PR TITLE
Add pending resource upload API and client form

### DIFF
--- a/api/resources/upload.ts
+++ b/api/resources/upload.ts
@@ -1,0 +1,266 @@
+import { errorResponse, jsonResponse, methodNotAllowed, normalizeMethod } from "../_lib/http";
+import { getSupabaseClient } from "../_lib/supabase";
+
+type ResourceType = "worksheet" | "video" | "picture" | "ppt" | "online" | "offline";
+
+type InsertedResource = {
+  id: string;
+  title: string;
+  description: string | null;
+  url: string | null;
+  storage_path: string | null;
+  type: ResourceType;
+  subject: string | null;
+  stage: string | null;
+  tags: string[];
+  thumbnail_url: string | null;
+  created_by: string | null;
+  created_at: string;
+  status: string;
+  is_active: boolean;
+};
+
+const VALID_TYPES: ResourceType[] = ["worksheet", "video", "picture", "ppt", "online", "offline"];
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+
+  if (method !== "POST") {
+    return methodNotAllowed(["POST"]);
+  }
+
+  const accessToken = extractAccessToken(request);
+  if (!accessToken) {
+    return errorResponse(401, "Authentication required");
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return errorResponse(400, "Invalid form data");
+  }
+
+  const supabase = getSupabaseClient();
+  const { data: userResult, error: authError } = await supabase.auth.getUser(accessToken);
+
+  if (authError || !userResult?.user?.id) {
+    return errorResponse(401, "Authentication required");
+  }
+
+  const userId = userResult.user.id;
+
+  const title = getRequiredField(formData, "title");
+  if (!title) {
+    return errorResponse(422, "A title is required");
+  }
+
+  const typeInput = getRequiredField(formData, "type");
+  if (!typeInput) {
+    return errorResponse(422, "A resource type is required");
+  }
+
+  const normalizedType = typeInput.toLowerCase() as ResourceType;
+  if (!VALID_TYPES.includes(normalizedType)) {
+    return errorResponse(422, "Invalid resource type");
+  }
+
+  const description = getOptionalField(formData, "description");
+  const subject = getOptionalField(formData, "subject");
+  const stage = getOptionalField(formData, "stage");
+  const thumbnailUrl = getOptionalField(formData, "thumbnail");
+
+  const urlValue = getOptionalUrl(formData, "url");
+  if (urlValue === false) {
+    return errorResponse(422, "Invalid resource URL");
+  }
+
+  const tags = parseTags(formData);
+
+  const fileEntry = formData.get("file");
+  let storagePath: string | null = null;
+
+  if (fileEntry instanceof File && fileEntry.size > 0) {
+    const extension = resolveFileExtension(fileEntry);
+    const fileName = `${crypto.randomUUID()}.${extension}`;
+    storagePath = `resources/uploads/${userId}/${fileName}`;
+
+    const { error: uploadError } = await supabase.storage.from("resources").upload(storagePath, fileEntry, {
+      cacheControl: "3600",
+      upsert: false,
+      contentType: fileEntry.type || "application/octet-stream",
+    });
+
+    if (uploadError) {
+      return errorResponse(500, "Failed to store uploaded file");
+    }
+  } else if (fileEntry instanceof File && fileEntry.size === 0) {
+    return errorResponse(422, "Uploaded file is empty");
+  }
+
+  if (!storagePath && !urlValue) {
+    return errorResponse(422, "Either a file or an external URL is required");
+  }
+
+  const insertPayload = {
+    title,
+    description,
+    url: urlValue ?? null,
+    storage_path: storagePath,
+    type: normalizedType,
+    subject,
+    stage,
+    tags,
+    thumbnail_url: thumbnailUrl,
+    created_by: userId,
+    status: "pending" as const,
+  } satisfies Partial<InsertedResource> & { title: string; type: ResourceType; created_by: string; status: "pending" };
+
+  const { data, error } = await supabase
+    .from("resources")
+    .insert(insertPayload)
+    .select(
+      "id,title,description,url,storage_path,type,subject,stage,tags,thumbnail_url,created_by,status,is_active,created_at",
+    )
+    .single<InsertedResource>();
+
+  if (error || !data) {
+    return errorResponse(500, "Failed to create resource");
+  }
+
+  return jsonResponse({ resource: data }, 201);
+}
+
+function getRequiredField(formData: FormData, name: string): string | null {
+  const value = formData.get(name);
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getOptionalField(formData: FormData, name: string): string | null {
+  const value = formData.get(name);
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getOptionalUrl(formData: FormData, name: string): string | null | false {
+  const value = getOptionalField(formData, name);
+  if (!value) {
+    return value;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false;
+    }
+    return parsed.toString();
+  } catch {
+    return false;
+  }
+}
+
+function parseTags(formData: FormData): string[] {
+  const rawValues = [...formData.getAll("tags[]"), ...formData.getAll("tags")];
+  const collected: string[] = [];
+
+  for (const value of rawValues) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (Array.isArray(parsed)) {
+          for (const entry of parsed) {
+            if (typeof entry === "string" && entry.trim()) {
+              collected.push(entry.trim());
+            }
+          }
+          continue;
+        }
+      } catch {
+        // fall through to simple handling
+      }
+    }
+
+    if (trimmed.includes(",")) {
+      for (const part of trimmed.split(",")) {
+        const tag = part.trim();
+        if (tag) {
+          collected.push(tag);
+        }
+      }
+      continue;
+    }
+
+    collected.push(trimmed);
+  }
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const tag of collected) {
+    const normalised = tag.trim();
+    if (!normalised || seen.has(normalised.toLowerCase())) {
+      continue;
+    }
+    seen.add(normalised.toLowerCase());
+    result.push(normalised);
+  }
+
+  return result;
+}
+
+function resolveFileExtension(file: File): string {
+  const nameParts = (file.name ?? "").split(".");
+  if (nameParts.length > 1) {
+    const candidate = nameParts.pop();
+    if (candidate && /^[a-zA-Z0-9]{1,8}$/.test(candidate)) {
+      return candidate.toLowerCase();
+    }
+  }
+
+  if (file.type && file.type.includes("/")) {
+    const subtype = file.type.split("/").pop();
+    if (subtype && /^[a-zA-Z0-9.+-]{1,16}$/.test(subtype)) {
+      return subtype.toLowerCase().replace(/[^a-z0-9]+/g, "");
+    }
+  }
+
+  return "bin";
+}
+
+function extractAccessToken(request: Request): string | null {
+  const header = request.headers.get("authorization") ?? request.headers.get("Authorization");
+  if (header) {
+    const match = header.match(/^Bearer\s+(.+)$/i);
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+
+  const cookieHeader = request.headers.get("cookie") ?? request.headers.get("Cookie");
+  if (cookieHeader) {
+    const cookies = cookieHeader.split(";");
+    for (const rawCookie of cookies) {
+      const [name, ...rest] = rawCookie.trim().split("=");
+      if (name === "sb-access-token") {
+        return decodeURIComponent(rest.join("="));
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/components/resources/ResourceUploadForm.tsx
+++ b/src/components/resources/ResourceUploadForm.tsx
@@ -1,0 +1,435 @@
+import { useRef, useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from "react";
+import { Loader2, X } from "lucide-react";
+
+import { supabase } from "@/integrations/supabase/client";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+interface PendingResource {
+  id: string;
+  title: string;
+  description: string | null;
+  url: string | null;
+  storage_path: string | null;
+  type: string;
+  subject: string | null;
+  stage: string | null;
+  tags: string[];
+  thumbnail_url: string | null;
+  created_by: string | null;
+  created_at: string;
+  status: string;
+  is_active: boolean;
+}
+
+const RESOURCE_TYPE_OPTIONS = [
+  { label: "Worksheet", value: "worksheet" },
+  { label: "Video", value: "video" },
+  { label: "Picture", value: "picture" },
+  { label: "Presentation", value: "ppt" },
+  { label: "Online activity", value: "online" },
+  { label: "Offline activity", value: "offline" },
+] as const;
+
+const STAGE_SUGGESTIONS = [
+  "Early Childhood",
+  "Primary",
+  "Lower Secondary",
+  "Upper Secondary",
+  "Higher Education",
+];
+
+const SUBJECT_SUGGESTIONS = [
+  "Math",
+  "Science",
+  "English",
+  "Social Studies",
+  "STEM",
+  "ICT",
+  "Arts",
+  "Languages",
+];
+
+export function ResourceUploadForm() {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [resourceType, setResourceType] = useState<string>("");
+  const [subject, setSubject] = useState("");
+  const [stage, setStage] = useState("");
+  const [url, setUrl] = useState("");
+  const [thumbnail, setThumbnail] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingResource, setPendingResource] = useState<PendingResource | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const addTag = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+
+    setTags(previous => {
+      if (previous.some(tag => tag.toLowerCase() === trimmed.toLowerCase())) {
+        return previous;
+      }
+      return [...previous, trimmed];
+    });
+  };
+
+  const commitTagInput = () => {
+    addTag(tagInput);
+    setTagInput("");
+  };
+
+  const handleTagKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      commitTagInput();
+    }
+  };
+
+  const handleRemoveTag = (value: string) => {
+    setTags(previous => previous.filter(tag => tag.toLowerCase() !== value.toLowerCase()));
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextFile = event.target.files?.[0] ?? null;
+    setFile(nextFile);
+  };
+
+  const resetForm = () => {
+    setTitle("");
+    setDescription("");
+    setResourceType("");
+    setSubject("");
+    setStage("");
+    setUrl("");
+    setThumbnail("");
+    setTags([]);
+    setTagInput("");
+    setFile(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+      if (sessionError) {
+        throw new Error("Unable to verify authentication");
+      }
+
+      const accessToken = sessionData.session?.access_token;
+      if (!accessToken) {
+        throw new Error("You must be signed in to upload a resource.");
+      }
+
+      if (!resourceType) {
+        throw new Error("Please choose a resource type.");
+      }
+
+      const formData = new FormData();
+      formData.append("title", title.trim());
+      formData.append("type", resourceType);
+
+      if (description.trim()) formData.append("description", description.trim());
+      if (subject.trim()) formData.append("subject", subject.trim());
+      if (stage.trim()) formData.append("stage", stage.trim());
+      if (url.trim()) formData.append("url", url.trim());
+      if (thumbnail.trim()) formData.append("thumbnail", thumbnail.trim());
+
+      tags.forEach(tag => {
+        formData.append("tags[]", tag);
+      });
+
+      if (file) {
+        formData.append("file", file);
+      }
+
+      const response = await fetch("/api/resources/upload", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: formData,
+      });
+
+      const payload = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        const message = (payload && typeof payload.error === "string" && payload.error) || "Failed to upload resource.";
+        throw new Error(message);
+      }
+
+      if (payload?.resource) {
+        setPendingResource(payload.resource as PendingResource);
+      } else {
+        setPendingResource(null);
+      }
+
+      resetForm();
+    } catch (submitError) {
+      setPendingResource(null);
+      if (submitError instanceof Error) {
+        setError(submitError.message);
+      } else {
+        setError("Something went wrong while submitting your resource.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const canSubmit = Boolean(title.trim() && resourceType && (file || url.trim()));
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card className="shadow-sm">
+          <CardHeader>
+            <CardTitle>Share a classroom resource</CardTitle>
+            <CardDescription>
+              Upload lesson materials or link to helpful content. Submissions remain hidden until an administrator approves them.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {error ? (
+              <Alert variant="destructive">
+                <AlertTitle>Upload failed</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            ) : null}
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="resource-title">Title</Label>
+                <Input
+                  id="resource-title"
+                  value={title}
+                  onChange={event => setTitle(event.target.value)}
+                  placeholder="e.g. Fractions practice worksheet"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="resource-type">Resource type</Label>
+                <Select value={resourceType || undefined} onValueChange={setResourceType}>
+                  <SelectTrigger id="resource-type">
+                    <SelectValue placeholder="Choose a type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {RESOURCE_TYPE_OPTIONS.map(option => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="resource-description">Description</Label>
+              <Textarea
+                id="resource-description"
+                value={description}
+                onChange={event => setDescription(event.target.value)}
+                rows={4}
+                placeholder="Provide context for how educators can use this resource."
+              />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="resource-subject">Subject</Label>
+                <Input
+                  id="resource-subject"
+                  list="resource-subject-suggestions"
+                  value={subject}
+                  onChange={event => setSubject(event.target.value)}
+                  placeholder="e.g. Math"
+                />
+                <datalist id="resource-subject-suggestions">
+                  {SUBJECT_SUGGESTIONS.map(option => (
+                    <option key={option} value={option} />
+                  ))}
+                </datalist>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="resource-stage">Stage / grade</Label>
+                <Input
+                  id="resource-stage"
+                  list="resource-stage-suggestions"
+                  value={stage}
+                  onChange={event => setStage(event.target.value)}
+                  placeholder="e.g. Lower Secondary"
+                />
+                <datalist id="resource-stage-suggestions">
+                  {STAGE_SUGGESTIONS.map(option => (
+                    <option key={option} value={option} />
+                  ))}
+                </datalist>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="resource-tags">Tags</Label>
+              <div className="flex flex-wrap items-center gap-2">
+                <Input
+                  id="resource-tags"
+                  value={tagInput}
+                  onChange={event => setTagInput(event.target.value)}
+                  onKeyDown={handleTagKeyDown}
+                  placeholder="Press enter to add each tag"
+                  className="max-w-xs"
+                />
+                <Button type="button" variant="secondary" size="sm" onClick={commitTagInput} disabled={!tagInput.trim()}>
+                  Add tag
+                </Button>
+              </div>
+              {tags.length > 0 ? (
+                <div className="flex flex-wrap gap-2 pt-1">
+                  {tags.map(tag => (
+                    <Badge key={tag} variant="secondary" className="flex items-center gap-1">
+                      <span>{tag}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveTag(tag)}
+                        className="rounded-full p-0.5 text-muted-foreground hover:bg-background/60"
+                        aria-label={`Remove tag ${tag}`}
+                      >
+                        <X className="h-3 w-3" aria-hidden />
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="resource-url">Resource URL</Label>
+                <Input
+                  id="resource-url"
+                  value={url}
+                  onChange={event => setUrl(event.target.value)}
+                  placeholder="https://"
+                  type="url"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="resource-thumbnail">Thumbnail URL</Label>
+                <Input
+                  id="resource-thumbnail"
+                  value={thumbnail}
+                  onChange={event => setThumbnail(event.target.value)}
+                  placeholder="Optional preview image"
+                  type="url"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="resource-file">Upload file</Label>
+              <Input id="resource-file" ref={fileInputRef} type="file" onChange={handleFileChange} />
+              <p className="text-sm text-muted-foreground">
+                Provide either a file upload or an external link. Files are stored securely until approved.
+              </p>
+              {file ? <p className="text-sm text-muted-foreground">Selected file: {file.name}</p> : null}
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              Your submission will appear in your account as <span className="font-medium">pending</span> until an administrator reviews it.
+            </p>
+            <Button type="submit" disabled={!canSubmit || isSubmitting}>
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                  Uploading...
+                </>
+              ) : (
+                "Submit for review"
+              )}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+
+      {pendingResource ? (
+        <Card className="border-dashed">
+          <CardHeader>
+            <CardTitle className="flex flex-wrap items-center justify-between gap-2">
+              <span>{pendingResource.title}</span>
+              <Badge variant="outline" className="uppercase tracking-wide">
+                {pendingResource.status}
+              </Badge>
+            </CardTitle>
+            <CardDescription>
+              This resource has been queued for review. Once approved it will appear publicly in the library.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <div>
+              <span className="font-medium text-foreground">Submitted:</span>{" "}
+              {new Date(pendingResource.created_at).toLocaleString()}
+            </div>
+            <div>
+              <span className="font-medium text-foreground">Type:</span>{" "}
+              <span className="capitalize">{pendingResource.type}</span>
+            </div>
+            {pendingResource.subject ? (
+              <div>
+                <span className="font-medium text-foreground">Subject:</span> {pendingResource.subject}
+              </div>
+            ) : null}
+            {pendingResource.stage ? (
+              <div>
+                <span className="font-medium text-foreground">Stage:</span> {pendingResource.stage}
+              </div>
+            ) : null}
+            {pendingResource.url ? (
+              <div>
+                <span className="font-medium text-foreground">External link:</span>{" "}
+                <a href={pendingResource.url} className="text-primary underline" target="_blank" rel="noreferrer">
+                  {pendingResource.url}
+                </a>
+              </div>
+            ) : null}
+            {pendingResource.storage_path ? (
+              <div>
+                <span className="font-medium text-foreground">Stored file:</span> {pendingResource.storage_path}
+              </div>
+            ) : null}
+            {pendingResource.tags.length ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-medium text-foreground">Tags:</span>
+                {pendingResource.tags.map(tag => (
+                  <Badge key={tag} variant="secondary">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+}
+
+export default ResourceUploadForm;


### PR DESCRIPTION
## Summary
- add an authenticated `/api/resources/upload` endpoint that stores uploads as pending resources and supports either file storage or external URLs
- introduce a reusable `ResourceUploadForm` component that captures metadata, tags, optional file uploads, and shows the pending submission summary

## Testing
- npm run lint
- npm test *(fails: existing lessonDraft store reset assertion and Builder page tests expect a QueryClient provider)*

------
https://chatgpt.com/codex/tasks/task_e_68d15a784fa4833199bb1af6f63ccaea