### PR TITLE
Add admin console shell with guarded routes

### DIFF
--- a/api/admin/guard.ts
+++ b/api/admin/guard.ts
@@ -1,0 +1,15 @@
+import { jsonResponse, methodNotAllowed, normalizeMethod } from "../_lib/http";
+import { requireAdmin } from "../_lib/auth";
+
+export default async function handler(request: Request): Promise<Response> {
+  if (normalizeMethod(request.method) !== "GET") {
+    return methodNotAllowed(["GET"]);
+  }
+
+  const context = await requireAdmin(request);
+  if (context instanceof Response) {
+    return context;
+  }
+
+  return jsonResponse({ ok: true });
+}

--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -25,6 +25,8 @@ import Sitemap from '@/pages/Sitemap';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import Builder from '@/pages/Builder';
+import AdminLayout from '@/pages/admin/AdminLayout';
+import AdminPage from '@/pages/admin/AdminPage';
 
 const RouteWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { lang } = useParams<{ lang?: string }>();
@@ -82,7 +84,13 @@ export const LocalizedRoutes = () => {
       <Route path="/account/resources/new" element={<RouteWrapper><AccountResourceNew /></RouteWrapper>} />
       <Route path="/account/resources/:id" element={<RouteWrapper><AccountResourceEdit /></RouteWrapper>} />
       <Route path="/sitemap" element={<RouteWrapper><Sitemap /></RouteWrapper>} />
-      
+      <Route path="/admin" element={<AdminLayout />}>
+        <Route index element={<AdminPage />} />
+        <Route path=":segment" element={<AdminPage />} />
+        <Route path=":segment/:subSegment" element={<AdminPage />} />
+        <Route path=":segment/:subSegment/:child" element={<AdminPage />} />
+      </Route>
+
       {/* Localized routes for Albanian and Vietnamese */}
       <Route path="/:lang">
         <Route index element={<RouteWrapper><Index /></RouteWrapper>} />

--- a/src/hooks/useAdminGuard.ts
+++ b/src/hooks/useAdminGuard.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+
+import { supabase } from "@/integrations/supabase/client";
+
+type AdminGuardState = "checking" | "allowed" | "forbidden" | "error";
+
+async function fetchAdminStatus(): Promise<Response> {
+  const { data, error } = await supabase.auth.getSession();
+
+  if (error || !data.session?.access_token) {
+    throw new Error("Missing access token");
+  }
+
+  return fetch("/api/admin/guard", {
+    headers: {
+      Authorization: `Bearer ${data.session.access_token}`,
+    },
+  });
+}
+
+export function useAdminGuard(pathname: string): AdminGuardState {
+  const [state, setState] = useState<AdminGuardState>("checking");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function verifyAdmin() {
+      setState("checking");
+
+      try {
+        const response = await fetchAdminStatus();
+        if (cancelled) {
+          return;
+        }
+
+        if (response.ok) {
+          setState("allowed");
+        } else if (response.status === 401 || response.status === 403) {
+          setState("forbidden");
+        } else {
+          setState("error");
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setState(error instanceof Error && error.message === "Missing access token" ? "forbidden" : "error");
+        }
+      }
+    }
+
+    void verifyAdmin();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pathname]);
+
+  return state;
+}

