### PR TITLE
Add strict RLS policies for classes and research tables

### DIFF
--- a/supabase/migrations/20251105000000_update_rls_policies.sql
+++ b/supabase/migrations/20251105000000_update_rls_policies.sql
@@ -1,0 +1,657 @@
+-- Update RLS policies to lock down classes, lesson plans, and research tables
+
+-- Drop existing policies that are superseded by this migration
+DROP POLICY IF EXISTS "Classes are viewable by owners and members" ON public.classes;
+DROP POLICY IF EXISTS "Class owners insert classes" ON public.classes;
+DROP POLICY IF EXISTS "Class owners manage classes" ON public.classes;
+DROP POLICY IF EXISTS "Class owners delete classes" ON public.classes;
+
+DROP POLICY IF EXISTS "Members view class memberships" ON public.class_members;
+DROP POLICY IF EXISTS "Owners manage class memberships" ON public.class_members;
+
+DROP POLICY IF EXISTS "Lesson plans are viewable by owners and linked classes" ON public.lesson_plans;
+DROP POLICY IF EXISTS "Lesson plan owners insert" ON public.lesson_plans;
+DROP POLICY IF EXISTS "Lesson plan owners update" ON public.lesson_plans;
+DROP POLICY IF EXISTS "Lesson plan owners delete" ON public.lesson_plans;
+
+DROP POLICY IF EXISTS "Lesson plan steps follow plan access" ON public.lesson_plan_steps;
+DROP POLICY IF EXISTS "Lesson plan owners manage steps" ON public.lesson_plan_steps;
+
+DROP POLICY IF EXISTS "Class links visible to related users" ON public.class_lesson_plans;
+DROP POLICY IF EXISTS "Owners link lesson plans to classes" ON public.class_lesson_plans;
+
+DROP POLICY IF EXISTS "Saved posts owned by user" ON public.saved_posts;
+
+DROP POLICY IF EXISTS "Notifications visible to owners" ON public.notifications;
+DROP POLICY IF EXISTS "Notifications can be inserted by system or owner" ON public.notifications;
+DROP POLICY IF EXISTS "Notifications manageable by owners" ON public.notifications;
+DROP POLICY IF EXISTS "Notifications deletable by owners" ON public.notifications;
+
+DROP POLICY IF EXISTS "Notification prefs owned by user" ON public.notification_prefs;
+
+DROP POLICY IF EXISTS "Research projects visibility" ON public.research_projects;
+DROP POLICY IF EXISTS "Research projects insert by owner" ON public.research_projects;
+DROP POLICY IF EXISTS "Research projects managed by owner" ON public.research_projects;
+
+DROP POLICY IF EXISTS "Research documents access" ON public.research_documents;
+DROP POLICY IF EXISTS "Research documents managed by owner" ON public.research_documents;
+
+DROP POLICY IF EXISTS "Research applications readable by stakeholders" ON public.research_applications;
+DROP POLICY IF EXISTS "Research applications insert by applicant" ON public.research_applications;
+DROP POLICY IF EXISTS "Research applications managed by owners" ON public.research_applications;
+
+DROP POLICY IF EXISTS "Research participants readable" ON public.research_participants;
+DROP POLICY IF EXISTS "Research participants insert by owner" ON public.research_participants;
+DROP POLICY IF EXISTS "Research participants update by owner" ON public.research_participants;
+DROP POLICY IF EXISTS "Research participants deletable by owner or self" ON public.research_participants;
+
+DROP POLICY IF EXISTS "Research submissions visibility" ON public.research_submissions;
+DROP POLICY IF EXISTS "Research submissions insert by participants" ON public.research_submissions;
+DROP POLICY IF EXISTS "Research submissions update by owner or participant" ON public.research_submissions;
+DROP POLICY IF EXISTS "Research submissions deletable by owner or participant" ON public.research_submissions;
+
+-- Classes policies
+CREATE POLICY "Class owners can view"
+  ON public.classes
+  FOR SELECT
+  USING (
+    owner_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Class owners can insert"
+  ON public.classes
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    owner_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Class owners can update"
+  ON public.classes
+  FOR UPDATE
+  TO authenticated
+  USING (
+    owner_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  )
+  WITH CHECK (
+    owner_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Class owners can delete"
+  ON public.classes
+  FOR DELETE
+  TO authenticated
+  USING (
+    owner_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Class members can view classes"
+  ON public.classes
+  FOR SELECT
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.class_members cm
+      WHERE cm.class_id = public.classes.id
+        AND cm.user_id = auth.uid()
+    )
+  );
+
+-- Class member policies
+CREATE POLICY "Class members view own rows"
+  ON public.class_members
+  FOR SELECT
+  USING (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Class owners view memberships"
+  ON public.class_members
+  FOR SELECT
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.classes c
+      WHERE c.id = class_id
+        AND c.owner_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Class owners manage memberships"
+  ON public.class_members
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.classes c
+      WHERE c.id = class_id
+        AND c.owner_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Class owners update memberships"
+  ON public.class_members
+  FOR UPDATE
+  TO authenticated
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.classes c
+      WHERE c.id = class_id
+        AND c.owner_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.classes c
+      WHERE c.id = class_id
+        AND c.owner_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Class owners delete memberships"
+  ON public.class_members
+  FOR DELETE
+  TO authenticated
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.classes c
+      WHERE c.id = class_id
+        AND c.owner_id = auth.uid()
+    )
+  );
+
+-- Lesson plan policies
+CREATE POLICY "Lesson plan owners and linked classes can view"
+  ON public.lesson_plans
+  FOR SELECT
+  USING (
+    owner_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.class_lesson_plans clp
+      JOIN public.classes c ON c.id = clp.class_id
+      WHERE clp.lesson_plan_id = public.lesson_plans.id
+        AND (
+          c.owner_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.class_members cm
+            WHERE cm.class_id = c.id
+              AND cm.user_id = auth.uid()
+          )
+        )
+    )
+  );
+
+CREATE POLICY "Lesson plan owners can insert"
+  ON public.lesson_plans
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    owner_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Lesson plan owners can update"
+  ON public.lesson_plans
+  FOR UPDATE
+  TO authenticated
+  USING (
+    owner_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  )
+  WITH CHECK (
+    owner_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Lesson plan owners can delete"
+  ON public.lesson_plans
+  FOR DELETE
+  TO authenticated
+  USING (
+    owner_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+-- Lesson plan steps
+CREATE POLICY "Lesson plan steps follow plan visibility"
+  ON public.lesson_plan_steps
+  FOR SELECT
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.lesson_plans lp
+      WHERE lp.id = lesson_plan_id
+        AND (
+          lp.owner_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.class_lesson_plans clp
+            JOIN public.classes c ON c.id = clp.class_id
+            WHERE clp.lesson_plan_id = lp.id
+              AND (
+                c.owner_id = auth.uid()
+                OR EXISTS (
+                  SELECT 1
+                  FROM public.class_members cm
+                  WHERE cm.class_id = c.id
+                    AND cm.user_id = auth.uid()
+                )
+              )
+          )
+        )
+    )
+  );
+
+CREATE POLICY "Lesson plan owners manage steps"
+  ON public.lesson_plan_steps
+  FOR ALL
+  TO authenticated
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.lesson_plans lp
+      WHERE lp.id = lesson_plan_id
+        AND lp.owner_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.lesson_plans lp
+      WHERE lp.id = lesson_plan_id
+        AND lp.owner_id = auth.uid()
+    )
+  );
+
+-- Class to lesson plan links
+CREATE POLICY "Class lesson links visible to class readers"
+  ON public.class_lesson_plans
+  FOR SELECT
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.classes c
+      WHERE c.id = class_id
+        AND (
+          c.owner_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.class_members cm
+            WHERE cm.class_id = c.id
+              AND cm.user_id = auth.uid()
+          )
+        )
+    )
+  );
+
+CREATE POLICY "Class owners manage lesson links"
+  ON public.class_lesson_plans
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.classes c
+      WHERE c.id = class_id
+        AND c.owner_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Class owners update lesson links"
+  ON public.class_lesson_plans
+  FOR UPDATE
+  TO authenticated
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.classes c
+      WHERE c.id = class_id
+        AND c.owner_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.classes c
+      WHERE c.id = class_id
+        AND c.owner_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Class owners delete lesson links"
+  ON public.class_lesson_plans
+  FOR DELETE
+  TO authenticated
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.classes c
+      WHERE c.id = class_id
+        AND c.owner_id = auth.uid()
+    )
+  );
+
+-- Saved posts
+CREATE POLICY "Saved posts owner access"
+  ON public.saved_posts
+  FOR ALL
+  USING (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  )
+  WITH CHECK (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+-- Notifications and preferences
+CREATE POLICY "Notifications readable by owner"
+  ON public.notifications
+  FOR SELECT
+  USING (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Notifications inserted by system"
+  ON public.notifications
+  FOR INSERT
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR auth.role() = 'service_role'
+  );
+
+CREATE POLICY "Notifications updatable by owner"
+  ON public.notifications
+  FOR UPDATE
+  USING (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  )
+  WITH CHECK (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Notifications deletable by owner"
+  ON public.notifications
+  FOR DELETE
+  USING (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Notification prefs readable"
+  ON public.notification_prefs
+  FOR SELECT
+  USING (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Notification prefs inserted by owner"
+  ON public.notification_prefs
+  FOR INSERT
+  WITH CHECK (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Notification prefs updatable"
+  ON public.notification_prefs
+  FOR UPDATE
+  USING (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  )
+  WITH CHECK (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Notification prefs deletable"
+  ON public.notification_prefs
+  FOR DELETE
+  USING (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+-- Research projects
+CREATE POLICY "Research projects public listing"
+  ON public.research_projects
+  FOR SELECT
+  TO public
+  USING (true);
+
+CREATE POLICY "Research projects owner insert"
+  ON public.research_projects
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    created_by = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Research projects owner manage"
+  ON public.research_projects
+  FOR UPDATE
+  TO authenticated
+  USING (
+    created_by = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  )
+  WITH CHECK (
+    created_by = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Research projects deletable by owner"
+  ON public.research_projects
+  FOR DELETE
+  TO authenticated
+  USING (
+    created_by = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+-- Research documents
+CREATE POLICY "Research documents visible to participants"
+  ON public.research_documents
+  FOR SELECT
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.research_participants rp
+      WHERE rp.project_id = public.research_documents.project_id
+        AND rp.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Research documents managed by admin"
+  ON public.research_documents
+  FOR ALL
+  TO authenticated
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+  )
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+-- Research applications
+CREATE POLICY "Research applications readable"
+  ON public.research_applications
+  FOR SELECT
+  USING (
+    applicant_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Research applications insert"
+  ON public.research_applications
+  FOR INSERT
+  WITH CHECK (
+    applicant_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Research applications update status"
+  ON public.research_applications
+  FOR UPDATE
+  TO authenticated
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+  )
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Research applications delete"
+  ON public.research_applications
+  FOR DELETE
+  TO authenticated
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+-- Research participants
+CREATE POLICY "Research participants readable"
+  ON public.research_participants
+  FOR SELECT
+  USING (
+    user_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.research_projects rp
+      WHERE rp.id = project_id
+        AND rp.created_by = auth.uid()
+    )
+  );
+
+CREATE POLICY "Research participants insert"
+  ON public.research_participants
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Research participants update"
+  ON public.research_participants
+  FOR UPDATE
+  TO authenticated
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+  )
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+CREATE POLICY "Research participants delete"
+  ON public.research_participants
+  FOR DELETE
+  TO authenticated
+  USING (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+  );
+
+-- Research submissions
+CREATE POLICY "Research submissions readable"
+  ON public.research_submissions
+  FOR SELECT
+  USING (
+    participant_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.research_projects rp
+      WHERE rp.id = project_id
+        AND rp.created_by = auth.uid()
+    )
+  );
+
+CREATE POLICY "Research submissions insert"
+  ON public.research_submissions
+  FOR INSERT
+  WITH CHECK (
+    coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR (
+      participant_id = auth.uid()
+      AND EXISTS (
+        SELECT 1
+        FROM public.research_participants rp
+        WHERE rp.project_id = project_id
+          AND rp.user_id = auth.uid()
+      )
+    )
+  );
+
+CREATE POLICY "Research submissions update"
+  ON public.research_submissions
+  FOR UPDATE
+  TO authenticated
+  USING (
+    participant_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.research_projects rp
+      WHERE rp.id = project_id
+        AND rp.created_by = auth.uid()
+    )
+  )
+  WITH CHECK (
+    participant_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.research_projects rp
+      WHERE rp.id = project_id
+        AND rp.created_by = auth.uid()
+    )
+  );
+
+CREATE POLICY "Research submissions delete"
+  ON public.research_submissions
+  FOR DELETE
+  TO authenticated
+  USING (
+    participant_id = auth.uid()
+    OR coalesce(request.jwt() ->> 'role', '') = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM public.research_projects rp
+      WHERE rp.id = project_id
+        AND rp.created_by = auth.uid()
+    )
+  );

--- a/supabase/tests/rls_policies.sql
+++ b/supabase/tests/rls_policies.sql
@@ -1,0 +1,126 @@
+-- Quick manual verification script for the RLS policies introduced in 20251105000000_update_rls_policies.sql
+-- Run inside a transaction so test data is discarded automatically.
+BEGIN;
+
+-- Seed baseline data with admin privileges
+SELECT set_config('request.jwt.claims', '{"role":"admin","sub":"00000000-0000-0000-0000-000000000000"}', true);
+
+INSERT INTO public.classes (id, name, owner_id)
+VALUES ('11111111-1111-1111-1111-111111111111', 'Example Class', '00000000-0000-0000-0000-000000000101');
+
+INSERT INTO public.class_members (id, class_id, user_id, role)
+VALUES ('21111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000102', 'teacher');
+
+INSERT INTO public.lesson_plans (id, owner_id, title)
+VALUES ('22222222-2222-2222-2222-222222222222', '00000000-0000-0000-0000-000000000201', 'Sample Plan');
+
+INSERT INTO public.lesson_plan_steps (id, lesson_plan_id, position, title)
+VALUES ('32222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 1, 'Warm up');
+
+INSERT INTO public.class_lesson_plans (id, class_id, lesson_plan_id, added_by)
+VALUES ('42222222-2222-2222-2222-222222222222', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', '00000000-0000-0000-0000-000000000101');
+
+INSERT INTO public.saved_posts (id, user_id, post_id)
+VALUES ('51111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000102', '99999999-9999-9999-9999-999999999999');
+
+INSERT INTO public.notifications (id, user_id, type, payload)
+VALUES ('61111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000102', 'resource_approved', '{}'::jsonb);
+
+INSERT INTO public.notification_prefs (user_id)
+VALUES ('00000000-0000-0000-0000-000000000102')
+ON CONFLICT (user_id) DO NOTHING;
+
+INSERT INTO public.research_projects (id, title, slug, summary, status, visibility, created_by)
+VALUES ('71111111-1111-1111-1111-111111111111', 'Literacy Study', 'literacy-study', 'Exploring literacy', 'open', 'list_public', '00000000-0000-0000-0000-000000000301');
+
+INSERT INTO public.research_participants (id, project_id, user_id)
+VALUES ('81111111-1111-1111-1111-111111111111', '71111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000302');
+
+INSERT INTO public.research_documents (id, project_id, title)
+VALUES ('82111111-1111-1111-1111-111111111111', '71111111-1111-1111-1111-111111111111', 'Consent Form');
+
+INSERT INTO public.research_applications (id, project_id, applicant_id, status)
+VALUES ('83111111-1111-1111-1111-111111111111', '71111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000302', 'pending');
+
+INSERT INTO public.research_submissions (id, project_id, participant_id, title)
+VALUES ('84111111-1111-1111-1111-111111111111', '71111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000302', 'Initial Report');
+
+-- Reset claims between scenarios
+SELECT set_config('request.jwt.claims', NULL, true);
+
+-- === Classes ===
+-- Owner can read/update
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000101"}', true);
+SELECT id FROM public.classes WHERE id = '11111111-1111-1111-1111-111111111111'; -- expect success
+
+-- Member can read via membership
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000102"}', true);
+SELECT id FROM public.classes WHERE id = '11111111-1111-1111-1111-111111111111'; -- expect success
+
+-- Outsider blocked from reading
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000103"}', true);
+SELECT id FROM public.classes WHERE id = '11111111-1111-1111-1111-111111111111'; -- expect ERROR: permission denied
+
+-- Outsider blocked from inserting membership
+INSERT INTO public.class_members (class_id, user_id, role)
+VALUES ('11111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000103', 'assistant'); -- expect ERROR: permission denied
+
+-- Member can read their own membership but not others
+SELECT id FROM public.class_members WHERE user_id = '00000000-0000-0000-0000-000000000102'; -- expect success
+SELECT id FROM public.class_members WHERE user_id = '00000000-0000-0000-0000-000000000101'; -- expect zero rows (no permission)
+
+-- === Lesson plans ===
+-- Plan owner can read
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000201"}', true);
+SELECT id FROM public.lesson_plans WHERE id = '22222222-2222-2222-2222-222222222222'; -- expect success
+
+-- Class member linked to plan can read
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000102"}', true);
+SELECT id FROM public.lesson_plans WHERE id = '22222222-2222-2222-2222-222222222222'; -- expect success
+
+-- Outsider blocked
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000103"}', true);
+SELECT id FROM public.lesson_plans WHERE id = '22222222-2222-2222-2222-222222222222'; -- expect ERROR: permission denied
+
+-- === Saved posts ===
+SELECT id FROM public.saved_posts WHERE user_id = '00000000-0000-0000-0000-000000000102'; -- expect success
+SELECT id FROM public.saved_posts WHERE user_id = '00000000-0000-0000-0000-000000000101'; -- expect zero rows (no permission)
+
+-- === Notifications ===
+UPDATE public.notifications SET is_read = true WHERE id = '61111111-1111-1111-1111-111111111111'; -- expect success
+INSERT INTO public.notifications (user_id, type, payload)
+VALUES ('00000000-0000-0000-0000-000000000102', 'resource_approved', '{}'::jsonb); -- expect ERROR: permission denied
+
+-- === Research documents ===
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000302"}', true);
+SELECT id FROM public.research_documents WHERE id = '82111111-1111-1111-1111-111111111111'; -- expect success
+
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000303"}', true);
+SELECT id FROM public.research_documents WHERE id = '82111111-1111-1111-1111-111111111111'; -- expect ERROR: permission denied
+
+-- === Research applications ===
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000302"}', true);
+SELECT id FROM public.research_applications WHERE id = '83111111-1111-1111-1111-111111111111'; -- expect success
+
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000303"}', true);
+SELECT id FROM public.research_applications WHERE id = '83111111-1111-1111-1111-111111111111'; -- expect ERROR: permission denied
+
+-- === Research participants ===
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000302"}', true);
+SELECT id FROM public.research_participants WHERE project_id = '71111111-1111-1111-1111-111111111111'; -- expect success (own row)
+
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000301"}', true);
+SELECT id FROM public.research_participants WHERE project_id = '71111111-1111-1111-1111-111111111111'; -- expect success (project owner)
+
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000303"}', true);
+SELECT id FROM public.research_participants WHERE project_id = '71111111-1111-1111-1111-111111111111'; -- expect ERROR: permission denied
+
+-- === Research submissions ===
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000302"}', true);
+SELECT id FROM public.research_submissions WHERE id = '84111111-1111-1111-1111-111111111111'; -- expect success
+
+SELECT set_config('request.jwt.claims', '{"role":"authenticated","sub":"00000000-0000-0000-0000-000000000303"}', true);
+SELECT id FROM public.research_submissions WHERE id = '84111111-1111-1111-1111-111111111111'; -- expect ERROR: permission denied
+
+-- Clean up
+ROLLBACK;


### PR DESCRIPTION
## Summary
- replace the existing class, membership, lesson plan, and class link policies with owner/member scoped rules and admin bypass via `request.jwt()`
- tighten saved post, notification, and notification preference access so only the owning user (or admin/service role insert) can read or modify data
- lock down the research schema tables to owner/participant/admin specific access patterns and add a manual SQL script with example queries for verification

## Testing
- not run (SQL-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d16151555483319ea767483303287e