### PR TITLE
Implement admin user directory, invitations, and role management

### DIFF
--- a/api/_lib/users.ts
+++ b/api/_lib/users.ts
@@ -1,0 +1,52 @@
+import type { SupabaseClient, User } from "@supabase/supabase-js";
+
+const DEFAULT_PAGE_SIZE = 100;
+const MAX_ITERATIONS = 100;
+
+function normaliseEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export async function findUserByEmail(
+  supabase: SupabaseClient,
+  email: string,
+): Promise<User | null> {
+  const normalised = normaliseEmail(email);
+  if (!normalised) {
+    return null;
+  }
+
+  let page = 1;
+  const perPage = DEFAULT_PAGE_SIZE;
+
+  for (let attempt = 0; attempt < MAX_ITERATIONS; attempt += 1) {
+    const response = await supabase.auth.admin.listUsers({ page, perPage });
+
+    if (response.error) {
+      throw response.error;
+    }
+
+    const { data } = response;
+    const match = data.users.find(user => normaliseEmail(user.email ?? "") === normalised);
+    if (match) {
+      return match;
+    }
+
+    const next = typeof data.nextPage === "number" ? data.nextPage : null;
+    const last = typeof data.lastPage === "number" ? data.lastPage : null;
+
+    if (next && next !== page) {
+      page = next;
+      continue;
+    }
+
+    if (last && page < last) {
+      page += 1;
+      continue;
+    }
+
+    break;
+  }
+
+  return null;
+}

--- a/api/admin/roles/grant.ts
+++ b/api/admin/roles/grant.ts
@@ -7,9 +7,11 @@ import {
 } from "../../_lib/http";
 import { recordAuditLog } from "../../_lib/audit";
 import { requireAdmin } from "../../_lib/auth";