--- a/src/pages/admin/AdminLayout.tsx
+++ b/src/pages/admin/AdminLayout.tsx
@@ -1,0 +1,222 @@
+import { Menu } from "lucide-react";
+import { Link, Navigate, NavLink, Outlet, useLocation } from "react-router-dom";
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAdminGuard } from "@/hooks/useAdminGuard";
+import { adminNavigation, getAdminPageMeta, type AdminPageMeta } from "./config";
+
+export interface AdminOutletContext {
+  meta: AdminPageMeta;
+}
+
+export default function AdminLayout() {
+  const location = useLocation();
+  const guardState = useAdminGuard(location.pathname);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const meta = useMemo(() => getAdminPageMeta(location.pathname), [location.pathname]);
+
+  if (guardState === "checking") {
+    return <AdminGuardSkeleton />;
+  }
+
+  if (guardState === "forbidden") {
+    return <AdminForbidden />;
+  }
+
+  if (guardState === "error") {
+    return <AdminGuardError />;
+  }
+
+  if (!meta) {
+    return <Navigate to="/admin" replace />;
+  }
+
+  return (
+    <div className="flex min-h-screen bg-muted/40">
+      <aside className="relative hidden w-64 shrink-0 border-r bg-background/70 px-4 py-6 md:flex md:flex-col">
+        <AdminSidebar />
+      </aside>
+
+      <div className="flex w-full flex-col">
+        <header className="sticky top-0 z-20 border-b bg-background/80 backdrop-blur">
+          <div className="flex items-center gap-3 px-4 py-3 md:px-6">
+            <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+              <SheetTrigger asChild>
+                <Button variant="outline" size="sm" className="md:hidden">
+                  <Menu className="mr-2 h-4 w-4" />
+                  Menu
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="left" className="w-72 p-0">
+                <div className="h-full overflow-y-auto px-4 py-6">
+                  <AdminSidebar onNavigate={() => setMobileOpen(false)} />
+                </div>
+              </SheetContent>
+            </Sheet>
+
+            <AdminBreadcrumbs meta={meta} />
+          </div>
+        </header>
+
+        <main className="flex-1 overflow-y-auto px-4 py-6 md:px-8">
+          <Outlet context={{ meta }} />
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function AdminSidebar({ onNavigate }: { onNavigate?: () => void }) {
+  return (
+    <div className="flex h-full flex-col gap-6">
+      <div className="space-y-1 px-3">
+        <h2 className="text-lg font-semibold tracking-tight">Admin Console</h2>
+        <p className="text-sm text-muted-foreground">Operational tools for SchoolTech Hub</p>
+      </div>
+
+      <nav className="flex-1 space-y-6 overflow-y-auto pb-6">
+        {adminNavigation.map((group, index) => (
+          <div key={index} className="space-y-2">
+            {group.label && (
+              <p className="px-3 text-xs font-semibold uppercase text-muted-foreground">{group.label}</p>
+            )}
+            <div className="space-y-1">
+              {group.items.map(item => (
+                <NavLink
+                  key={item.path}
+                  to={item.path}
+                  end={item.path === "/admin"}
+                  className={({ isActive }) =>
+                    `flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                      isActive
+                        ? "bg-primary/10 text-primary"
+                        : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                    }`
+                  }
+                  onClick={onNavigate}
+                >
+                  {item.title}
+                </NavLink>
+              ))}
+            </div>
+          </div>
+        ))}
+      </nav>
+    </div>
+  );
+}
+
+function AdminBreadcrumbs({ meta }: { meta: AdminPageMeta }) {
+  const crumbs = useMemo(() => {
+    const items: Array<{ label: string; href?: string; current?: boolean }> = [
+      { label: "Admin", href: "/admin" },
+    ];
+
+    if (meta.groupLabel) {
+      items.push({ label: meta.groupLabel });
+    }
+
+    items.push({ label: meta.title, current: true });
+
+    return items;
+  }, [meta.groupLabel, meta.title]);
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        {crumbs.map((crumb, index) => (
+          <div key={index} className="flex items-center">
+            {index > 0 && <BreadcrumbSeparator />}
+            <BreadcrumbItem>
+              {crumb.href ? (
+                <BreadcrumbLink asChild>
+                  <Link to={crumb.href}>{crumb.label}</Link>
+                </BreadcrumbLink>
+              ) : crumb.current ? (
+                <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+              ) : (
+                <span className="text-sm text-muted-foreground">{crumb.label}</span>
+              )}
+            </BreadcrumbItem>
+          </div>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+function AdminGuardSkeleton() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4">
+      <Card className="w-full max-w-md border-dashed">
+        <CardHeader className="space-y-3 text-center">
+          <Skeleton className="mx-auto h-10 w-10 rounded-full" />
+          <CardTitle className="text-xl">Checking permissions</CardTitle>
+          <p className="text-sm text-muted-foreground">Verifying your admin access…</p>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-5/6" />
+          <Skeleton className="h-3 w-2/3" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function AdminForbidden() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-2 text-center">
+          <CardTitle className="text-xl">Admin access required</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            You need to be signed in with an administrator account to open the console.
+          </p>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <Button asChild>
+            <Link to="/auth">Sign in</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link to="/">Return home</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function AdminGuardError() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-2 text-center">
+          <CardTitle className="text-xl">Unable to verify access</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Something went wrong while confirming your administrator status. Please try again.
+          </p>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <Button onClick={() => window.location.reload()}>Retry</Button>
+          <Button asChild variant="outline">
+            <Link to="/">Return home</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -1,0 +1,14 @@
+import { useOutletContext } from "react-router-dom";
+
+import type { AdminOutletContext } from "./AdminLayout";
+import { AdminDashboardSkeleton, AdminSectionSkeleton } from "./components/AdminSkeletons";
+
+export default function AdminPage() {
+  const { meta } = useOutletContext<AdminOutletContext>();
+
+  if (meta.variant === "dashboard") {
+    return <AdminDashboardSkeleton title={meta.title} description={meta.description} />;
+  }
+
+  return <AdminSectionSkeleton title={meta.title} description={meta.description} />;
+}

--- a/src/pages/admin/components/AdminSkeletons.tsx
+++ b/src/pages/admin/components/AdminSkeletons.tsx
@@ -1,0 +1,149 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface AdminSectionProps {
+  title: string;
+  description?: string;
+}
+
+export function AdminDashboardSkeleton({ title, description }: AdminSectionProps) {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+        {description && <p className="text-muted-foreground">{description}</p>}
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Card key={index} className="border-dashed">
+            <CardHeader className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-8 w-20" />
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-3 w-24" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card className="border-dashed">
+        <CardHeader className="space-y-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-3 w-64" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="space-y-2">
+              <Skeleton className="h-4 w-40" />
+              <div className="flex gap-2">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <AdminReviewSkeleton />
+    </div>
+  );
+}
+
+export function AdminSectionSkeleton({ title, description }: AdminSectionProps) {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+        {description && <p className="text-muted-foreground">{description}</p>}
+      </header>
+
+      <AdminReviewSkeleton />
+    </div>
+  );
+}
+
+function AdminReviewSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(280px,340px)]">
+        <Card className="border-dashed">
+          <CardHeader className="space-y-4">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <Skeleton className="h-10 w-full md:w-64" />
+              <div className="flex w-full items-center gap-2 md:w-auto">
+                <Skeleton className="h-9 w-full md:w-28" />
+                <Skeleton className="h-9 w-full md:w-20" />
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Skeleton className="h-6 w-20" />
+              <Skeleton className="h-6 w-24" />
+              <Skeleton className="h-6 w-16" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)] gap-4">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <Skeleton key={index} className="h-4 w-full" />
+              ))}
+            </div>
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)] gap-4 rounded-md border bg-muted/40 p-4"
+                >
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-4 w-2/3" />
+                  <Skeleton className="h-4 w-1/2" />
+                  <Skeleton className="h-4 w-1/2" />
+                </div>
+              ))}
+            </div>
+            <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <Skeleton className="h-9 w-40" />
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <Skeleton className="h-8 w-16" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-dashed">
+          <CardHeader className="space-y-3">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-4 w-48" />
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <div key={index} className="space-y-2">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-3/4" />
+              </div>
+            ))}
+            <div className="flex flex-col gap-2 pt-2 sm:flex-row">
+              <Skeleton className="h-9 w-full sm:flex-1" />
+              <Skeleton className="h-9 w-full sm:flex-1" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="border-dashed bg-muted/30">
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-base font-medium">Server-confirmed actions</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Optimistic UI feedback is deferred until the server confirms each update. Tables and drawers below stay in a pending state
+            until that confirmation arrives.
+          </p>
+        </CardHeader>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/admin/config.ts
+++ b/src/pages/admin/config.ts
@@ -1,0 +1,172 @@
+export type AdminPageVariant = "dashboard" | "default";
+
+export interface AdminNavItem {
+  title: string;
+  path: string;
+  slug: string;
+  description?: string;
+  variant?: AdminPageVariant;
+}
+
+export interface AdminNavGroup {
+  label?: string;
+  items: AdminNavItem[];
+}
+
+export interface AdminPageMeta extends AdminNavItem {
+  groupLabel?: string;
+}
+
+export const adminNavigation: AdminNavGroup[] = [
+  {
+    items: [
+      {
+        title: "Dashboard",
+        path: "/admin",
+        slug: "",
+        description: "Monitor platform health, stats, and the latest approvals in one place.",
+        variant: "dashboard",
+      },
+    ],
+  },
+  {
+    label: "Moderation",
+    items: [
+      {
+        title: "Resources",
+        path: "/admin/moderation/resources",
+        slug: "moderation/resources",
+        description: "Review resource submissions awaiting approval.",
+      },
+      {
+        title: "Blogposts",
+        path: "/admin/moderation/blogposts",
+        slug: "moderation/blogposts",
+        description: "Approve or reject drafted blogposts before they go live.",
+      },
+      {
+        title: "Research Applications",
+        path: "/admin/moderation/research-applications",
+        slug: "moderation/research-applications",
+        description: "Triage research study requests and coordinate reviewer feedback.",
+      },
+      {
+        title: "Comments (stub)",
+        path: "/admin/moderation/comments",
+        slug: "moderation/comments",
+        description: "Centralise comment moderation with a forthcoming workflow.",
+      },
+    ],
+  },
+  {
+    label: "Content",
+    items: [
+      {
+        title: "Posts",
+        path: "/admin/content/posts",
+        slug: "content/posts",
+        description: "Plan and manage editorial posts across the site.",
+      },
+      {
+        title: "Resources",
+        path: "/admin/content/resources",
+        slug: "content/resources",
+        description: "Curate approved resources and update catalogue metadata.",
+      },
+      {
+        title: "Users",
+        path: "/admin/content/users",
+        slug: "content/users",
+        description: "Oversee contributor access and publishing permissions.",
+      },
+    ],
+  },
+  {
+    label: "Directory",
+    items: [
+      {
+        title: "Invitations",
+        path: "/admin/directory/invitations",
+        slug: "directory/invitations",
+        description: "Track outstanding invitations and reminders for collaborators.",
+      },
+      {
+        title: "Roles (Admins)",
+        path: "/admin/directory/roles",
+        slug: "directory/roles",
+        description: "Grant or revoke administrative roles across the organisation.",
+      },
+    ],
+  },
+  {
+    label: "Research",
+    items: [
+      {
+        title: "Projects",
+        path: "/admin/research/projects",
+        slug: "research/projects",
+        description: "Coordinate active research projects and milestones.",
+      },
+      {
+        title: "Documents",
+        path: "/admin/research/documents",
+        slug: "research/documents",
+        description: "Organise research documentation, consent forms, and templates.",
+      },
+      {
+        title: "Participants",
+        path: "/admin/research/participants",
+        slug: "research/participants",
+        description: "Manage participant rosters, consent, and communication.",
+      },
+      {
+        title: "Submissions",
+        path: "/admin/research/submissions",
+        slug: "research/submissions",
+        description: "Review submitted findings, datasets, and supporting evidence.",
+      },
+    ],
+  },
+  {
+    label: "System",
+    items: [
+      {
+        title: "Notifications",
+        path: "/admin/system/notifications",
+        slug: "system/notifications",
+        description: "Broadcast updates and manage delivery schedules.",
+      },
+      {
+        title: "Audit Log",
+        path: "/admin/system/audit-log",
+        slug: "system/audit-log",
+        description: "Inspect sensitive changes recorded across the platform.",
+      },
+      {
+        title: "Settings",
+        path: "/admin/system/settings",
+        slug: "system/settings",
+        description: "Adjust platform-wide configuration and integration keys.",
+      },
+    ],
+  },
+];
+
+const adminPageMeta = new Map<string, AdminPageMeta>();
+
+for (const group of adminNavigation) {
+  for (const item of group.items) {
+    adminPageMeta.set(item.slug, { ...item, groupLabel: group.label });
+  }
+}
+
+function normaliseAdminPath(pathname: string): string {
+  const withoutPrefix = pathname.startsWith("/admin") ? pathname.slice("/admin".length) : pathname;
+  const trimmed = withoutPrefix.replace(/^\/+/, "").replace(/\/+$/, "");
+  return trimmed;
+}
+
+export function getAdminPageMeta(pathname: string): AdminPageMeta | undefined {
+  const slug = normaliseAdminPath(pathname);
+  return adminPageMeta.get(slug);
+}


### PR DESCRIPTION
## Summary
- add a guard endpoint that reuses `requireAdmin` so the UI can confirm administrator access
- introduce an admin layout with sidebar navigation, breadcrumbs, and a skeleton review workspace for every section
- wire the `/admin` routes through the new layout and guard hook so each section renders server-confirmed placeholders

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d164e5dc24833190c09b5c9caf815f