### PR TITLE
Add admin consoles for posts and resources

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -174,8 +174,10 @@ const Blog = () => {
       let query = supabase
         .from("content_master")
         .select("*")
-        .in("page", ["research_blog", "edutech", "teacher_diary"]) 
+        .in("page", ["research_blog", "edutech", "teacher_diary"])
         .eq("is_published", true)
+        .eq("status", "published")
+        .is("deleted_at", null)
         .eq("language", language);
 
       if (searchTerm) {

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -85,7 +85,9 @@ export default function BlogPost() {
         .eq("slug", slug)
         .in("page", ["research_blog", "edutech", "teacher_diary"])
         .eq("language", language)
-        .eq("is_published", true);
+        .eq("is_published", true)
+        .eq("status", "published")
+        .is("deleted_at", null);
 
       if (error) {
         throw error;

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -2,9 +2,22 @@ import { useOutletContext } from "react-router-dom";
 
 import type { AdminOutletContext } from "./AdminLayout";
 import { AdminDashboardSkeleton, AdminSectionSkeleton } from "./components/AdminSkeletons";
+import AdminPostsPage from "./content/AdminPostsPage";
+import AdminResourcesPage from "./content/AdminResourcesPage";
+
+const PAGE_COMPONENTS: Record<string, () => JSX.Element> = {
+  "content/posts": AdminPostsPage,
+  "content/resources": AdminResourcesPage,
+};
 
 export default function AdminPage() {
   const { meta } = useOutletContext<AdminOutletContext>();
+
+  const Component = meta.slug ? PAGE_COMPONENTS[meta.slug] : undefined;
+
+  if (Component) {
+    return <Component />;
+  }
 
   if (meta.variant === "dashboard") {
     return <AdminDashboardSkeleton title={meta.title} description={meta.description} />;

--- a/src/pages/admin/content/AdminPostsPage.tsx
+++ b/src/pages/admin/content/AdminPostsPage.tsx
@@ -1,0 +1,599 @@
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+
+type AdminPostStatus = "draft" | "pending" | "approved" | "published";
+
+const POST_STATUS: Array<AdminPostStatus> = ["draft", "pending", "approved", "published"];
+const POST_PAGES = [
+  { value: "research_blog", label: "Research blog" },
+  { value: "edutech", label: "Edutech" },
+  { value: "teacher_diary", label: "Teacher diary" },
+] as const;
+
+const STATUS_LABELS: Record<AdminPostStatus, string> = {
+  draft: "Draft",
+  pending: "Pending",
+  approved: "Approved",
+  published: "Published",
+};
+
+type ContentBlock = {
+  type: string;
+  data?: { text?: string };
+};
+
+type ContentDocument = {
+  time?: number;
+  version?: string;
+  blocks?: ContentBlock[];
+};
+
+interface AdminPostRecord {
+  id: string;
+  title: string;
+  slug: string;
+  language: string | null;
+  page: string;
+  status: AdminPostStatus;
+  updated_at: string | null;
+  created_at: string | null;
+  published_at: string | null;
+  is_published: boolean | null;
+  deleted_at: string | null;
+  subtitle: string | null;
+  excerpt: string | null;
+  author: Record<string, unknown> | null;
+  content: unknown;
+  tags: string[] | null;
+}
+
+interface AdminPost extends Omit<AdminPostRecord, "author" | "content"> {
+  authorName: string | null;
+  contentBody: string;
+}
+
+interface PostFormValues {
+  title: string;
+  slug: string;
+  language: string;
+  page: string;
+  status: AdminPostStatus;
+  authorName: string;
+  subtitle: string;
+  excerpt: string;
+  body: string;
+  tags: string;
+}
+
+function extractAuthorName(author: Record<string, unknown> | null): string | null {
+  if (!author || typeof author !== "object") {
+    return null;
+  }
+
+  const value = "name" in author ? author.name : undefined;
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+
+  const altValue = "full_name" in author ? author.full_name : undefined;
+  if (typeof altValue === "string" && altValue.trim()) {
+    return altValue.trim();
+  }
+
+  return null;
+}
+
+function extractBodyFromContent(content: unknown): string {
+  if (!content) {
+    return "";
+  }
+
+  if (typeof content === "string") {
+    try {
+      const parsed = JSON.parse(content) as ContentDocument;
+      return extractBodyFromContent(parsed);
+    } catch {
+      return content;
+    }
+  }
+
+  if (typeof content === "object" && content !== null) {
+    const document = content as ContentDocument;
+    if (Array.isArray(document.blocks)) {
+      const parts = document.blocks
+        .map(block => {
+          if (!block || typeof block !== "object") {
+            return null;
+          }
+          if (block.type !== "paragraph") {
+            return null;
+          }
+          const text = block.data?.text;
+          if (typeof text === "string" && text.trim()) {
+            return text.replace(/<br\s*\/?\s*>/gi, "\n");
+          }
+          return null;
+        })
+        .filter((value): value is string => Boolean(value));
+      if (parts.length > 0) {
+        return parts.join("\n\n");
+      }
+    }
+
+    return JSON.stringify(document, null, 2);
+  }
+
+  return "";
+}
+
+function buildContentPayload(body: string): ContentDocument | null {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const paragraphs = trimmed
+    .split(/\n{2,}/)
+    .map(part => part.trim())
+    .filter(Boolean);
+
+  if (paragraphs.length === 0) {
+    return null;
+  }
+
+  return {
+    time: Date.now(),
+    version: "1.0",
+    blocks: paragraphs.map(paragraph => ({
+      type: "paragraph",
+      data: {
+        text: paragraph.replace(/\n/g, "<br>"),
+      },
+    })),
+  };
+}
+
+function normaliseTags(tags: string): string[] {
+  return tags
+    .split(",")
+    .map(tag => tag.trim())
+    .filter(Boolean)
+    .map(tag => tag.replace(/\s+/g, " "));
+}
+
+async function fetchAdminPosts(): Promise<AdminPost[]> {
+  const { data, error } = await supabase
+    .from("content_master")
+    .select<AdminPostRecord>(
+      "id,title,slug,language,page,status,updated_at,created_at,published_at,is_published,deleted_at,subtitle,excerpt,author,content,tags",
+    )
+    .in(
+      "page",
+      POST_PAGES.map(option => option.value),
+    )
+    .order("updated_at", { ascending: false, nullsLast: true })
+    .order("created_at", { ascending: false, nullsLast: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? []).map(record => ({
+    ...record,
+    authorName: extractAuthorName(record.author),
+    contentBody: extractBodyFromContent(record.content),
+  }));
+}
+
+async function savePost(values: PostFormValues, existing?: AdminPost): Promise<AdminPost> {
+  const payload = {
+    title: values.title.trim(),
+    slug: values.slug.trim(),
+    language: values.language.trim(),
+    page: values.page,
+    status: values.status,
+    subtitle: values.subtitle.trim() || null,
+    excerpt: values.excerpt.trim() || null,
+    author: values.authorName.trim() ? { name: values.authorName.trim() } : null,
+    tags: normaliseTags(values.tags),
+    content: buildContentPayload(values.body),
+    deleted_at: existing?.deleted_at ?? null,
+    content_type: "blog",
+  };
+
+  const now = new Date().toISOString();
+  const shouldPublish = values.status === "published";
+  const publishPatch = shouldPublish
+    ? { published_at: existing?.published_at ?? now }
+    : { published_at: existing?.status === "published" ? existing.published_at : null };
+
+  if (!existing) {
+    const { data, error } = await supabase
+      .from("content_master")
+      .insert({
+        ...payload,
+        ...publishPatch,
+      })
+      .select<AdminPostRecord>(
+        "id,title,slug,language,page,status,updated_at,created_at,published_at,is_published,deleted_at,subtitle,excerpt,author,content,tags",
+      )
+      .single();
+
+    if (error || !data) {
+      throw new Error(error?.message ?? "Failed to create post");
+    }
+
+    return {
+      ...data,
+      authorName: extractAuthorName(data.author),
+      contentBody: extractBodyFromContent(data.content),
+    };
+  }
+
+  const { data, error } = await supabase
+    .from("content_master")
+    .update({
+      ...payload,
+      ...publishPatch,
+    })
+    .eq("id", existing.id)
+    .select<AdminPostRecord>(
+      "id,title,slug,language,page,status,updated_at,created_at,published_at,is_published,deleted_at,subtitle,excerpt,author,content,tags",
+    )
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message ?? "Failed to update post");
+  }
+
+  return {
+    ...data,
+    authorName: extractAuthorName(data.author),
+    contentBody: extractBodyFromContent(data.content),
+  };
+}
+
+export function AdminPostsPage() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: posts, isLoading, isError, error } = useQuery({
+    queryKey: ["admin", "posts"],
+    queryFn: fetchAdminPosts,
+  });
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingPost, setEditingPost] = useState<AdminPost | null>(null);
+  const [actionPostId, setActionPostId] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: ({ values, existing }: { values: PostFormValues; existing?: AdminPost }) =>
+      savePost(values, existing),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "posts"] });
+      const existing = mutation.variables?.existing;
+      toast({ title: existing ? "Post updated" : "Post created", variant: "default" });
+      setDialogOpen(false);
+      setEditingPost(null);
+    },
+    onError: mutationError => {
+      const description =
+        mutationError instanceof Error ? mutationError.message : "Something went wrong while saving the post.";
+      toast({ title: "Unable to save post", description, variant: "destructive" });
+    },
+  });
+
+  const defaultValues = useMemo<PostFormValues>(() => {
+    if (!editingPost) {
+      return {
+        title: "",
+        slug: "",
+        language: "en",
+        page: POST_PAGES[0]?.value ?? "research_blog",
+        status: "draft",
+        authorName: "",
+        subtitle: "",
+        excerpt: "",
+        body: "",
+        tags: "",
+      };
+    }
+
+    return {
+      title: editingPost.title ?? "",
+      slug: editingPost.slug ?? "",
+      language: editingPost.language ?? "en",
+      page: editingPost.page ?? POST_PAGES[0]?.value ?? "research_blog",
+      status: editingPost.status,
+      authorName: editingPost.authorName ?? "",
+      subtitle: editingPost.subtitle ?? "",
+      excerpt: editingPost.excerpt ?? "",
+      body: editingPost.contentBody ?? "",
+      tags: (editingPost.tags ?? []).join(", "),
+    };
+  }, [editingPost]);
+
+  const form = useForm<PostFormValues>({ defaultValues });
+
+  useEffect(() => {
+    form.reset(defaultValues);
+  }, [defaultValues, form]);
+
+  const resetForm = () => {
+    form.reset(defaultValues);
+  };
+
+  const handleOpenCreate = () => {
+    setEditingPost(null);
+    setDialogOpen(true);
+  };
+
+  const handleOpenEdit = (post: AdminPost) => {
+    setEditingPost(post);
+    setDialogOpen(true);
+  };
+
+  const handleDialogChange = (open: boolean) => {
+    setDialogOpen(open);
+    if (!open) {
+      setEditingPost(null);
+      resetForm();
+    }
+  };
+
+  const performUpdate = async (id: string, update: Record<string, unknown>, successMessage: string) => {
+    setActionPostId(id);
+    try {
+      const { error: updateError } = await supabase.from("content_master").update(update).eq("id", id);
+      if (updateError) {
+        throw new Error(updateError.message);
+      }
+      toast({ title: successMessage });
+      void queryClient.invalidateQueries({ queryKey: ["admin", "posts"] });
+    } catch (updateError) {
+      const description = updateError instanceof Error ? updateError.message : "Unexpected error";
+      toast({ title: "Update failed", description, variant: "destructive" });
+    } finally {
+      setActionPostId(null);
+    }
+  };
+
+  const handlePublish = (post: AdminPost) =>
+    performUpdate(post.id, { status: "published", deleted_at: null }, "Post published");
+
+  const handleUnpublish = (post: AdminPost) =>
+    performUpdate(post.id, { status: "draft" }, "Post moved back to draft");
+
+  const handleSoftDelete = (post: AdminPost) =>
+    performUpdate(post.id, { deleted_at: new Date().toISOString() }, "Post moved to recycle bin");
+
+  const handleRestore = (post: AdminPost) =>
+    performUpdate(post.id, { deleted_at: null }, "Post restored");
+
+  const onSubmit = form.handleSubmit(values => {
+    mutation.mutate({ values, existing: editingPost ?? undefined });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">Posts</h1>
+          <p className="text-sm text-muted-foreground">
+            Create, edit, and publish editorial content across research blog, Edutech, and diary sections.
+          </p>
+        </div>
+        <Dialog open={dialogOpen} onOpenChange={handleDialogChange}>
+          <Button onClick={handleOpenCreate}>New post</Button>
+          <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+            <DialogHeader>
+              <DialogTitle>{editingPost ? "Edit post" : "Create a new post"}</DialogTitle>
+            </DialogHeader>
+            <form onSubmit={onSubmit} className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="post-title">Title</Label>
+                  <Input id="post-title" {...form.register("title", { required: true })} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="post-slug">Slug</Label>
+                  <Input id="post-slug" {...form.register("slug", { required: true })} placeholder="my-new-post" />
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="space-y-2">
+                  <Label htmlFor="post-language">Language</Label>
+                  <Input id="post-language" {...form.register("language", { required: true })} placeholder="en" />
+                </div>
+                <div className="space-y-2">
+                  <Label>Section</Label>
+                  <Select
+                    value={form.watch("page")}
+                    onValueChange={value => {
+                      form.setValue("page", value);
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a section" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {POST_PAGES.map(option => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Status</Label>
+                  <Select
+                    value={form.watch("status")}
+                    onValueChange={value => {
+                      form.setValue("status", value as AdminPostStatus);
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Choose status" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {POST_STATUS.map(status => (
+                        <SelectItem key={status} value={status}>
+                          {STATUS_LABELS[status]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="post-author">Author name</Label>
+                  <Input id="post-author" {...form.register("authorName")} placeholder="e.g. Jane Smith" />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="post-tags">Tags</Label>
+                  <Input
+                    id="post-tags"
+                    {...form.register("tags")}
+                    placeholder="Comma separated e.g. AI, Math, Case Study"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="post-subtitle">Subtitle</Label>
+                <Input id="post-subtitle" {...form.register("subtitle")} />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="post-excerpt">Excerpt</Label>
+                <Textarea id="post-excerpt" rows={3} {...form.register("excerpt")} />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="post-body">Body</Label>
+                <Textarea id="post-body" rows={10} {...form.register("body")} />
+              </div>
+
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={() => handleDialogChange(false)} disabled={mutation.isPending}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={mutation.isPending}>
+                  {mutation.isPending ? "Saving…" : editingPost ? "Update" : "Create"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card className="border-dashed">
+        <CardHeader>
+          <CardTitle>Recent posts</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading posts…</p>
+          ) : isError ? (
+            <p className="text-sm text-destructive">{error instanceof Error ? error.message : "Failed to load posts."}</p>
+          ) : posts && posts.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Title</TableHead>
+                  <TableHead>Section</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Updated</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {posts.map(post => (
+                  <TableRow key={post.id} className={post.deleted_at ? "opacity-60" : undefined}>
+                    <TableCell>
+                      <div className="font-medium">{post.title}</div>
+                      <div className="text-xs text-muted-foreground">{post.authorName ?? "Unknown author"}</div>
+                      {post.deleted_at ? (
+                        <div className="text-xs text-muted-foreground">Deleted {format(new Date(post.deleted_at), "dd MMM yyyy")}</div>
+                      ) : null}
+                    </TableCell>
+                    <TableCell>{POST_PAGES.find(option => option.value === post.page)?.label ?? post.page}</TableCell>
+                    <TableCell>
+                      <Badge variant={post.status === "published" ? "default" : "secondary"}>{STATUS_LABELS[post.status]}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      {post.updated_at ? format(new Date(post.updated_at), "dd MMM yyyy") : post.created_at ? format(new Date(post.created_at), "dd MMM yyyy") : "—"}
+                    </TableCell>
+                    <TableCell className="text-right space-x-2">
+                      <Button variant="ghost" size="sm" onClick={() => handleOpenEdit(post)}>Edit</Button>
+                      {post.status === "published" ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={actionPostId === post.id}
+                          onClick={() => handleUnpublish(post)}
+                        >
+                          {actionPostId === post.id ? "…" : "Unpublish"}
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={actionPostId === post.id}
+                          onClick={() => handlePublish(post)}
+                        >
+                          {actionPostId === post.id ? "…" : "Publish"}
+                        </Button>
+                      )}
+                      {post.deleted_at ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={actionPostId === post.id}
+                          onClick={() => handleRestore(post)}
+                        >
+                          {actionPostId === post.id ? "…" : "Restore"}
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={actionPostId === post.id}
+                          onClick={() => handleSoftDelete(post)}
+                        >
+                          {actionPostId === post.id ? "…" : "Delete"}
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <p className="text-sm text-muted-foreground">No posts have been created yet.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default AdminPostsPage;

--- a/src/pages/admin/content/AdminResourcesPage.tsx
+++ b/src/pages/admin/content/AdminResourcesPage.tsx
@@ -1,0 +1,591 @@
+import { useEffect, useMemo, useState, type ChangeEvent } from "react";
+import { useForm } from "react-hook-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+
+const RESOURCE_TYPES = [
+  { value: "worksheet", label: "Worksheet" },
+  { value: "video", label: "Video" },
+  { value: "picture", label: "Picture" },
+  { value: "ppt", label: "Presentation" },
+  { value: "online", label: "Online activity" },
+  { value: "offline", label: "Offline activity" },
+] as const;
+
+const RESOURCE_STATUSES: ResourceStatus[] = ["pending", "approved", "rejected"];
+
+const STATUS_LABELS: Record<ResourceStatus, string> = {
+  pending: "Pending",
+  approved: "Approved",
+  rejected: "Rejected",
+};
+
+type ResourceStatus = "pending" | "approved" | "rejected";
+
+interface AdminResourceRecord {
+  id: string;
+  title: string;
+  description: string | null;
+  url: string | null;
+  storage_path: string | null;
+  type: string;
+  subject: string | null;
+  stage: string | null;
+  tags: string[] | null;
+  thumbnail_url: string | null;
+  status: ResourceStatus;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+  approved_by: string | null;
+  approved_at: string | null;
+}
+
+interface AdminResource extends AdminResourceRecord {
+  tagList: string[];
+}
+
+interface ResourceFormValues {
+  title: string;
+  description: string;
+  type: string;
+  subject: string;
+  stage: string;
+  tags: string;
+  url: string;
+  status: ResourceStatus;
+  is_active: boolean;
+}
+
+function normaliseTags(input: string): string[] {
+  return input
+    .split(",")
+    .map(tag => tag.trim())
+    .filter(Boolean)
+    .map(tag => tag.replace(/\s+/g, " "));
+}
+
+async function fetchResources(): Promise<AdminResource[]> {
+  const { data, error } = await supabase
+    .from("resources")
+    .select<AdminResourceRecord>(
+      "id,title,description,url,storage_path,type,subject,stage,tags,thumbnail_url,status,is_active,created_at,updated_at,created_by,approved_by,approved_at",
+    )
+    .order("updated_at", { ascending: false, nullsLast: true })
+    .order("created_at", { ascending: false, nullsLast: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? []).map(record => ({
+    ...record,
+    tagList: record.tags ?? [],
+  }));
+}
+
+function buildStoragePath(userId: string | null, file: File): string {
+  const extensionMatch = file.name?.match(/\.([^.]+)$/);
+  const extension = extensionMatch ? extensionMatch[1] : "bin";
+  const uuid =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  const ownerSegment = userId ?? "system";
+  return `admin/${ownerSegment}/${uuid}.${extension}`;
+}
+
+async function saveResource(
+  values: ResourceFormValues,
+  options: { file: File | null; clearStoredFile: boolean; existing?: AdminResource },
+): Promise<AdminResource> {
+  const { data: userResult } = await supabase.auth.getUser();
+  const userId = userResult?.user?.id ?? null;
+
+  let storagePath = options.existing?.storage_path ?? null;
+
+  if (options.clearStoredFile) {
+    storagePath = null;
+  }
+
+  if (options.file) {
+    const path = buildStoragePath(userId, options.file);
+    const { error: uploadError } = await supabase.storage
+      .from("resources")
+      .upload(path, options.file, {
+        upsert: false,
+        cacheControl: "3600",
+        contentType: options.file.type || "application/octet-stream",
+      });
+
+    if (uploadError) {
+      throw new Error(uploadError.message || "Failed to upload file to storage");
+    }
+
+    storagePath = path;
+  }
+
+  const urlValue = values.url.trim();
+  if (!urlValue && !storagePath) {
+    throw new Error("Provide either an external URL or upload a file.");
+  }
+
+  const payload = {
+    title: values.title.trim(),
+    description: values.description.trim() || null,
+    type: values.type,
+    subject: values.subject.trim() || null,
+    stage: values.stage.trim() || null,
+    tags: normaliseTags(values.tags),
+    url: urlValue || null,
+    storage_path: storagePath,
+    status: values.status,
+    is_active: values.is_active,
+  } satisfies Partial<AdminResourceRecord> & { title: string; type: string; status: ResourceStatus; is_active: boolean };
+
+  const approvedPatch =
+    values.status === "approved"
+      ? {
+          approved_by: userId,
+          approved_at: options.existing?.approved_at ?? new Date().toISOString(),
+        }
+      : {
+          approved_by: null,
+          approved_at: null,
+        };
+
+  if (!options.existing) {
+    const { data, error } = await supabase
+      .from("resources")
+      .insert({
+        ...payload,
+        ...approvedPatch,
+        created_by: userId,
+      })
+      .select<AdminResourceRecord>(
+        "id,title,description,url,storage_path,type,subject,stage,tags,thumbnail_url,status,is_active,created_at,updated_at,created_by,approved_by,approved_at",
+      )
+      .single();
+
+    if (error || !data) {
+      throw new Error(error?.message ?? "Failed to create resource");
+    }
+
+    return { ...data, tagList: data.tags ?? [] };
+  }
+
+  const { data, error } = await supabase
+    .from("resources")
+    .update({
+      ...payload,
+      ...approvedPatch,
+    })
+    .eq("id", options.existing.id)
+    .select<AdminResourceRecord>(
+      "id,title,description,url,storage_path,type,subject,stage,tags,thumbnail_url,status,is_active,created_at,updated_at,created_by,approved_by,approved_at",
+    )
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message ?? "Failed to update resource");
+  }
+
+  return { ...data, tagList: data.tags ?? [] };
+}
+
+export function AdminResourcesPage() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: resources, isLoading, isError, error } = useQuery({
+    queryKey: ["admin", "resources"],
+    queryFn: fetchResources,
+  });
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingResource, setEditingResource] = useState<AdminResource | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [clearStoredFile, setClearStoredFile] = useState(false);
+  const [actionResourceId, setActionResourceId] = useState<string | null>(null);
+
+  const typeOptions = useMemo(() => {
+    const base = [...RESOURCE_TYPES];
+    if (editingResource && editingResource.type && !base.some(option => option.value === editingResource.type)) {
+      base.push({ value: editingResource.type, label: editingResource.type });
+    }
+    return base;
+  }, [editingResource]);
+
+  const mutation = useMutation({
+    mutationFn: ({ values, file, clearFile, existing }: { values: ResourceFormValues; file: File | null; clearFile: boolean; existing?: AdminResource }) =>
+      saveResource(values, { file, clearStoredFile: clearFile, existing }),
+    onSuccess: result => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "resources"] });
+      const existing = mutation.variables?.existing;
+      toast({ title: existing ? "Resource updated" : "Resource created" });
+      setDialogOpen(false);
+      setEditingResource(null);
+      setSelectedFile(null);
+      setClearStoredFile(false);
+    },
+    onError: mutationError => {
+      const description =
+        mutationError instanceof Error ? mutationError.message : "Something went wrong while saving the resource.";
+      toast({ title: "Unable to save resource", description, variant: "destructive" });
+    },
+  });
+
+  const defaultValues = useMemo<ResourceFormValues>(() => {
+    if (!editingResource) {
+      return {
+        title: "",
+        description: "",
+        type: RESOURCE_TYPES[0]?.value ?? "worksheet",
+        subject: "",
+        stage: "",
+        tags: "",
+        url: "",
+        status: "pending",
+        is_active: true,
+      };
+    }
+
+    return {
+      title: editingResource.title,
+      description: editingResource.description ?? "",
+      type: editingResource.type,
+      subject: editingResource.subject ?? "",
+      stage: editingResource.stage ?? "",
+      tags: (editingResource.tagList ?? []).join(", "),
+      url: editingResource.url ?? "",
+      status: editingResource.status,
+      is_active: editingResource.is_active,
+    };
+  }, [editingResource]);
+
+  const form = useForm<ResourceFormValues>({ defaultValues });
+
+  useEffect(() => {
+    form.reset(defaultValues);
+    setSelectedFile(null);
+    setClearStoredFile(false);
+  }, [defaultValues, form]);
+
+  const openCreate = () => {
+    setEditingResource(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (resource: AdminResource) => {
+    setEditingResource(resource);
+    setDialogOpen(true);
+  };
+
+  const handleDialogChange = (open: boolean) => {
+    setDialogOpen(open);
+    if (!open) {
+      setEditingResource(null);
+      setSelectedFile(null);
+      setClearStoredFile(false);
+    }
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextFile = event.target.files?.[0] ?? null;
+    setSelectedFile(nextFile);
+    if (nextFile) {
+      setClearStoredFile(false);
+    }
+  };
+
+  const handleRemoveStoredFile = () => {
+    setSelectedFile(null);
+    setClearStoredFile(true);
+  };
+
+  const onSubmit = form.handleSubmit(values => {
+    mutation.mutate({ values, file: selectedFile, clearFile: clearStoredFile, existing: editingResource ?? undefined });
+  });
+
+  const performUpdate = async (id: string, update: Record<string, unknown>, successMessage: string) => {
+    setActionResourceId(id);
+    try {
+      const { error: updateError } = await supabase.from("resources").update(update).eq("id", id);
+      if (updateError) {
+        throw new Error(updateError.message);
+      }
+      toast({ title: successMessage });
+      void queryClient.invalidateQueries({ queryKey: ["admin", "resources"] });
+    } catch (updateError) {
+      const description = updateError instanceof Error ? updateError.message : "Unexpected error";
+      toast({ title: "Update failed", description, variant: "destructive" });
+    } finally {
+      setActionResourceId(null);
+    }
+  };
+
+  const handleApprove = async (resource: AdminResource) => {
+    setActionResourceId(resource.id);
+    try {
+      const { data: userResult, error: authError } = await supabase.auth.getUser();
+      if (authError) {
+        throw new Error(authError.message);
+      }
+      const userId = userResult?.user?.id ?? null;
+      const { error: updateError } = await supabase
+        .from("resources")
+        .update({
+          status: "approved",
+          is_active: true,
+          approved_at: new Date().toISOString(),
+          approved_by: userId,
+        })
+        .eq("id", resource.id);
+
+      if (updateError) {
+        throw new Error(updateError.message);
+      }
+
+      toast({ title: "Resource approved" });
+      void queryClient.invalidateQueries({ queryKey: ["admin", "resources"] });
+    } catch (updateError) {
+      const description = updateError instanceof Error ? updateError.message : "Unexpected error";
+      toast({ title: "Update failed", description, variant: "destructive" });
+    } finally {
+      setActionResourceId(null);
+    }
+  };
+
+  const handleMarkPending = (resource: AdminResource) =>
+    performUpdate(resource.id, { status: "pending", is_active: false, approved_at: null, approved_by: null }, "Resource marked as pending");
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">Resources</h1>
+          <p className="text-sm text-muted-foreground">
+            Curate catalog items, upload private files, and approve submissions from educators.
+          </p>
+        </div>
+        <Dialog open={dialogOpen} onOpenChange={handleDialogChange}>
+          <Button onClick={openCreate}>New resource</Button>
+          <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+            <DialogHeader>
+              <DialogTitle>{editingResource ? "Edit resource" : "Create a new resource"}</DialogTitle>
+            </DialogHeader>
+            <form onSubmit={onSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="resource-title">Title</Label>
+                <Input id="resource-title" {...form.register("title", { required: true })} />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="resource-description">Description</Label>
+                <Textarea id="resource-description" rows={4} {...form.register("description")} />
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Type</Label>
+                  <Select
+                    value={form.watch("type")}
+                    onValueChange={value => {
+                      form.setValue("type", value);
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {typeOptions.map(option => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Status</Label>
+                  <Select
+                    value={form.watch("status")}
+                    onValueChange={value => {
+                      form.setValue("status", value as ResourceStatus);
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Moderation status" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {RESOURCE_STATUSES.map(status => (
+                        <SelectItem key={status} value={status}>
+                          {STATUS_LABELS[status]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="resource-subject">Subject</Label>
+                  <Input id="resource-subject" {...form.register("subject")} placeholder="e.g. Math" />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="resource-stage">Stage</Label>
+                  <Input id="resource-stage" {...form.register("stage")} placeholder="e.g. Lower Secondary" />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="resource-tags">Tags</Label>
+                <Input
+                  id="resource-tags"
+                  {...form.register("tags")}
+                  placeholder="Comma separated e.g. ai, worksheet"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="resource-url">External URL</Label>
+                <Input id="resource-url" type="url" {...form.register("url")}
+                  placeholder="https://example.com/resource" />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="resource-file">Upload file</Label>
+                <Input id="resource-file" type="file" onChange={handleFileChange} />
+                {editingResource?.storage_path && !selectedFile && !clearStoredFile ? (
+                  <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+                    <span>Stored file: {editingResource.storage_path}</span>
+                    <Button type="button" variant="ghost" size="sm" onClick={handleRemoveStoredFile}>
+                      Remove
+                    </Button>
+                  </div>
+                ) : null}
+                {selectedFile ? (
+                  <div className="text-xs text-muted-foreground">Selected file: {selectedFile.name}</div>
+                ) : null}
+              </div>
+
+              <div className="flex items-center justify-between rounded-md border p-3">
+                <div>
+                  <Label htmlFor="resource-active" className="text-sm font-medium">
+                    Visible in catalog
+                  </Label>
+                  <p className="text-xs text-muted-foreground">Inactive resources remain hidden from the public gallery.</p>
+                </div>
+                <Switch
+                  id="resource-active"
+                  checked={form.watch("is_active")}
+                  onCheckedChange={checked => form.setValue("is_active", checked)}
+                />
+              </div>
+
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={() => handleDialogChange(false)} disabled={mutation.isPending}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={mutation.isPending}>
+                  {mutation.isPending ? "Saving…" : editingResource ? "Update" : "Create"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card className="border-dashed">
+        <CardHeader>
+          <CardTitle>Resource library</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading resources…</p>
+          ) : isError ? (
+            <p className="text-sm text-destructive">{error instanceof Error ? error.message : "Failed to load resources."}</p>
+          ) : resources && resources.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Title</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Updated</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {resources.map(resource => (
+                  <TableRow key={resource.id}>
+                    <TableCell>
+                      <div className="font-medium">{resource.title}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {resource.url ? "External" : resource.storage_path ? "Stored file" : ""}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {RESOURCE_TYPES.find(option => option.value === resource.type)?.label ?? resource.type}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={resource.status === "approved" ? "default" : resource.status === "rejected" ? "destructive" : "secondary"}>
+                        {STATUS_LABELS[resource.status]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {resource.updated_at ? format(new Date(resource.updated_at), "dd MMM yyyy") : "—"}
+                    </TableCell>
+                    <TableCell className="text-right space-x-2">
+                      <Button variant="ghost" size="sm" onClick={() => openEdit(resource)}>
+                        Edit
+                      </Button>
+                      {resource.status === "approved" ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={actionResourceId === resource.id}
+                          onClick={() => handleMarkPending(resource)}
+                        >
+                          {actionResourceId === resource.id ? "…" : "Unapprove"}
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={actionResourceId === resource.id}
+                          onClick={() => handleApprove(resource)}
+                        >
+                          {actionResourceId === resource.id ? "…" : "Approve"}
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <p className="text-sm text-muted-foreground">No resources available yet.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default AdminResourcesPage;

--- a/supabase/migrations/20251116000000_admin_content_controls.sql
+++ b/supabase/migrations/20251116000000_admin_content_controls.sql
@@ -1,0 +1,163 @@
+-- Ensure an admin registry exists for permission checks
+create table if not exists public.app_admins (
+  user_id uuid primary key,
+  granted_at timestamptz not null default now()
+);
+
+alter table public.app_admins enable row level security;
+
+-- Helper function to determine if the current or provided user is an admin
+create or replace function public.is_admin(target_user_id uuid default auth.uid())
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  effective_user uuid := coalesce(target_user_id, auth.uid());
+begin
+  if auth.role() = 'service_role' then
+    return true;
+  end if;
+
+  if effective_user is null then
+    return false;
+  end if;
+
+  return exists (
+    select 1
+    from public.app_admins a
+    where a.user_id = effective_user
+  );
+end;
+$$;
+
+comment on function public.is_admin is 'Returns true when the provided (or current) user is registered as an application administrator.';
+
+-- Strengthen the content master schema for editorial workflows
+alter table public.content_master
+  add column if not exists status text;
+
+alter table public.content_master
+  add column if not exists deleted_at timestamptz;
+
+update public.content_master
+set status = case
+    when is_published then 'published'
+    when status is null or status not in ('draft','pending','approved','published') then 'draft'
+    else status
+  end
+where status is null
+   or status not in ('draft','pending','approved','published')
+   or (is_published = true and status <> 'published');
+
+alter table public.content_master
+  alter column status set default 'draft';
+
+alter table public.content_master
+  alter column status set not null;
+
+alter table public.content_master
+  add constraint if not exists content_master_status_check
+  check (status in ('draft','pending','approved','published'));
+
+create index if not exists idx_content_master_status
+  on public.content_master(status);
+
+create index if not exists idx_content_master_deleted_at
+  on public.content_master(deleted_at);
+
+create or replace function public.sync_content_master_status()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.status = 'published' and new.deleted_at is null then
+    new.is_published := true;
+    if new.published_at is null then
+      new.published_at := now();
+    end if;
+  else
+    new.is_published := false;
+  end if;
+
+  if new.deleted_at is not null and new.status = 'published' then
+    new.status := 'draft';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists content_master_sync_status on public.content_master;
+create trigger content_master_sync_status
+before insert or update on public.content_master
+for each row
+execute function public.sync_content_master_status();
+
+-- Administrative policies for editorial content
+drop policy if exists "Admins manage content" on public.content_master;
+drop policy if exists "Admins read all content" on public.content_master;
+
+create policy "Admins read all content"
+  on public.content_master
+  for select
+  to authenticated
+  using (public.is_admin());
+
+create policy "Admins manage content"
+  on public.content_master
+  for all
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- Resource catalog enhancements
+alter table public.resources
+  add column if not exists updated_at timestamptz;
+
+update public.resources
+set updated_at = coalesce(updated_at, created_at);
+
+alter table public.resources
+  alter column updated_at set default now();
+
+alter table public.resources
+  alter column updated_at set not null;
+
+create or replace function public.touch_resources_updated_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists resources_set_updated_at on public.resources;
+create trigger resources_set_updated_at
+before update on public.resources
+for each row execute function public.touch_resources_updated_at();
+
+-- Refresh resource policies to leverage the shared admin helper
+drop policy if exists "Admins can update any resource" on public.resources;
+drop policy if exists "Admins can manage resources" on public.resources;
+drop policy if exists "Admins can read resources" on public.resources;
+
+create policy "Admins can read resources"
+  on public.resources
+  for select
+  to authenticated
+  using (public.is_admin());
+
+create policy "Admins can manage resources"
+  on public.resources
+  for all
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());


### PR DESCRIPTION
## Summary
- add an admin posts workspace that supports creating, editing, publishing, and soft deleting editorial content
- build an admin resources console with upload support, status management, and inline approvals
- extend Supabase content controls plus blog queries to honor post status/soft delete flags with admin-only RLS helpers

## Testing
- npm run lint
- npm run test *(fails: `BuilderLessonPlanDetail > adds a searched resource to the current step and schedules autosave` timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68d16cdb7c808331959430842f35d13c