+import { findUserByEmail } from "../../_lib/users";
 
 interface RolePayload {
   userId?: string;
+  email?: string;
 }
 
 export default async function handler(request: Request): Promise<Response> {
@@ -22,17 +24,34 @@ export default async function handler(request: Request): Promise<Response> {
     return context;
   }
 
+  const { supabase, user } = context;
   const payload = (await parseJsonBody<RolePayload>(request)) ?? {};
   const userId = typeof payload.userId === "string" ? payload.userId.trim() : "";
+  const email = typeof payload.email === "string" ? payload.email.trim() : "";
 
-  if (userId.length === 0) {
-    return errorResponse(400, "A user id is required");
+  if (userId.length === 0 && email.length === 0) {
+    return errorResponse(400, "A user id or email address is required");
   }
 
-  const { supabase, user } = context;
+  let targetId = userId;
+  let resolvedEmail = email || null;
+
+  if (!targetId) {
+    try {
+      const lookup = await findUserByEmail(supabase, email);
+      if (!lookup) {
+        return errorResponse(404, "No user with that email address was found");
+      }
+      targetId = lookup.id;
+      resolvedEmail = lookup.email ?? resolvedEmail;
+    } catch {
+      return errorResponse(500, "Failed to resolve the requested user");
+    }
+  }
+
   const upsertResult = await supabase
     .from("app_admins")
-    .upsert({ user_id: userId }, { onConflict: "user_id" });
+    .upsert({ user_id: targetId }, { onConflict: "user_id" });
 
   if (upsertResult.error) {
     return errorResponse(500, "Failed to grant admin role");
@@ -41,7 +60,8 @@ export default async function handler(request: Request): Promise<Response> {
   await recordAuditLog(supabase, {
     action: "admin.roles.grant",
     actorId: user.id,
-    targetId: userId,
+    targetId: targetId,
+    metadata: resolvedEmail ? { email: resolvedEmail } : null,
   });
 
   return jsonResponse({ success: true });

--- a/api/admin/roles/index.ts
+++ b/api/admin/roles/index.ts
@@ -1,0 +1,55 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+} from "../../_lib/http";
+import { requireAdmin } from "../../_lib/auth";
+
+interface AdminRecord {
+  user_id: string;
+  granted_at: string | null;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  if (normalizeMethod(request.method) !== "GET") {
+    return methodNotAllowed(["GET"]);
+  }
+
+  const context = await requireAdmin(request);
+  if (context instanceof Response) {
+    return context;
+  }
+
+  const { supabase } = context;
+  const adminsResult = await supabase
+    .from<AdminRecord>("app_admins")
+    .select("user_id, granted_at")
+    .order("granted_at", { ascending: false, nullsLast: true });
+
+  if (adminsResult.error) {
+    return errorResponse(500, "Failed to load admin roster");
+  }
+
+  const records = adminsResult.data ?? [];
+  const lookups = await Promise.all(
+    records.map(async record => {
+      const lookup = await supabase.auth.admin.getUserById(record.user_id);
+      if (lookup.error || !lookup.data?.user) {
+        return {
+          userId: record.user_id,
+          email: null as string | null,
+          grantedAt: record.granted_at,
+        };
+      }
+
+      return {
+        userId: record.user_id,
+        email: lookup.data.user.email ?? null,
+        grantedAt: record.granted_at,
+      };
+    }),
+  );
+
+  return jsonResponse({ admins: lookups });
+}

--- a/api/admin/roles/revoke.ts
+++ b/api/admin/roles/revoke.ts
@@ -7,9 +7,11 @@ import {
 } from "../../_lib/http";
 import { recordAuditLog } from "../../_lib/audit";
 import { requireAdmin } from "../../_lib/auth";
+import { findUserByEmail } from "../../_lib/users";
 
 interface RolePayload {
   userId?: string;
+  email?: string;
 }
 
 export default async function handler(request: Request): Promise<Response> {
@@ -22,15 +24,32 @@ export default async function handler(request: Request): Promise<Response> {
     return context;
   }
 
+  const { supabase, user } = context;
   const payload = (await parseJsonBody<RolePayload>(request)) ?? {};
   const userId = typeof payload.userId === "string" ? payload.userId.trim() : "";
+  const email = typeof payload.email === "string" ? payload.email.trim() : "";
 
-  if (userId.length === 0) {
-    return errorResponse(400, "A user id is required");
+  if (userId.length === 0 && email.length === 0) {
+    return errorResponse(400, "A user id or email address is required");
   }
 
-  const { supabase, user } = context;
-  const deleteResult = await supabase.from("app_admins").delete().eq("user_id", userId);
+  let targetId = userId;
+  let resolvedEmail = email || null;
+
+  if (!targetId) {
+    try {
+      const lookup = await findUserByEmail(supabase, email);
+      if (!lookup) {
+        return errorResponse(404, "No user with that email address was found");
+      }
+      targetId = lookup.id;
+      resolvedEmail = lookup.email ?? resolvedEmail;
+    } catch {
+      return errorResponse(500, "Failed to resolve the requested user");
+    }
+  }
+
+  const deleteResult = await supabase.from("app_admins").delete().eq("user_id", targetId);
 
   if (deleteResult.error) {
     return errorResponse(500, "Failed to revoke admin role");
@@ -39,7 +58,8 @@ export default async function handler(request: Request): Promise<Response> {
   await recordAuditLog(supabase, {
     action: "admin.roles.revoke",
     actorId: user.id,
-    targetId: userId,
+    targetId: targetId,
+    metadata: resolvedEmail ? { email: resolvedEmail } : null,
   });
 
   return jsonResponse({ success: true });

--- a/api/admin/users/index.ts
+++ b/api/admin/users/index.ts
@@ -1,0 +1,81 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+} from "../../_lib/http";
+import { requireAdmin } from "../../_lib/auth";
+
+const MAX_PER_PAGE = 200;
+const DEFAULT_PER_PAGE = 25;
+
+type DirectoryStatus = "enabled" | "disabled";
+
+function clampPerPage(value: number): number {
+  return Math.max(1, Math.min(MAX_PER_PAGE, value));
+}
+
+function parsePositiveInteger(value: string | null, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  if (normalizeMethod(request.method) !== "GET") {
+    return methodNotAllowed(["GET"]);
+  }
+
+  const context = await requireAdmin(request);
+  if (context instanceof Response) {
+    return context;
+  }
+
+  const { supabase } = context;
+  const url = new URL(request.url);
+  const page = parsePositiveInteger(url.searchParams.get("page"), 1);
+  const perPage = clampPerPage(parsePositiveInteger(url.searchParams.get("perPage"), DEFAULT_PER_PAGE));
+
+  const listResult = await supabase.auth.admin.listUsers({ page, perPage });
+  if (listResult.error) {
+    return errorResponse(500, "Failed to load users");
+  }
+
+  const adminResult = await supabase.from("app_admins").select("user_id");
+  if (adminResult.error) {
+    return errorResponse(500, "Failed to load admin assignments");
+  }
+
+  const adminIds = new Set((adminResult.data ?? []).map(record => record.user_id as string));
+
+  const users = listResult.data.users.map(user => ({
+    id: user.id,
+    email: user.email ?? null,
+    createdAt: user.created_at ?? null,
+    lastSignInAt: user.last_sign_in_at ?? null,
+    status: (user.banned_until ? "disabled" : "enabled") as DirectoryStatus,
+    isAdmin: adminIds.has(user.id),
+  }));
+
+  const total = typeof listResult.data.total === "number" && listResult.data.total > 0
+    ? listResult.data.total
+    : users.length;
+  const lastPage = typeof listResult.data.lastPage === "number" && listResult.data.lastPage > 0
+    ? listResult.data.lastPage
+    : Math.max(1, Math.ceil(total / perPage));
+  const nextPage = typeof listResult.data.nextPage === "number" ? listResult.data.nextPage : null;
+
+  return jsonResponse({
+    users,
+    page,
+    perPage,
+    total,
+    lastPage,
+    nextPage: nextPage && nextPage > page ? nextPage : page < lastPage ? page + 1 : null,
+  });
+}

--- a/src/lib/admin/api.ts
+++ b/src/lib/admin/api.ts
@@ -1,0 +1,77 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export class AdminApiError extends Error {
+  status: number;
+  details: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = "AdminApiError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+async function requireAccessToken(): Promise<string> {
+  const { data, error } = await supabase.auth.getSession();
+
+  if (error) {
+    throw new AdminApiError("Unable to verify authentication state.", 401, error);
+  }
+
+  const token = data.session?.access_token;
+
+  if (!token) {
+    throw new AdminApiError("You must be signed in to access the admin console.", 401);
+  }
+
+  return token;
+}
+
+export interface AdminRequestOptions extends Omit<RequestInit, "body"> {
+  body?: BodyInit | null;
+  json?: unknown;
+}
+
+export async function adminRequest<TResponse>(
+  path: string,
+  options: AdminRequestOptions = {},
+): Promise<TResponse> {
+  const { json, ...rest } = options;
+  const accessToken = await requireAccessToken();
+
+  const headers = new Headers(rest.headers);
+  headers.set("Authorization", `Bearer ${accessToken}`);
+
+  let body = rest.body ?? null;
+  if (json !== undefined) {
+    headers.set("Content-Type", "application/json");
+    body = JSON.stringify(json);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(path, {
+      ...rest,
+      headers,
+      body,
+    });
+  } catch (error) {
+    throw new AdminApiError("Network request failed.", 500, error);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const isJson = contentType.includes("application/json");
+  const payload = isJson ? await response.json().catch(() => null) : null;
+
+  if (!response.ok) {
+    const message =
+      (payload && typeof payload === "object" && "error" in payload &&
+        typeof (payload as { error?: unknown }).error === "string"
+        ? (payload as { error: string }).error
+        : null) ?? `Request failed with status ${response.status}`;
+    throw new AdminApiError(message, response.status, payload);
+  }
+
+  return (payload as TResponse) ?? ({} as TResponse);
+}

--- a/src/lib/admin/users.ts
+++ b/src/lib/admin/users.ts
@@ -1,0 +1,99 @@
+import { adminRequest, AdminApiError } from "./api";
+
+export type DirectoryUserStatus = "enabled" | "disabled";
+
+export interface DirectoryUser {
+  id: string;
+  email: string | null;
+  createdAt: string | null;
+  lastSignInAt: string | null;
+  status: DirectoryUserStatus;
+  isAdmin: boolean;
+}
+
+export interface DirectoryResponse {
+  users: DirectoryUser[];
+  page: number;
+  perPage: number;
+  total: number;
+  lastPage: number;
+  nextPage: number | null;
+}
+
+export interface AdminRole {
+  userId: string;
+  email: string | null;
+  grantedAt: string | null;
+}
+
+export interface AdminRoleResponse {
+  admins: AdminRole[];
+}
+
+export async function fetchDirectory(page = 1, perPage = 25): Promise<DirectoryResponse> {
+  const params = new URLSearchParams();
+  params.set("page", String(page));
+  params.set("perPage", String(perPage));
+  return adminRequest<DirectoryResponse>(`/api/admin/users?${params.toString()}`);
+}
+
+export async function inviteUser(email: string): Promise<{ success: boolean; userId: string | null }> {
+  return adminRequest<{ success: boolean; userId: string | null }>("/api/admin/users/invite", {
+    method: "POST",
+    json: { email },
+  });
+}
+
+export async function disableUser(userId: string): Promise<{ success: boolean }> {
+  return adminRequest<{ success: boolean }>("/api/admin/users/disable", {
+    method: "POST",
+    json: { userId },
+  });
+}
+
+export async function enableUser(userId: string): Promise<{ success: boolean }> {
+  return adminRequest<{ success: boolean }>("/api/admin/users/enable", {
+    method: "POST",
+    json: { userId },
+  });
+}
+
+export async function deleteUser(userId: string): Promise<{ success: boolean }> {
+  return adminRequest<{ success: boolean }>("/api/admin/users/delete", {
+    method: "POST",
+    json: { userId },
+  });
+}
+
+export async function sendPasswordReset(userId: string): Promise<{ success: boolean }> {
+  return adminRequest<{ success: boolean }>("/api/admin/users/reset-password", {
+    method: "POST",
+    json: { userId },
+  });
+}
+
+export async function grantAdminRole(params: { userId?: string; email?: string }): Promise<{ success: boolean }> {
+  if (!params.userId && !params.email) {
+    throw new AdminApiError("A user id or email address is required", 400);
+  }
+
+  return adminRequest<{ success: boolean }>("/api/admin/roles/grant", {
+    method: "POST",
+    json: params,
+  });
+}
+
+export async function revokeAdminRole(params: { userId?: string; email?: string }): Promise<{ success: boolean }> {
+  if (!params.userId && !params.email) {
+    throw new AdminApiError("A user id or email address is required", 400);
+  }
+
+  return adminRequest<{ success: boolean }>("/api/admin/roles/revoke", {
+    method: "POST",
+    json: params,
+  });
+}
+
+export async function fetchAdminRoles(): Promise<AdminRoleResponse> {
+  return adminRequest<AdminRoleResponse>("/api/admin/roles");
+}

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -4,10 +4,16 @@ import type { AdminOutletContext } from "./AdminLayout";
 import { AdminDashboardSkeleton, AdminSectionSkeleton } from "./components/AdminSkeletons";
 import AdminPostsPage from "./content/AdminPostsPage";
 import AdminResourcesPage from "./content/AdminResourcesPage";
+import AdminUserDirectoryPage from "./users/AdminUserDirectoryPage";
+import AdminUserInvitationsPage from "./users/AdminUserInvitationsPage";
+import AdminUserRolesPage from "./users/AdminUserRolesPage";
 
 const PAGE_COMPONENTS: Record<string, () => JSX.Element> = {
   "content/posts": AdminPostsPage,
   "content/resources": AdminResourcesPage,
+  "users/directory": AdminUserDirectoryPage,
+  "users/invitations": AdminUserInvitationsPage,
+  "users/roles": AdminUserRolesPage,
 };
 
 export default function AdminPage() {

--- a/src/pages/admin/config.ts
+++ b/src/pages/admin/config.ts
@@ -73,27 +73,27 @@ export const adminNavigation: AdminNavGroup[] = [
         slug: "content/resources",
         description: "Curate approved resources and update catalogue metadata.",
       },
-      {
-        title: "Users",
-        path: "/admin/content/users",
-        slug: "content/users",
-        description: "Oversee contributor access and publishing permissions.",
-      },
     ],
   },
   {
-    label: "Directory",
+    label: "Users",
     items: [
       {
+        title: "Directory",
+        path: "/admin/users/directory",
+        slug: "users/directory",
+        description: "Audit accounts, access levels, and sign-in activity.",
+      },
+      {
         title: "Invitations",
-        path: "/admin/directory/invitations",
-        slug: "directory/invitations",
+        path: "/admin/users/invitations",
+        slug: "users/invitations",
         description: "Track outstanding invitations and reminders for collaborators.",
       },
       {
         title: "Roles (Admins)",
-        path: "/admin/directory/roles",
-        slug: "directory/roles",
+        path: "/admin/users/roles",
+        slug: "users/roles",
         description: "Grant or revoke administrative roles across the organisation.",
       },
     ],

--- a/src/pages/admin/users/AdminUserDirectoryPage.tsx
+++ b/src/pages/admin/users/AdminUserDirectoryPage.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { MoreHorizontal } from "lucide-react";
+
+import {
+  disableUser,
+  DirectoryResponse,
+  DirectoryUser,
+  enableUser,
+  fetchDirectory,
+  grantAdminRole,
+  revokeAdminRole,
+  sendPasswordReset,
+  deleteUser,
+} from "@/lib/admin/users";
+import { AdminApiError } from "@/lib/admin/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useToast } from "@/components/ui/use-toast";
+
+const PER_PAGE = 25;
+
+function formatDate(value: string | null): string {
+  if (!value) {
+    return "—";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+
+  try {
+    return format(date, "PPpp");
+  } catch {
+    return "—";
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof AdminApiError) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "An unexpected error occurred.";
+}
+
+export default function AdminUserDirectoryPage() {
+  const [page, setPage] = useState(1);
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const { data, error, isError, isFetching, isLoading } = useQuery<DirectoryResponse, AdminApiError>({
+    queryKey: ["admin-users", page, PER_PAGE],
+    queryFn: () => fetchDirectory(page, PER_PAGE),
+    keepPreviousData: true,
+  });
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    if (page > 1 && data.users.length === 0) {
+      setPage(Math.max(1, Math.min(page - 1, data.lastPage)));
+    }
+  }, [data, page]);
+
+  const disableMutation = useMutation({
+    mutationFn: ({ userId }: { userId: string }) => disableUser(userId),
+    onSuccess: () => {
+      toast({ title: "Account disabled", description: "The user can no longer sign in." });
+      void queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+      void queryClient.invalidateQueries({ queryKey: ["admin-roles"] });
+    },
+    onError: mutationError => {
+      toast({
+        title: "Unable to disable account",
+        description: getErrorMessage(mutationError),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const enableMutation = useMutation({
+    mutationFn: ({ userId }: { userId: string }) => enableUser(userId),
+    onSuccess: () => {
+      toast({ title: "Account enabled", description: "The user can sign in again." });
+      void queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+    },
+    onError: mutationError => {
+      toast({
+        title: "Unable to enable account",
+        description: getErrorMessage(mutationError),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const resetMutation = useMutation({
+    mutationFn: ({ userId }: { userId: string }) => sendPasswordReset(userId),
+    onSuccess: () => {
+      toast({
+        title: "Reset email sent",
+        description: "The user has received password reset instructions.",
+      });
+    },
+    onError: mutationError => {
+      toast({
+        title: "Unable to send reset email",
+        description: getErrorMessage(mutationError),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: ({ userId }: { userId: string }) => deleteUser(userId),
+    onSuccess: () => {
+      toast({ title: "User deleted", description: "The account has been removed." });
+      void queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+      void queryClient.invalidateQueries({ queryKey: ["admin-roles"] });
+    },
+    onError: mutationError => {
+      toast({
+        title: "Unable to delete user",
+        description: getErrorMessage(mutationError),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const grantMutation = useMutation({
+    mutationFn: ({ userId }: { userId: string }) => grantAdminRole({ userId }),
+    onSuccess: () => {
+      toast({ title: "Admin role granted", description: "The user now has administrative access." });
+      void queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+      void queryClient.invalidateQueries({ queryKey: ["admin-roles"] });
+    },
+    onError: mutationError => {
+      toast({
+        title: "Unable to grant admin role",
+        description: getErrorMessage(mutationError),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: ({ userId }: { userId: string }) => revokeAdminRole({ userId }),
+    onSuccess: () => {
+      toast({ title: "Admin role revoked", description: "The user no longer has admin access." });
+      void queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+      void queryClient.invalidateQueries({ queryKey: ["admin-roles"] });
+    },
+    onError: mutationError => {
+      toast({
+        title: "Unable to revoke admin role",
+        description: getErrorMessage(mutationError),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const isPerformingAction =
+    disableMutation.isPending ||
+    enableMutation.isPending ||
+    resetMutation.isPending ||
+    deleteMutation.isPending ||
+    grantMutation.isPending ||
+    revokeMutation.isPending;
+
+  const pagination = useMemo(() => {
+    if (!data) {
+      return { start: 0, end: 0, total: 0, hasNext: false };
+    }
+
+    const hasUsers = data.users.length > 0;
+    const start = (data.page - 1) * data.perPage + (hasUsers ? 1 : 0);
+    const end = hasUsers ? start + data.users.length - 1 : start;
+    const hasNext = data.nextPage !== null && data.nextPage > data.page;
+
+    return { start, end: Math.max(start, end), total: data.total, hasNext };
+  }, [data]);
+
+  function handleToggleStatus(user: DirectoryUser) {
+    if (user.status === "enabled") {
+      disableMutation.mutate({ userId: user.id });
+    } else {
+      enableMutation.mutate({ userId: user.id });
+    }
+  }
+
+  function handleDelete(user: DirectoryUser) {
+    const confirmed = window.confirm(
+      `Delete ${user.email ?? "this user"}? This action cannot be undone and will remove all access.`,
+    );
+    if (!confirmed) {
+      return;
+    }
+    deleteMutation.mutate({ userId: user.id });
+  }
+
+  function handleRoleToggle(user: DirectoryUser) {
+    if (user.isAdmin) {
+      revokeMutation.mutate({ userId: user.id });
+    } else {
+      grantMutation.mutate({ userId: user.id });
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>User directory</CardTitle>
+          <CardDescription>Review accounts, enforce access controls, and manage permissions.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isError && (
+            <Alert variant="destructive">
+              <AlertTitle>Unable to load users</AlertTitle>
+              <AlertDescription>{getErrorMessage(error)}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Email</TableHead>
+                  <TableHead className="hidden xl:table-cell">Created</TableHead>
+                  <TableHead className="hidden lg:table-cell">Last active</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Admin</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {isLoading ? (
+                  Array.from({ length: 5 }).map((_, index) => (
+                    <TableRow key={`loading-${index}`}>
+                      <TableCell colSpan={6}>
+                        <Skeleton className="h-6 w-full" />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : data && data.users.length > 0 ? (
+                  data.users.map(user => (
+                    <TableRow key={user.id} className={user.status === "disabled" ? "opacity-75" : undefined}>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-medium text-foreground">{user.email ?? "Unknown"}</span>
+                          <span className="text-xs text-muted-foreground">{user.id}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="hidden xl:table-cell">{formatDate(user.createdAt)}</TableCell>
+                      <TableCell className="hidden lg:table-cell">{formatDate(user.lastSignInAt)}</TableCell>
+                      <TableCell>
+                        <Badge variant={user.status === "enabled" ? "secondary" : "destructive"}>
+                          {user.status === "enabled" ? "Enabled" : "Disabled"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={user.isAdmin ? "default" : "outline"}>{user.isAdmin ? "Admin" : "User"}</Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="icon" disabled={isPerformingAction}>
+                              <MoreHorizontal className="h-4 w-4" />
+                              <span className="sr-only">Open actions</span>
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem onClick={() => handleToggleStatus(user)}>
+                              {user.status === "enabled" ? "Disable account" : "Enable account"}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => resetMutation.mutate({ userId: user.id })}>
+                              Send reset password email
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => handleRoleToggle(user)}>
+                              {user.isAdmin ? "Revoke admin role" : "Grant admin role"}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => handleDelete(user)} className="text-destructive focus:text-destructive">
+                              Delete user
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={6} className="py-10 text-center text-sm text-muted-foreground">
+                      No users were found for this page.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              {pagination.total > 0
+                ? `Showing ${pagination.start}–${pagination.end} of ${pagination.total} users`
+                : "No users to display"}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage(current => Math.max(1, current - 1))}
+                disabled={page === 1 || isFetching || isLoading}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  if (data) {
+                    const next = data.nextPage ?? (data.lastPage > data.page ? data.page + 1 : data.page);
+                    if (next !== data.page) {
+                      setPage(next);
+                    }
+                  }
+                }}
+                disabled={!data || !pagination.hasNext || isFetching || isLoading}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/admin/users/AdminUserInvitationsPage.tsx
+++ b/src/pages/admin/users/AdminUserInvitationsPage.tsx
@@ -1,0 +1,100 @@
+import { useForm } from "react-hook-form";
+import { useMutation } from "@tanstack/react-query";
+
+import { inviteUser } from "@/lib/admin/users";
+import { AdminApiError } from "@/lib/admin/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useToast } from "@/components/ui/use-toast";
+
+interface InvitationFormValues {
+  email: string;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof AdminApiError) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "An unexpected error occurred.";
+}
+
+export default function AdminUserInvitationsPage() {
+  const { toast } = useToast();
+  const form = useForm<InvitationFormValues>({
+    defaultValues: { email: "" },
+  });
+
+  const invitationMutation = useMutation({
+    mutationFn: ({ email }: InvitationFormValues) => inviteUser(email),
+    onSuccess: result => {
+      const description = result.userId
+        ? "An invitation has been sent and linked to the existing user account."
+        : "Invitation email has been sent.";
+      toast({ title: "Invitation sent", description });
+      form.reset();
+    },
+    onError: error => {
+      toast({ title: "Unable to send invitation", description: getErrorMessage(error), variant: "destructive" });
+    },
+  });
+
+  const onSubmit = (values: InvitationFormValues) => {
+    invitationMutation.mutate(values);
+  };
+
+  const emailError = form.formState.errors.email?.message;
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Invite a collaborator</CardTitle>
+          <CardDescription>Send onboarding instructions to new contributors and administrators.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email address</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="name@example.com"
+                {...form.register("email", {
+                  required: "Please provide an email address.",
+                  pattern: {
+                    value: /.+@.+\..+/,
+                    message: "Enter a valid email address.",
+                  },
+                })}
+              />
+              {emailError && <p className="text-sm text-destructive">{emailError}</p>}
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={invitationMutation.isPending}>
+                {invitationMutation.isPending ? "Sending…" : "Send invitation"}
+              </Button>
+              <Button type="button" variant="outline" onClick={() => form.reset()} disabled={invitationMutation.isPending}>
+                Reset
+              </Button>
+            </div>
+          </form>
+
+          <Alert>
+            <AlertTitle>What happens next?</AlertTitle>
+            <AlertDescription>
+              Invited users receive an email with a sign-in link. If an account already exists, the invite simply nudges them to
+              return and complete onboarding.
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/admin/users/AdminUserRolesPage.tsx
+++ b/src/pages/admin/users/AdminUserRolesPage.tsx
@@ -1,0 +1,197 @@
+import { useForm } from "react-hook-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { fetchAdminRoles, grantAdminRole, revokeAdminRole } from "@/lib/admin/users";
+import { AdminApiError } from "@/lib/admin/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+
+interface RoleFormValues {
+  email: string;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof AdminApiError) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "An unexpected error occurred.";
+}
+
+export default function AdminUserRolesPage() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data, error, isError, isLoading } = useQuery({
+    queryKey: ["admin-roles"],
+    queryFn: fetchAdminRoles,
+  });
+
+  const form = useForm<RoleFormValues>({
+    defaultValues: { email: "" },
+  });
+
+  const grantMutation = useMutation({
+    mutationFn: ({ email }: RoleFormValues) => grantAdminRole({ email }),
+    onSuccess: () => {
+      toast({ title: "Admin access granted", description: "The user can now access the admin console." });
+      form.reset();
+      void queryClient.invalidateQueries({ queryKey: ["admin-roles"] });
+      void queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+    },
+    onError: mutationError => {
+      toast({
+        title: "Unable to grant admin access",
+        description: getErrorMessage(mutationError),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (userId: string) => revokeAdminRole({ userId }),
+    onSuccess: () => {
+      toast({ title: "Admin access revoked", description: "The user no longer has elevated permissions." });
+      void queryClient.invalidateQueries({ queryKey: ["admin-roles"] });
+      void queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+    },
+    onError: mutationError => {
+      toast({
+        title: "Unable to revoke admin access",
+        description: getErrorMessage(mutationError),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = (values: RoleFormValues) => {
+    grantMutation.mutate(values);
+  };
+
+  const emailError = form.formState.errors.email?.message;
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+      <Card className="lg:col-span-1 lg:row-span-2">
+        <CardHeader>
+          <CardTitle>Admin roster</CardTitle>
+          <CardDescription>Review who currently holds administrative permissions.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isError && (
+            <Alert variant="destructive">
+              <AlertTitle>Unable to load admin roles</AlertTitle>
+              <AlertDescription>{getErrorMessage(error)}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Email</TableHead>
+                  <TableHead className="hidden md:table-cell">Granted</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {isLoading ? (
+                  Array.from({ length: 3 }).map((_, index) => (
+                    <TableRow key={`loading-${index}`}>
+                      <TableCell colSpan={3}>
+                        <Skeleton className="h-6 w-full" />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : data && data.admins.length > 0 ? (
+                  data.admins.map(admin => (
+                    <TableRow key={admin.userId}>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-medium text-foreground">{admin.email ?? "Unknown"}</span>
+                          <span className="text-xs text-muted-foreground">{admin.userId}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell">
+                        {admin.grantedAt ? new Date(admin.grantedAt).toLocaleString() : "—"}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => revokeMutation.mutate(admin.userId)}
+                          disabled={revokeMutation.isPending}
+                        >
+                          Remove
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={3} className="py-8 text-center text-sm text-muted-foreground">
+                      No administrators have been registered yet.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Add an administrator</CardTitle>
+          <CardDescription>Grant elevated privileges by referencing an existing user&apos;s email.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="space-y-2">
+              <Label htmlFor="admin-email">Email address</Label>
+              <Input
+                id="admin-email"
+                type="email"
+                placeholder="name@example.com"
+                {...form.register("email", {
+                  required: "Please enter an email address.",
+                  pattern: {
+                    value: /.+@.+\..+/,
+                    message: "Enter a valid email address.",
+                  },
+                })}
+              />
+              {emailError && <p className="text-sm text-destructive">{emailError}</p>}
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={grantMutation.isPending}>
+                {grantMutation.isPending ? "Granting…" : "Grant access"}
+              </Button>
+              <Button type="button" variant="outline" onClick={() => form.reset()} disabled={grantMutation.isPending}>
+                Reset
+              </Button>
+            </div>
+          </form>
+
+          <Alert>
+            <AlertTitle>Need to invite someone?</AlertTitle>
+            <AlertDescription>
+              If the person hasn&apos;t signed up yet, send them an invitation first. Once they have an account, you can grant admin
+              privileges here.
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin API endpoints for listing users, loading admin roster, and resolving role changes by email
- create shared admin fetch utilities and update navigation to surface the new user management pages
- build directory, invitation, and admin roles React pages that call the secured APIs for account actions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d1718f23908331bc9904e5976b58c7