### PR TITLE
feat: add admin console layout with protected routes

### DIFF
--- a/api/admin/session.ts
+++ b/api/admin/session.ts
@@ -1,0 +1,26 @@
+import {
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+} from "../_lib/http";
+import { requireAdmin } from "../_lib/auth";
+
+export default async function handler(request: Request): Promise<Response> {
+  if (normalizeMethod(request.method) !== "GET") {
+    return methodNotAllowed(["GET"]);
+  }
+
+  const context = await requireAdmin(request);
+  if (context instanceof Response) {
+    return context;
+  }
+
+  const { user } = context;
+
+  return jsonResponse({
+    user: {
+      id: user.id,
+      email: user.email,
+    },
+  });
+}

--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -25,6 +25,11 @@ import Sitemap from '@/pages/Sitemap';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import Builder from '@/pages/Builder';
+import AdminLayout from '@/features/admin/components/AdminLayout';
+import AdminGuard from '@/features/admin/components/AdminGuard';
+import { AdminDashboard } from '@/features/admin/pages/AdminDashboard';
+import AdminSection from '@/features/admin/components/AdminSection';
+import { ADMIN_ROUTE_META } from '@/features/admin/constants/routes';
 
 const RouteWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { lang } = useParams<{ lang?: string }>();
@@ -55,8 +60,113 @@ const LegacyBuilderRedirect: React.FC<{ includeLanguage?: boolean }> = ({ includ
 };
 
 export const LocalizedRoutes = () => {
+  const renderAdminSection = (path: string, tableColumns?: string[]) => {
+    const meta = ADMIN_ROUTE_META[path];
+
+    if (!meta) {
+      return (
+        <AdminSection
+          title="Admin"
+          description="Administrative workspace."
+          tableColumns={tableColumns}
+        />
+      );
+    }
+
+    return (
+      <AdminSection
+        title={meta.title}
+        description={meta.description}
+        tableColumns={tableColumns}
+      />
+    );
+  };
+
   return (
     <Routes>
+      <Route
+        path="/admin"
+        element={(
+          <AdminGuard>
+            <AdminLayout />
+          </AdminGuard>
+        )}
+      >
+        <Route index element={<AdminDashboard />} />
+        <Route path="moderation">
+          <Route index element={renderAdminSection('/admin/moderation')} />
+          <Route
+            path="resources"
+            element={renderAdminSection('/admin/moderation/resources')}
+          />
+          <Route
+            path="blogposts"
+            element={renderAdminSection('/admin/moderation/blogposts')}
+          />
+          <Route
+            path="research-applications"
+            element={renderAdminSection('/admin/moderation/research-applications')}
+          />
+          <Route
+            path="comments"
+            element={renderAdminSection('/admin/moderation/comments')}
+          />
+        </Route>
+        <Route path="content">
+          <Route index element={renderAdminSection('/admin/content')} />
+          <Route path="posts" element={renderAdminSection('/admin/content/posts')} />
+          <Route
+            path="resources"
+            element={renderAdminSection('/admin/content/resources')}
+          />
+        </Route>
+        <Route path="users">
+          <Route index element={renderAdminSection('/admin/users')} />
+          <Route
+            path="directory"
+            element={renderAdminSection('/admin/users/directory')}
+          />
+          <Route
+            path="invitations"
+            element={renderAdminSection('/admin/users/invitations')}
+          />
+          <Route path="roles" element={renderAdminSection('/admin/users/roles')} />
+        </Route>
+        <Route path="research">
+          <Route index element={renderAdminSection('/admin/research')} />
+          <Route
+            path="projects"
+            element={renderAdminSection('/admin/research/projects')}
+          />
+          <Route
+            path="documents"
+            element={renderAdminSection('/admin/research/documents')}
+          />
+          <Route
+            path="participants"
+            element={renderAdminSection('/admin/research/participants')}
+          />
+          <Route
+            path="submissions"
+            element={renderAdminSection('/admin/research/submissions')}
+          />
+        </Route>
+        <Route path="system">
+          <Route index element={renderAdminSection('/admin/system')} />
+          <Route
+            path="notifications"
+            element={renderAdminSection('/admin/system/notifications')}
+          />
+          <Route
+            path="audit-log"
+            element={renderAdminSection('/admin/system/audit-log')}
+          />
+          <Route
+            path="settings"
+            element={renderAdminSection('/admin/system/settings')}
+          />
+        </Route>
+      </Route>
       {/* English routes (default) */}
       <Route path="/" element={<RouteWrapper><Index /></RouteWrapper>} />
       <Route path="/about" element={<RouteWrapper><About /></RouteWrapper>} />

--- a/src/features/admin/components/AdminGuard.tsx
+++ b/src/features/admin/components/AdminGuard.tsx
@@ -1,0 +1,118 @@
+import { ReactNode, useEffect, useState } from "react";
+import { Link, Navigate, useLocation } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface AdminGuardProps {
+  children: ReactNode;
+}
+
+type GuardState = "loading" | "authorized" | "unauthorized" | "error";
+
+export const AdminGuard = ({ children }: AdminGuardProps) => {
+  const location = useLocation();
+  const [state, setState] = useState<GuardState>("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const controller = new AbortController();
+
+    async function verifyAccess() {
+      const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+
+      if (sessionError || !sessionData.session) {
+        if (mounted) {
+          setState("unauthorized");
+        }
+        return;
+      }
+
+      try {
+        const response = await fetch("/api/admin/session", {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${sessionData.session.access_token}`,
+          },
+          credentials: "include",
+          signal: controller.signal,
+        });
+
+        if (!mounted) return;
+
+        if (response.ok) {
+          setState("authorized");
+          return;
+        }
+
+        if (response.status === 401 || response.status === 403) {
+          setState("unauthorized");
+          return;
+        }
+
+        setState("error");
+        setErrorMessage("We couldn't confirm your admin access. Please try again.");
+      } catch (error) {
+        if (!mounted) return;
+        if ((error as Error).name === "AbortError") {
+          return;
+        }
+        setState("error");
+        setErrorMessage("We couldn't reach the server to verify admin access.");
+      }
+    }
+
+    verifyAccess();
+
+    return () => {
+      mounted = false;
+      controller.abort();
+    };
+  }, []);
+
+  if (state === "loading") {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background">
+        <div className="space-y-3 text-center">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-72" />
+        </div>
+        <div className="grid w-full max-w-sm gap-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "unauthorized") {
+    return <Navigate to="/auth" state={{ from: location.pathname }} replace />;
+  }
+
+  if (state === "error") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background p-6">
+        <Card className="max-w-md">
+          <CardHeader>
+            <CardTitle>Unable to confirm access</CardTitle>
+            <CardDescription>
+              {errorMessage ?? "Something went wrong while verifying your administrator permissions."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex justify-end">
+            <Button asChild>
+              <Link to="/">Return home</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export default AdminGuard;

--- a/src/features/admin/components/AdminLayout.tsx
+++ b/src/features/admin/components/AdminLayout.tsx
@@ -1,0 +1,147 @@
+import { Fragment, useMemo } from "react";
+import { Link, Outlet, useLocation } from "react-router-dom";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarMenuSub,
+  SidebarMenuSubItem,
+  SidebarMenuSubButton,
+  SidebarProvider,
+  SidebarSeparator,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { ADMIN_NAVIGATION, ADMIN_ROUTE_META } from "../constants/routes";
+
+const normalizePath = (pathname: string) => {
+  if (!pathname) return "/admin";
+  if (pathname === "/") return "/admin";
+  return pathname.endsWith("/") && pathname !== "/admin" ? pathname.slice(0, -1) : pathname;
+};
+
+export const AdminLayout = () => {
+  const location = useLocation();
+  const pathname = normalizePath(location.pathname || "/admin");
+
+  const breadcrumbs = useMemo(() => {
+    const crumbs: { href: string; title: string }[] = [];
+    let current = pathname;
+    const visited = new Set<string>();
+
+    while (current) {
+      const meta = ADMIN_ROUTE_META[current];
+      if (!meta || visited.has(current)) {
+        break;
+      }
+
+      crumbs.push({ href: current, title: meta.title });
+      visited.add(current);
+      current = meta.parent ?? "";
+    }
+
+    if (crumbs.length === 0) {
+      crumbs.push({ href: "/admin", title: ADMIN_ROUTE_META["/admin"].title });
+    }
+
+    return crumbs.reverse();
+  }, [pathname]);
+
+  const isGroupActive = (href: string) => {
+    if (href === "/admin") {
+      return pathname === href;
+    }
+
+    return pathname === href || pathname.startsWith(`${href}/`);
+  };
+
+  const isItemActive = (href: string) => pathname === href;
+
+  return (
+    <SidebarProvider>
+      <Sidebar collapsible="icon">
+        <SidebarHeader>
+          <Link to="/admin" className="flex items-center gap-2 rounded-md px-2 py-1 text-sm font-semibold">
+            <span>SchoolTech Hub</span>
+            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">Admin</span>
+          </Link>
+        </SidebarHeader>
+        <SidebarSeparator />
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {ADMIN_NAVIGATION.map((group) => (
+                  <SidebarMenuItem key={group.href}>
+                    <SidebarMenuButton asChild isActive={isGroupActive(group.href)}>
+                      <Link to={group.href} className="flex items-center gap-2">
+                        <group.icon className="size-4" />
+                        <span>{group.label}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                    {group.items && (
+                      <SidebarMenuSub>
+                        {group.items.map((item) => (
+                          <SidebarMenuSubItem key={item.href}>
+                            <SidebarMenuSubButton asChild isActive={isItemActive(item.href)}>
+                              <Link to={item.href}>{item.label}</Link>
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                        ))}
+                      </SidebarMenuSub>
+                    )}
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarFooter>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/">Return to site</Link>
+          </Button>
+        </SidebarFooter>
+      </Sidebar>
+      <SidebarInset>
+        <header className="flex h-16 shrink-0 items-center gap-3 border-b bg-background px-4">
+          <SidebarTrigger />
+          <Separator orientation="vertical" className="hidden h-6 md:block" />
+          <Breadcrumb>
+            <BreadcrumbList>
+              {breadcrumbs.map((crumb, index) => (
+                <Fragment key={crumb.href}>
+                  <BreadcrumbItem>
+                    {index < breadcrumbs.length - 1 ? (
+                      <BreadcrumbLink asChild>
+                        <Link to={crumb.href}>{crumb.title}</Link>
+                      </BreadcrumbLink>
+                    ) : (
+                      <BreadcrumbPage>{crumb.title}</BreadcrumbPage>
+                    )}
+                  </BreadcrumbItem>
+                  {index < breadcrumbs.length - 1 && <BreadcrumbSeparator />}
+                </Fragment>
+              ))}
+            </BreadcrumbList>
+          </Breadcrumb>
+        </header>
+        <div className="flex-1 bg-muted/10 p-4 md:p-6">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+            <Outlet />
+          </div>
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+};
+
+export default AdminLayout;

--- a/src/features/admin/components/AdminSection.tsx
+++ b/src/features/admin/components/AdminSection.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from "react";
+import { AdminTableSkeleton } from "./AdminTableSkeleton";
+
+interface AdminSectionProps {
+  title: string;
+  description: string;
+  tableColumns?: string[];
+  children?: ReactNode;
+}
+
+export const AdminSection = ({ title, description, tableColumns, children }: AdminSectionProps) => {
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+        <p className="text-muted-foreground">{description}</p>
+      </header>
+      {children ?? <AdminTableSkeleton columns={tableColumns} />}
+    </section>
+  );
+};
+
+export default AdminSection;

--- a/src/features/admin/components/AdminTableSkeleton.tsx
+++ b/src/features/admin/components/AdminTableSkeleton.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Drawer, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+interface AdminTableSkeletonProps {
+  columns?: string[];
+  rows?: number;
+  showToolbar?: boolean;
+}
+
+const DEFAULT_COLUMNS = ["Item", "Status", "Owner", "Updated", "Actions"];
+
+export const AdminTableSkeleton = ({
+  columns = DEFAULT_COLUMNS,
+  rows = 5,
+  showToolbar = true,
+}: AdminTableSkeletonProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <div className="overflow-hidden rounded-lg border bg-background">
+        {showToolbar && (
+          <div className="flex flex-col gap-4 border-b p-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-4 w-48" />
+            </div>
+            <div className="flex w-full flex-col gap-3 md:w-auto md:flex-row">
+              <Skeleton className="h-10 w-full md:w-40" />
+              <Skeleton className="h-10 w-full md:w-24" />
+            </div>
+          </div>
+        )}
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {columns.map((column) => (
+                <TableHead key={column}>{column}</TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {Array.from({ length: rows }).map((_, index) => (
+              <TableRow key={index}>
+                <TableCell>
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="h-10 w-10 rounded-full" />
+                    <div className="space-y-2">
+                      <Skeleton className="h-4 w-40" />
+                      <Skeleton className="h-3 w-24" />
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Skeleton className="h-4 w-20" />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className="h-4 w-32" />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className="h-4 w-16" />
+                </TableCell>
+                <TableCell className="text-right">
+                  <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
+                    Review
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Server-confirmed details</DrawerTitle>
+            <DrawerDescription>
+              Actions become available only after the server verifies the latest state. Optimistic updates are disabled until a
+              response is received.
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="space-y-4 px-4 pb-4">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-20 w-full" />
+            <div className="grid gap-3 md:grid-cols-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <Skeleton className="h-10 w-full" />
+          </div>
+          <DrawerFooter>
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+};
+
+export default AdminTableSkeleton;

--- a/src/features/admin/constants/routes.ts
+++ b/src/features/admin/constants/routes.ts
@@ -1,0 +1,198 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  FileText,
+  FlaskConical,
+  LayoutDashboard,
+  ShieldCheck,
+  Users,
+  Waypoints,
+} from "lucide-react";
+
+export interface AdminNavItem {
+  label: string;
+  href: string;
+}
+
+export interface AdminNavGroup {
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  items?: AdminNavItem[];
+}
+
+export interface AdminRouteMeta {
+  title: string;
+  description: string;
+  parent?: string;
+}
+
+export const ADMIN_NAVIGATION: AdminNavGroup[] = [
+  {
+    label: "Dashboard",
+    href: "/admin",
+    icon: LayoutDashboard,
+  },
+  {
+    label: "Moderation",
+    href: "/admin/moderation",
+    icon: ShieldCheck,
+    items: [
+      { label: "Resources", href: "/admin/moderation/resources" },
+      { label: "Blogposts", href: "/admin/moderation/blogposts" },
+      { label: "Research Applications", href: "/admin/moderation/research-applications" },
+      { label: "Comments", href: "/admin/moderation/comments" },
+    ],
+  },
+  {
+    label: "Content",
+    href: "/admin/content",
+    icon: FileText,
+    items: [
+      { label: "Posts", href: "/admin/content/posts" },
+      { label: "Resources", href: "/admin/content/resources" },
+    ],
+  },
+  {
+    label: "Users",
+    href: "/admin/users",
+    icon: Users,
+    items: [
+      { label: "Directory", href: "/admin/users/directory" },
+      { label: "Invitations", href: "/admin/users/invitations" },
+      { label: "Roles (Admins)", href: "/admin/users/roles" },
+    ],
+  },
+  {
+    label: "Research",
+    href: "/admin/research",
+    icon: FlaskConical,
+    items: [
+      { label: "Projects", href: "/admin/research/projects" },
+      { label: "Documents", href: "/admin/research/documents" },
+      { label: "Participants", href: "/admin/research/participants" },
+      { label: "Submissions", href: "/admin/research/submissions" },
+    ],
+  },
+  {
+    label: "System",
+    href: "/admin/system",
+    icon: Waypoints,
+    items: [
+      { label: "Notifications", href: "/admin/system/notifications" },
+      { label: "Audit Log", href: "/admin/system/audit-log" },
+      { label: "Settings", href: "/admin/system/settings" },
+    ],
+  },
+];
+
+export const ADMIN_ROUTE_META: Record<string, AdminRouteMeta> = {
+  "/admin": {
+    title: "Dashboard",
+    description: "Track high-level program metrics and see the most recent approvals awaiting follow-up.",
+  },
+  "/admin/moderation": {
+    title: "Moderation",
+    description: "Review queues across content types that require human approval.",
+    parent: "/admin",
+  },
+  "/admin/moderation/resources": {
+    title: "Resource Moderation",
+    description: "Pending teaching resources awaiting review before publication.",
+    parent: "/admin/moderation",
+  },
+  "/admin/moderation/blogposts": {
+    title: "Blogpost Moderation",
+    description: "Draft and submitted blog content to approve or reject.",
+    parent: "/admin/moderation",
+  },
+  "/admin/moderation/research-applications": {
+    title: "Research Applications",
+    description: "Incoming research study applications and institutional approvals.",
+    parent: "/admin/moderation",
+  },
+  "/admin/moderation/comments": {
+    title: "Comment Moderation",
+    description: "Community discussion that needs moderation attention.",
+    parent: "/admin/moderation",
+  },
+  "/admin/content": {
+    title: "Content",
+    description: "Published and scheduled editorial content.",
+    parent: "/admin",
+  },
+  "/admin/content/posts": {
+    title: "Posts",
+    description: "Manage published articles, announcements, and updates.",
+    parent: "/admin/content",
+  },
+  "/admin/content/resources": {
+    title: "Resource Library",
+    description: "Catalog of instructional resources available to educators.",
+    parent: "/admin/content",
+  },
+  "/admin/users": {
+    title: "Users",
+    description: "Administrative controls for user accounts and permissions.",
+    parent: "/admin",
+  },
+  "/admin/users/directory": {
+    title: "User Directory",
+    description: "Search and audit the full directory of registered users.",
+    parent: "/admin/users",
+  },
+  "/admin/users/invitations": {
+    title: "Invitations",
+    description: "Track outstanding invitations and resend as needed.",
+    parent: "/admin/users",
+  },
+  "/admin/users/roles": {
+    title: "Roles & Admins",
+    description: "Grant and revoke elevated administrative access.",
+    parent: "/admin/users",
+  },
+  "/admin/research": {
+    title: "Research",
+    description: "Oversight for partner research initiatives.",
+    parent: "/admin",
+  },
+  "/admin/research/projects": {
+    title: "Research Projects",
+    description: "Active and proposed research collaborations.",
+    parent: "/admin/research",
+  },
+  "/admin/research/documents": {
+    title: "Research Documents",
+    description: "Protocols, consent forms, and related documentation.",
+    parent: "/admin/research",
+  },
+  "/admin/research/participants": {
+    title: "Research Participants",
+    description: "Roster of participant cohorts and recruitment status.",
+    parent: "/admin/research",
+  },
+  "/admin/research/submissions": {
+    title: "Research Submissions",
+    description: "Recent submissions awaiting review or archiving.",
+    parent: "/admin/research",
+  },
+  "/admin/system": {
+    title: "System",
+    description: "Operational tooling for platform health.",
+    parent: "/admin",
+  },
+  "/admin/system/notifications": {
+    title: "System Notifications",
+    description: "Outgoing messages and delivery health.",
+    parent: "/admin/system",
+  },
+  "/admin/system/audit-log": {
+    title: "Audit Log",
+    description: "Immutable log of administrator actions.",
+    parent: "/admin/system",
+  },
+  "/admin/system/settings": {
+    title: "Admin Settings",
+    description: "Configuration for administrative preferences and feature flags.",
+    parent: "/admin/system",
+  },
+};

--- a/src/features/admin/pages/AdminDashboard.tsx
+++ b/src/features/admin/pages/AdminDashboard.tsx
@@ -1,0 +1,73 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ADMIN_ROUTE_META } from "../constants/routes";
+import { AdminTableSkeleton } from "../components/AdminTableSkeleton";
+
+const DASHBOARD_METRIC_LABELS = [
+  "Pending approvals",
+  "Active research projects",
+  "New submissions",
+  "Open support items",
+];
+
+export const AdminDashboard = () => {
+  const meta = ADMIN_ROUTE_META["/admin"];
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-3xl font-semibold tracking-tight">{meta.title}</h1>
+        <p className="text-muted-foreground">{meta.description}</p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {DASHBOARD_METRIC_LABELS.map((label) => (
+          <Card key={label} className="overflow-hidden">
+            <CardHeader className="space-y-1 pb-2">
+              <CardDescription>{label}</CardDescription>
+              <CardTitle className="text-3xl font-semibold">
+                <Skeleton className="h-8 w-24" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Skeleton className="h-3 w-32" />
+              <Skeleton className="h-3 w-24" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card className="flex flex-col">
+          <CardHeader>
+            <CardTitle>Focus areas</CardTitle>
+            <CardDescription>Where moderators should spend time next.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-1 flex-col justify-between gap-4">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="space-y-2">
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="h-3 w-56" />
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-2 w-full" />
+                  <Skeleton className="h-3 w-10" />
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card className="flex flex-col">
+          <CardHeader>
+            <CardTitle>Recent approvals</CardTitle>
+            <CardDescription>Latest items confirmed by administrators.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <AdminTableSkeleton columns={["Item", "Type", "Moderator", "Decision", "Actions"]} rows={4} showToolbar={false} />
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+};
+
+export default AdminDashboard;


### PR DESCRIPTION
## Summary
- add an admin session API handler that verifies access with the existing `requireAdmin` utility
- introduce an SSR-backed admin console shell with guarded routing, sidebar navigation, and breadcrumbs
- provide skeleton table + drawer experiences for every admin section, including a metrics dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1609c877083319f0fbbc4c446a2d9