### PR TITLE
feat: add signed file downloads

### DIFF
--- a/api/__tests__/files-signed.test.ts
+++ b/api/__tests__/files-signed.test.ts
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "../files/signed";
+
+type QueryHandler = (args: { filters: Record<string, unknown> }) => {
+  data: any | null;
+  error: { message: string } | null;
+};
+
+type SignedUrlCall = { bucket: string; path: string; expiresIn: number };
+
+type AuthResponse = {
+  data: { user: { id: string; app_metadata?: Record<string, unknown> } } | { user: null } | null;
+  error: { message: string } | null;
+};
+
+const { stub } = vi.hoisted(() => {
+  class QueryBuilder {
+    private filters: Record<string, unknown> = {};
+
+    constructor(
+      private readonly handler: QueryHandler | null,
+    ) {}
+
+    select(): this {
+      return this;
+    }
+
+    eq(column: string, value: unknown): this {
+      this.filters[column] = value;
+      return this;
+    }
+
+    maybeSingle() {
+      if (!this.handler) {
+        return Promise.resolve({ data: null, error: null });
+      }
+      return Promise.resolve(this.handler({ filters: { ...this.filters } }));
+    }
+  }
+
+  class StorageBucket {
+    constructor(
+      private readonly parent: SupabaseStub,
+      private readonly bucket: string,
+    ) {}
+
+    async createSignedUrl(path: string, expiresIn: number) {
+      this.parent.storageCalls.push({ bucket: this.bucket, path, expiresIn });
+      return this.parent.storageResponse;
+    }
+  }
+
+  class SupabaseStub {
+    public tableHandlers: Record<string, QueryHandler | null> = {};
+    public storageResponse = { data: { signedUrl: "https://cdn.example.com/signed" }, error: null };
+    public storageCalls: SignedUrlCall[] = [];
+    public authResponse: AuthResponse = {
+      data: { user: { id: "user-1" } },
+      error: null,
+    };
+
+    setTableHandler(table: string, handler: QueryHandler | null) {
+      this.tableHandlers[table] = handler;
+    }
+
+    setStorageResponse(url: string) {
+      this.storageResponse = { data: { signedUrl: url }, error: null };
+    }
+
+    setAuthResponse(response: AuthResponse) {
+      this.authResponse = response;
+    }
+
+    reset() {
+      this.tableHandlers = {};
+      this.storageCalls = [];
+      this.storageResponse = { data: { signedUrl: "https://cdn.example.com/signed" }, error: null };
+      this.authResponse = {
+        data: { user: { id: "user-1" } },
+        error: null,
+      };
+    }
+
+    from(table: string) {
+      const handler = this.tableHandlers[table] ?? null;
+      return new QueryBuilder(handler);
+    }
+
+    storage = {
+      from: (bucket: string) => new StorageBucket(this, bucket),
+    };
+
+    auth = {
+      getUser: async (token: string) => {
+        this.lastAuthToken = token;
+        return this.authResponse;
+      },
+    };
+
+    public lastAuthToken: string | null = null;
+  }
+
+  const stub = new SupabaseStub();
+
+  return { stub };
+});
+
+vi.mock("../_lib/supabase", () => ({
+  getSupabaseClient: () => stub,
+}));
+
+describe("files signed endpoint", () => {
+  beforeEach(() => {
+    stub.reset();
+  });
+
+  it("returns 401 when authentication is missing", async () => {
+    const response = await handler(new Request("https://example.com/api/files/signed?bucket=research&path=test"));
+    expect(response.status).toBe(401);
+    const payload = await response.json();
+    expect(payload.error).toMatch(/authentication/i);
+  });
+
+  it("validates required query parameters", async () => {
+    const withBucket = await handler(
+      new Request("https://example.com/api/files/signed?bucket=&path=abc", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+    expect(withBucket.status).toBe(400);
+
+    const withPath = await handler(
+      new Request("https://example.com/api/files/signed?bucket=research", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+    expect(withPath.status).toBe(400);
+  });
+
+  it("rejects unsupported buckets", async () => {
+    const response = await handler(
+      new Request("https://example.com/api/files/signed?bucket=public&path=file.pdf", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns a signed url for lesson plan exports when owned by the user", async () => {
+    stub.setTableHandler("lesson_plan_builder_plans", ({ filters }) => {
+      return filters.latest_export_path === "exports/plan.pdf"
+        ? { data: { id: "plan-1", owner_id: "user-1" }, error: null }
+        : { data: null, error: null };
+    });
+
+    const response = await handler(
+      new Request("https://example.com/api/files/signed?bucket=lesson-plans&path=exports/plan.pdf", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.url).toBe("https://cdn.example.com/signed");
+    expect(stub.storageCalls).toEqual([
+      { bucket: "lesson-plans", path: "exports/plan.pdf", expiresIn: 600 },
+    ]);
+  });
+
+  it("returns 403 when requesting another user's lesson plan export", async () => {
+    stub.setTableHandler("lesson_plan_builder_plans", () => ({
+      data: { id: "plan-1", owner_id: "other-user" },
+      error: null,
+    }));
+
+    const response = await handler(
+      new Request("https://example.com/api/files/signed?bucket=lesson-plans&path=exports/plan.pdf", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows participants to download research documents", async () => {
+    stub.setTableHandler("research_documents", ({ filters }) => {
+      return filters.storage_path === "proj/file.pdf"
+        ? { data: { id: "doc-1", project_id: "project-1" }, error: null }
+        : { data: null, error: null };
+    });
+    stub.setTableHandler("research_projects", ({ filters }) => {
+      return filters.id === "project-1"
+        ? { data: { created_by: "owner" }, error: null }
+        : { data: null, error: null };
+    });
+    stub.setTableHandler("research_participants", ({ filters }) => {
+      return filters.project_id === "project-1" && filters.user_id === "user-1"
+        ? { data: { id: "participant" }, error: null }
+        : { data: null, error: null };
+    });
+
+    const response = await handler(
+      new Request("https://example.com/api/files/signed?bucket=research&path=proj/file.pdf", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.url).toBe("https://cdn.example.com/signed");
+  });
+
+  it("blocks access to research documents for non-participants", async () => {
+    stub.setTableHandler("research_documents", () => ({
+      data: { id: "doc-1", project_id: "project-1" },
+      error: null,
+    }));
+    stub.setTableHandler("research_projects", () => ({
+      data: { created_by: "someone-else" },
+      error: null,
+    }));
+    stub.setTableHandler("research_participants", () => ({ data: null, error: null }));
+
+    const response = await handler(
+      new Request("https://example.com/api/files/signed?bucket=research&path=proj/file.pdf", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows participants to download their submissions", async () => {
+    stub.setTableHandler("research_documents", () => ({ data: null, error: null }));
+    stub.setTableHandler("research_submissions", ({ filters }) => {
+      return filters.storage_path === "project/submission.pdf"
+        ? { data: { id: "sub-1", project_id: "project-1", participant_id: "user-1" }, error: null }
+        : { data: null, error: null };
+    });
+
+    const response = await handler(
+      new Request("https://example.com/api/files/signed?bucket=research&path=project/submission.pdf", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("allows project owners to download submissions", async () => {
+    stub.setTableHandler("research_submissions", () => ({
+      data: { id: "sub-1", project_id: "project-1", participant_id: "user-2" },
+      error: null,
+    }));
+    stub.setTableHandler("research_projects", () => ({
+      data: { created_by: "user-1" },
+      error: null,
+    }));
+
+    const response = await handler(
+      new Request("https://example.com/api/files/signed?bucket=research&path=project/submission.pdf", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 403 when viewing another participant's submission", async () => {
+    stub.setTableHandler("research_submissions", () => ({
+      data: { id: "sub-1", project_id: "project-1", participant_id: "user-2" },
+      error: null,
+    }));
+    stub.setTableHandler("research_projects", () => ({
+      data: { created_by: "owner" },
+      error: null,
+    }));
+    stub.setTableHandler("research_participants", () => ({ data: null, error: null }));
+
+    const response = await handler(
+      new Request("https://example.com/api/files/signed?bucket=research&path=project/submission.pdf", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 404 when no file matches the path", async () => {
+    stub.setTableHandler("research_documents", () => ({ data: null, error: null }));
+    stub.setTableHandler("research_submissions", () => ({ data: null, error: null }));
+
+    const response = await handler(
+      new Request("https://example.com/api/files/signed?bucket=research&path=missing.pdf", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/api/files/signed.ts
+++ b/api/files/signed.ts
@@ -1,0 +1,271 @@
+import type { User } from "@supabase/supabase-js";
+import { errorResponse, jsonResponse, methodNotAllowed, normalizeMethod } from "../_lib/http";
+import { getSupabaseClient } from "../_lib/supabase";
+
+const ALLOWED_BUCKETS = new Set(["lesson-plans", "research"]);
+const SIGNED_URL_TTL_SECONDS = 60 * 10; // 10 minutes
+
+interface MaybeSingleBuilder<T> {
+  maybeSingle(): Promise<{ data: T | null; error: { message: string } | null }>;
+}
+
+interface SignedUrlBuilder {
+  createSignedUrl(path: string, expiresIn: number): Promise<{
+    data: { signedUrl: string | null } | null;
+    error: { message: string } | null;
+  }>;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const method = normalizeMethod(request.method);
+
+  if (method !== "GET") {
+    return methodNotAllowed(["GET"]);
+  }
+
+  const url = new URL(request.url);
+  const bucket = url.searchParams.get("bucket");
+  const path = url.searchParams.get("path");
+
+  if (!bucket || !bucket.trim()) {
+    return errorResponse(400, "A storage bucket is required");
+  }
+
+  if (!path || !path.trim()) {
+    return errorResponse(400, "A file path is required");
+  }
+
+  if (!ALLOWED_BUCKETS.has(bucket)) {
+    return errorResponse(400, "Unsupported storage bucket requested");
+  }
+
+  const accessToken = extractAccessToken(request);
+  if (!accessToken) {
+    return errorResponse(401, "Authentication required");
+  }
+
+  const supabase = getSupabaseClient();
+  const { data: authData, error: authError } = await supabase.auth.getUser(accessToken);
+
+  if (authError || !authData?.user) {
+    return errorResponse(401, "Authentication required");
+  }
+
+  const user = authData.user;
+  const userId = user.id;
+  const isAdminUser = await isAdmin(supabase, user);
+
+  if (bucket === "lesson-plans") {
+    return handleLessonPlanFile(supabase, userId, path, isAdminUser);
+  }
+
+  return handleResearchFile(supabase, userId, path, isAdminUser);
+}
+
+async function handleLessonPlanFile(
+  supabase: ReturnType<typeof getSupabaseClient>,
+  userId: string,
+  path: string,
+  isAdminUser: boolean,
+): Promise<Response> {
+  const planResult = await selectSingle(
+    supabase
+      .from<{ id: string; owner_id: string | null }>("lesson_plan_builder_plans")
+      .select("id, owner_id")
+      .eq("latest_export_path", path)
+  );
+
+  if (planResult.error) {
+    return errorResponse(500, "Failed to verify lesson plan export access");
+  }
+
+  const plan = planResult.data;
+  if (!plan) {
+    return errorResponse(404, "File not found");
+  }
+
+  const ownerId = plan.owner_id;
+  if (!isAdminUser && (!ownerId || ownerId !== userId)) {
+    return errorResponse(403, "You do not have permission to access this file");
+  }
+
+  return createSignedUrlResponse(
+    supabase.storage.from("lesson-plans").createSignedUrl(path, SIGNED_URL_TTL_SECONDS),
+  );
+}
+
+async function handleResearchFile(
+  supabase: ReturnType<typeof getSupabaseClient>,
+  userId: string,
+  path: string,
+  isAdminUser: boolean,
+): Promise<Response> {
+  const documentResult = await selectSingle(
+    supabase
+      .from<{ id: string; project_id: string }>("research_documents")
+      .select("id, project_id")
+      .eq("storage_path", path)
+  );
+
+  if (documentResult.error) {
+    return errorResponse(500, "Failed to verify research document access");
+  }
+
+  const document = documentResult.data;
+  if (document) {
+    const projectAccess = await resolveProjectAccess(supabase, document.project_id, userId);
+    if (!projectAccess.ok) {
+      return projectAccess.error;
+    }
+
+    if (!isAdminUser && !projectAccess.canAccessDocuments) {
+      return errorResponse(403, "You do not have permission to access this file");
+    }
+
+    return createSignedUrlResponse(
+      supabase.storage.from("research").createSignedUrl(path, SIGNED_URL_TTL_SECONDS),
+    );
+  }
+
+  const submissionResult = await selectSingle(
+    supabase
+      .from<{ id: string; project_id: string; participant_id: string | null }>("research_submissions")
+      .select("id, project_id, participant_id")
+      .eq("storage_path", path)
+  );
+
+  if (submissionResult.error) {
+    return errorResponse(500, "Failed to verify research submission access");
+  }
+
+  const submission = submissionResult.data;
+  if (!submission) {
+    return errorResponse(404, "File not found");
+  }
+
+  if (isAdminUser || submission.participant_id === userId) {
+    return createSignedUrlResponse(
+      supabase.storage.from("research").createSignedUrl(path, SIGNED_URL_TTL_SECONDS),
+    );
+  }
+
+  const projectAccess = await resolveProjectAccess(supabase, submission.project_id, userId);
+  if (!projectAccess.ok) {
+    return projectAccess.error;
+  }
+
+  if (!projectAccess.canAccessSubmissions) {
+    return errorResponse(403, "You do not have permission to access this file");
+  }
+
+  return createSignedUrlResponse(
+    supabase.storage.from("research").createSignedUrl(path, SIGNED_URL_TTL_SECONDS),
+  );
+}
+
+async function resolveProjectAccess(
+  supabase: ReturnType<typeof getSupabaseClient>,
+  projectId: string,
+  userId: string,
+): Promise<
+  | { ok: true; canAccessDocuments: boolean; canAccessSubmissions: boolean }
+  | { ok: false; error: Response }
+> {
+  const projectResult = await selectSingle(
+    supabase
+      .from<{ created_by: string | null }>("research_projects")
+      .select("created_by")
+      .eq("id", projectId)
+  );
+
+  if (projectResult.error) {
+    return { ok: false, error: errorResponse(500, "Failed to verify research project access") };
+  }
+
+  const createdBy = projectResult.data?.created_by ?? null;
+  if (createdBy === userId) {
+    return { ok: true, canAccessDocuments: true, canAccessSubmissions: true };
+  }
+
+  const participantResult = await selectSingle(
+    supabase
+      .from<{ id: string }>("research_participants")
+      .select("id")
+      .eq("project_id", projectId)
+      .eq("user_id", userId)
+  );
+
+  if (participantResult.error) {
+    return { ok: false, error: errorResponse(500, "Failed to verify research project access") };
+  }
+
+  const isParticipant = Boolean(participantResult.data);
+  return {
+    ok: true,
+    canAccessDocuments: isParticipant,
+    canAccessSubmissions: false,
+  };
+}
+
+async function selectSingle<T>(builder: MaybeSingleBuilder<T>): Promise<{
+  data: T | null;
+  error: { message: string } | null;
+}> {
+  return builder.maybeSingle();
+}
+
+async function createSignedUrlResponse(resultPromise: ReturnType<SignedUrlBuilder["createSignedUrl"]>): Promise<Response> {
+  const { data, error } = await resultPromise;
+
+  if (error || !data?.signedUrl) {
+    return errorResponse(500, "Failed to generate a signed download link");
+  }
+
+  return jsonResponse({ url: data.signedUrl });
+}
+
+function extractAccessToken(request: Request): string | null {
+  const header = request.headers.get("authorization") ?? request.headers.get("Authorization");
+  if (header) {
+    const match = header.match(/^Bearer\s+(.+)$/i);
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+  }
+
+  const cookieHeader = request.headers.get("cookie") ?? request.headers.get("Cookie");
+  if (cookieHeader) {
+    const cookies = cookieHeader.split(";");
+    for (const rawCookie of cookies) {
+      const [name, ...rest] = rawCookie.trim().split("=");
+      if (name === "sb-access-token") {
+        return decodeURIComponent(rest.join("="));
+      }
+    }
+  }
+
+  return null;
+}
+
+async function isAdmin(supabase: ReturnType<typeof getSupabaseClient>, user: User): Promise<boolean> {
+  const role = typeof user.app_metadata?.role === "string" ? user.app_metadata.role.toLowerCase() : "";
+  if (role === "admin") {
+    return true;
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from<{ user_id: string }>("app_admins")
+      .select("user_id")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (!error && data?.user_id === user.id) {
+      return true;
+    }
+  } catch {
+    // Ignore lookup failures and continue with non-admin access.
+  }
+
+  return false;
+}

--- a/src/lib/lessonPlans.ts
+++ b/src/lib/lessonPlans.ts
@@ -7,6 +7,8 @@ const LESSON_STEP_SELECT = "*";
 
 type Client = SupabaseClient;
 
+const SIGNED_FILE_ENDPOINT = "/api/files/signed";
+
 export class LessonPlanDataError extends Error {
   declare cause?: unknown;
 
@@ -62,6 +64,65 @@ async function requireUserId(client: Client, action: string): Promise<string> {
   }
 
   return userId;
+}
+
+async function requireAccessToken(client: Client, action: string): Promise<string> {
+  const { data, error } = await client.auth.getSession();
+
+  if (error) {
+    throw new LessonPlanDataError("Unable to verify authentication state.", { cause: error });
+  }
+
+  const accessToken = data.session?.access_token;
+
+  if (!accessToken) {
+    throw new LessonPlanDataError(`You must be signed in to ${action}.`);
+  }
+
+  return accessToken;
+}
+
+async function requestSignedExportUrl(
+  client: Client,
+  path: string,
+  action: string,
+): Promise<string> {
+  const accessToken = await requireAccessToken(client, action);
+  const query = new URLSearchParams({ bucket: "lesson-plans", path }).toString();
+
+  let response: Response;
+  try {
+    response = await fetch(`${SIGNED_FILE_ENDPOINT}?${query}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+  } catch (error) {
+    throw new LessonPlanDataError("Failed to request a signed download link.", { cause: error });
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const isJson = contentType.includes("application/json");
+  const payload = isJson ? await response.json().catch(() => null) : null;
+
+  if (!response.ok) {
+    const message =
+      payload && typeof payload.error === "string" && payload.error.trim()
+        ? payload.error
+        : `Unable to ${action}.`;
+    throw new LessonPlanDataError(message);
+  }
+
+  const url = payload && typeof (payload as Record<string, unknown>).url === "string"
+    ? (payload as { url: string }).url
+    : null;
+
+  if (!url) {
+    throw new LessonPlanDataError("Download URL was not provided by the server.");
+  }
+
+  return url;
 }
 
 function mapLessonPlan(record: Record<string, any>): LessonPlan {
@@ -274,6 +335,18 @@ export async function getPlanWithSteps(
   const steps = Array.isArray(stepData) ? stepData.map(mapLessonStep) : [];
 
   return { plan, steps } satisfies LessonPlanWithSteps;
+}
+
+export async function getLessonPlanExportUrl(
+  exportPath: string,
+  client: Client = supabase,
+): Promise<string> {
+  const trimmedPath = exportPath.trim();
+  if (!trimmedPath) {
+    throw new LessonPlanDataError("No export file is available for this lesson plan.");
+  }
+
+  return requestSignedExportUrl(client, trimmedPath, "download this lesson plan export");
 }
 
 function renderLessonPlan(plan: LessonPlan, steps: LessonStep[]): string {

--- a/supabase/migrations/20251106000000_create_private_storage_buckets.sql
+++ b/supabase/migrations/20251106000000_create_private_storage_buckets.sql
@@ -1,0 +1,42 @@
+-- Ensure private storage buckets exist for lesson plan exports and research files
+INSERT INTO storage.buckets (id, name, public)
+VALUES
+  ('lesson-plans', 'lesson-plans', false),
+  ('research', 'research', false)
+ON CONFLICT (id)
+DO UPDATE SET
+  name = EXCLUDED.name,
+  public = EXCLUDED.public;
+
+-- Allow research participants to upload submissions into the shared bucket
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE polname = 'Research participants upload files'
+      AND schemaname = 'storage'
+      AND tablename = 'objects'
+  ) THEN
+    CREATE POLICY "Research participants upload files"
+      ON storage.objects
+      FOR INSERT
+      WITH CHECK (
+        bucket_id = 'research'
+        AND auth.role() = 'authenticated'
+        AND split_part(name, '/', 2) = auth.uid()
+        AND EXISTS (
+          SELECT 1
+          FROM public.research_participants rp
+          WHERE rp.user_id = auth.uid()
+            AND rp.project_id = (
+              CASE
+                WHEN split_part(name, '/', 1) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+                  THEN split_part(name, '/', 1)::uuid
+                ELSE NULL
+              END
+            )
+        )
+      );
+  END IF;
+END $$;

--- a/test/lib-downloads.test.ts
+++ b/test/lib-downloads.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getLessonPlanExportUrl } from "@/lib/lessonPlans";
+import { getDocumentDownloadUrl, getSubmissionDownloadUrl } from "@/lib/research";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+function createClient(): SupabaseClient {
+  return {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({
+        data: { session: { access_token: "token", user: { id: "user-1" } } },
+        error: null,
+      }),
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe("download helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retrieves a signed lesson plan export url", async () => {
+    const client = createClient();
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ url: "https://signed.example/lesson" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const url = await getLessonPlanExportUrl("exports/plan.pdf", client);
+
+    expect(url).toBe("https://signed.example/lesson");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/files/signed?bucket=lesson-plans&path=exports%2Fplan.pdf",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer token" }),
+        method: "GET",
+      }),
+    );
+  });
+
+  it("retrieves a signed research document url", async () => {
+    const client = createClient();
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ url: "https://signed.example/doc" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const url = await getDocumentDownloadUrl({ storagePath: "project/doc.pdf" }, client);
+
+    expect(url).toBe("https://signed.example/doc");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/files/signed?bucket=research&path=project%2Fdoc.pdf",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer token" }),
+        method: "GET",
+      }),
+    );
+  });
+
+  it("retrieves a signed research submission url", async () => {
+    const client = createClient();
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ url: "https://signed.example/sub" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const url = await getSubmissionDownloadUrl({ storagePath: "project/submission.pdf" }, client);
+
+    expect(url).toBe("https://signed.example/sub");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/files/signed?bucket=research&path=project%2Fsubmission.pdf",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer token" }),
+        method: "GET",
+      }),
+    );
+  });
+});

--- a/test/lib-happy-path.test.ts
+++ b/test/lib-happy-path.test.ts
@@ -176,7 +176,7 @@ function createSupabaseClient(config: ClientConfig): SupabaseClient {
     auth: {
       getSession: () =>
         Promise.resolve({
-          data: { session: { user: { id: config.userId } } },
+          data: { session: { user: { id: config.userId }, access_token: "test-access-token" } },
           error: null,
         }),
     },
@@ -497,7 +497,7 @@ describe("research helpers", () => {
       },
     },
     storage: {
-      "research-submissions": {
+      research: {
         upload: () => Promise.resolve({ error: null }),
       },
     },


### PR DESCRIPTION
## Summary
- create private storage buckets for lesson plan exports and research files
- add `/api/files/signed` endpoint that validates access before issuing temporary URLs
- update lesson plan and research client helpers plus tests to consume the new signed download flow

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d16dd19e7c833186abb7931736bf44