### PR TITLE
Enable cross-tab resource attachments for lesson builder

### DIFF
--- a/src/components/lesson-draft/ResourceCard.tsx
+++ b/src/components/lesson-draft/ResourceCard.tsx
@@ -1,7 +1,9 @@
+import type { MouseEvent } from "react";
 import { Plus } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { Resource } from "@/types/resources";
 
@@ -10,6 +12,8 @@ interface ResourceCardProps {
   layout?: "horizontal" | "vertical";
   onAdd?: () => void;
   addButtonLabel?: string;
+  addButtonDisabled?: boolean;
+  addButtonTooltip?: string;
 }
 
 const formatMetadata = (resource: Resource) => {
@@ -31,6 +35,8 @@ export const ResourceCard = ({
   layout = "horizontal",
   onAdd,
   addButtonLabel,
+  addButtonDisabled = false,
+  addButtonTooltip,
 }: ResourceCardProps) => {
   const metadata = formatMetadata(resource);
   const tags = resource.tags?.filter(tag => tag.trim().length > 0).slice(0, 4) ?? [];
@@ -86,6 +92,29 @@ export const ResourceCard = ({
     </div>
   );
 
+  const handleAddClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (addButtonDisabled) {
+      return;
+    }
+    onAdd?.();
+  };
+
+  const addButton = (
+    <Button
+      type="button"
+      variant="secondary"
+      size="icon"
+      className="absolute right-3 top-3 h-7 w-7"
+      onClick={handleAddClick}
+      aria-label={addButtonLabel ?? "Add resource"}
+      disabled={addButtonDisabled}
+    >
+      <Plus className="h-4 w-4" aria-hidden />
+    </Button>
+  );
+
   return (
     <article
       className={cn(
@@ -95,20 +124,18 @@ export const ResourceCard = ({
       )}
     >
       {showAddButton ? (
-        <Button
-          type="button"
-          variant="secondary"
-          size="icon"
-          className="absolute right-3 top-3 h-7 w-7"
-          onClick={event => {
-            event.preventDefault();
-            event.stopPropagation();
-            onAdd?.();
-          }}
-          aria-label={addButtonLabel ?? "Add resource"}
-        >
-          <Plus className="h-4 w-4" aria-hidden />
-        </Button>
+        addButtonTooltip ? (
+          <TooltipProvider delayDuration={100}>
+            <Tooltip>
+              <TooltipTrigger asChild>{addButton}</TooltipTrigger>
+              <TooltipContent side="left" align="center">
+                {addButtonTooltip}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          addButton
+        )
       ) : null}
       {isVertical ? (
         <>

--- a/src/lib/lesson-draft-bridge.ts
+++ b/src/lib/lesson-draft-bridge.ts
@@ -1,6 +1,9 @@
 import type { LessonDraft } from "@/stores/lessonDraft";
 
 const ACTIVE_STEP_STORAGE_PREFIX = "lesson-draft:active-step:";
+const ACTIVE_DRAFT_FLAG_STORAGE_KEY = "lesson-draft:active";
+const ACTIVE_DRAFT_ID_STORAGE_KEY = "lesson-draft:active-id";
+const GLOBAL_ACTIVE_STEP_STORAGE_KEY = "lesson-draft:active-step-id";
 const CONTEXT_EVENT = "lesson-draft:context-change";
 const ACTIVE_STEP_EVENT = "lesson-draft:active-step-change";
 const ATTACH_RESOURCE_EVENT = "lesson-draft:attach-resource";
@@ -24,13 +27,52 @@ type LessonDraftAttachResourceDetail = {
   resourceId: string;
 };
 
+type LessonDraftBroadcastMessage =
+  | {
+      name: typeof CONTEXT_EVENT;
+      detail: LessonDraftContextDetail;
+    }
+  | {
+      name: typeof ACTIVE_STEP_EVENT;
+      detail: LessonDraftActiveStepDetail;
+    }
+  | {
+      name: typeof ATTACH_RESOURCE_EVENT;
+      detail: LessonDraftAttachResourceDetail;
+    };
+
 const isBrowser = () => typeof window !== "undefined";
+
+let lessonDraftBroadcast: BroadcastChannel | null | undefined;
 
 const getLessonDraftWindow = (): LessonDraftWindow | null => {
   if (!isBrowser()) {
     return null;
   }
   return window as LessonDraftWindow;
+};
+
+const getBroadcastChannel = (): BroadcastChannel | null => {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  if (lessonDraftBroadcast !== undefined) {
+    return lessonDraftBroadcast;
+  }
+
+  if (typeof BroadcastChannel === "undefined") {
+    lessonDraftBroadcast = null;
+    return lessonDraftBroadcast;
+  }
+
+  try {
+    lessonDraftBroadcast = new BroadcastChannel("lesson-draft");
+  } catch {
+    lessonDraftBroadcast = null;
+  }
+
+  return lessonDraftBroadcast;
 };
 
 const getStorage = (): Storage | null => {
@@ -47,35 +89,124 @@ const getStorage = (): Storage | null => {
 
 const getActiveStepStorageKey = (draftId: string) => `${ACTIVE_STEP_STORAGE_PREFIX}${draftId}`;
 
-const dispatchEvent = <TDetail,>(name: string, detail: TDetail) => {
-  const target = getLessonDraftWindow();
-  if (!target) {
+const setStoredActiveDraftId = (draftId: LessonDraft["id"] | null) => {
+  const storage = getStorage();
+  if (!storage) {
     return;
   }
 
-  target.dispatchEvent(new CustomEvent<TDetail>(name, { detail }));
+  try {
+    if (draftId) {
+      storage.setItem(ACTIVE_DRAFT_FLAG_STORAGE_KEY, "true");
+      storage.setItem(ACTIVE_DRAFT_ID_STORAGE_KEY, draftId);
+    } else {
+      storage.removeItem(ACTIVE_DRAFT_FLAG_STORAGE_KEY);
+      storage.removeItem(ACTIVE_DRAFT_ID_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage errors
+  }
+};
+
+const getStoredActiveDraftId = (): LessonDraft["id"] | null => {
+  const storage = getStorage();
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    const value = storage.getItem(ACTIVE_DRAFT_ID_STORAGE_KEY);
+    return typeof value === "string" && value.trim().length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+const setGlobalActiveStepId = (stepId: string | null) => {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    if (stepId && stepId.trim().length > 0) {
+      storage.setItem(GLOBAL_ACTIVE_STEP_STORAGE_KEY, stepId);
+    } else {
+      storage.removeItem(GLOBAL_ACTIVE_STEP_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage errors
+  }
+};
+
+const getGlobalActiveStepId = (): string | null => {
+  const storage = getStorage();
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    const value = storage.getItem(GLOBAL_ACTIVE_STEP_STORAGE_KEY);
+    return typeof value === "string" && value.trim().length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+const dispatchEvent = <TDetail,>(name: string, detail: TDetail) => {
+  const target = getLessonDraftWindow();
+  if (target) {
+    target.dispatchEvent(new CustomEvent<TDetail>(name, { detail }));
+  }
+
+  const channel = getBroadcastChannel();
+  if (channel) {
+    try {
+      channel.postMessage({ name, detail } as LessonDraftBroadcastMessage);
+    } catch {
+      // Ignore broadcast errors
+    }
+  }
 };
 
 export const getActiveLessonDraftId = (): LessonDraft["id"] | null => {
   const target = getLessonDraftWindow();
-  if (!target) {
-    return null;
+  if (target) {
+    const id = target.__activeLessonDraft;
+    if (typeof id === "string" && id.trim().length > 0) {
+      return id;
+    }
   }
 
-  const id = target.__activeLessonDraft;
-  return typeof id === "string" && id.trim().length > 0 ? id : null;
+  return getStoredActiveDraftId();
+};
+
+export const hasActiveLessonDraft = (): boolean => {
+  const storage = getStorage();
+  if (!storage) {
+    return false;
+  }
+
+  try {
+    return storage.getItem(ACTIVE_DRAFT_FLAG_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
 };
 
 export const setActiveLessonDraftId = (draftId: LessonDraft["id"] | null) => {
   const target = getLessonDraftWindow();
-  if (!target) {
-    return;
+  if (target) {
+    if (draftId) {
+      target.__activeLessonDraft = draftId;
+    } else {
+      delete target.__activeLessonDraft;
+    }
   }
 
-  if (draftId) {
-    target.__activeLessonDraft = draftId;
-  } else {
-    delete target.__activeLessonDraft;
+  setStoredActiveDraftId(draftId);
+  if (!draftId) {
+    setGlobalActiveStepId(null);
   }
 
   dispatchEvent<LessonDraftContextDetail>(CONTEXT_EVENT, { draftId });
@@ -110,55 +241,81 @@ export const persistActiveStepId = (draftId: LessonDraft["id"], stepId: string |
     }
   }
 
+  if (getStoredActiveDraftId() === draftId) {
+    setGlobalActiveStepId(stepId);
+  }
+
   dispatchEvent<LessonDraftActiveStepDetail>(ACTIVE_STEP_EVENT, { draftId, stepId });
+};
+
+const subscribeToBroadcast = <TDetail,>(
+  name: LessonDraftBroadcastMessage["name"],
+  handler: (detail: TDetail) => void,
+) => {
+  const channel = getBroadcastChannel();
+  if (!channel) {
+    return () => undefined;
+  }
+
+  const listener = (event: MessageEvent<LessonDraftBroadcastMessage>) => {
+    if (event.data?.name === name) {
+      handler(event.data.detail as TDetail);
+    }
+  };
+
+  channel.addEventListener("message", listener as EventListener);
+  return () => channel.removeEventListener("message", listener as EventListener);
 };
 
 export const subscribeToLessonDraftContext = (
   handler: (detail: LessonDraftContextDetail) => void,
 ) => {
   const target = getLessonDraftWindow();
-  if (!target) {
-    return () => undefined;
-  }
-
   const listener = (event: Event) => {
     handler((event as CustomEvent<LessonDraftContextDetail>).detail);
   };
 
-  target.addEventListener(CONTEXT_EVENT, listener as EventListener);
-  return () => target.removeEventListener(CONTEXT_EVENT, listener as EventListener);
+  target?.addEventListener(CONTEXT_EVENT, listener as EventListener);
+  const unsubscribeBroadcast = subscribeToBroadcast(CONTEXT_EVENT, handler);
+
+  return () => {
+    target?.removeEventListener(CONTEXT_EVENT, listener as EventListener);
+    unsubscribeBroadcast();
+  };
 };
 
 export const subscribeToActiveStepChanges = (
   handler: (detail: LessonDraftActiveStepDetail) => void,
 ) => {
   const target = getLessonDraftWindow();
-  if (!target) {
-    return () => undefined;
-  }
-
   const listener = (event: Event) => {
     handler((event as CustomEvent<LessonDraftActiveStepDetail>).detail);
   };
 
-  target.addEventListener(ACTIVE_STEP_EVENT, listener as EventListener);
-  return () => target.removeEventListener(ACTIVE_STEP_EVENT, listener as EventListener);
+  target?.addEventListener(ACTIVE_STEP_EVENT, listener as EventListener);
+  const unsubscribeBroadcast = subscribeToBroadcast(ACTIVE_STEP_EVENT, handler);
+
+  return () => {
+    target?.removeEventListener(ACTIVE_STEP_EVENT, listener as EventListener);
+    unsubscribeBroadcast();
+  };
 };
 
 export const subscribeToResourceAttachments = (
   handler: (detail: LessonDraftAttachResourceDetail) => void,
 ) => {
   const target = getLessonDraftWindow();
-  if (!target) {
-    return () => undefined;
-  }
-
   const listener = (event: Event) => {
     handler((event as CustomEvent<LessonDraftAttachResourceDetail>).detail);
   };
 
-  target.addEventListener(ATTACH_RESOURCE_EVENT, listener as EventListener);
-  return () => target.removeEventListener(ATTACH_RESOURCE_EVENT, listener as EventListener);
+  target?.addEventListener(ATTACH_RESOURCE_EVENT, listener as EventListener);
+  const unsubscribeBroadcast = subscribeToBroadcast(ATTACH_RESOURCE_EVENT, handler);
+
+  return () => {
+    target?.removeEventListener(ATTACH_RESOURCE_EVENT, listener as EventListener);
+    unsubscribeBroadcast();
+  };
 };
 
 export const emitAttachResource = (detail: LessonDraftAttachResourceDetail) => {
@@ -182,12 +339,13 @@ export const attachResourceToActiveStep = (resourceId: string): boolean => {
 
 export const clearLessonDraftContext = (draftId: LessonDraft["id"]) => {
   const target = getLessonDraftWindow();
-  if (!target) {
-    return;
+  if (target && target.__activeLessonDraft === draftId) {
+    delete target.__activeLessonDraft;
   }
 
-  if (target.__activeLessonDraft === draftId) {
-    delete target.__activeLessonDraft;
+  if (getStoredActiveDraftId() === draftId) {
+    setStoredActiveDraftId(null);
+    setGlobalActiveStepId(null);
   }
 
   dispatchEvent<LessonDraftContextDetail>(CONTEXT_EVENT, { draftId: null });
@@ -197,4 +355,13 @@ export type {
   LessonDraftContextDetail,
   LessonDraftActiveStepDetail,
   LessonDraftAttachResourceDetail,
+};
+
+export {
+  ACTIVE_DRAFT_FLAG_STORAGE_KEY,
+  ACTIVE_DRAFT_ID_STORAGE_KEY,
+  ACTIVE_STEP_STORAGE_PREFIX,
+  GLOBAL_ACTIVE_STEP_STORAGE_KEY,
+  getStoredActiveDraftId,
+  getGlobalActiveStepId,
 };


### PR DESCRIPTION
## Summary
- persist the active lesson draft context in localStorage and broadcast updates across tabs so resources know which step is active
- add disabled “Add to plan” affordances with tooltips and success toasts so resources can attach to the active lesson step when available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d16a4286008331ad55ad27e248d23c