### PR TITLE
Add saved posts bookmarking and account tab

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1048,6 +1048,27 @@ export type Database = {
         }
         Relationships: []
       }
+      saved_posts: {
+        Row: {
+          id: string
+          post_id: string
+          saved_at: string
+          user_id: string
+        }
+        Insert: {
+          id?: string
+          post_id: string
+          saved_at?: string
+          user_id: string
+        }
+        Update: {
+          id?: string
+          post_id?: string
+          saved_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       testimonials: {
         Row: {
           consent: boolean | null

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -39,6 +39,7 @@ import {
   BellRing,
   Globe,
   GraduationCap,
+  Bookmark,
 } from "lucide-react";
 import type { Database, Json } from "@/integrations/supabase/types";
 import { EnrolledClasses } from "@/components/EnrolledClasses";
@@ -89,6 +90,13 @@ type BlogSummary = Pick<
   "id" | "title" | "slug" | "page" | "is_published" | "created_at" | "author" | "language"
 >;
 
+type SavedPostWithContent = Database["public"]["Tables"]["saved_posts"]["Row"] & {
+  content?: Pick<
+    Database["public"]["Tables"]["content_master"]["Row"],
+    "id" | "title" | "slug" | "language" | "page" | "published_at"
+  > | null;
+};
+
 const Account = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -107,6 +115,7 @@ const Account = () => {
     role: userRoleOptions[0],
     bio: "",
   });
+  const [removingPostId, setRemovingPostId] = useState<string | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -250,6 +259,91 @@ const Account = () => {
       });
 
       return filtered;
+    },
+  });
+
+  const savedPostsQuery = useQuery({
+    queryKey: ["saved-posts", user?.id],
+    enabled: !!user?.id,
+    queryFn: async () => {
+      if (!user?.id) return [] as SavedPostWithContent[];
+
+      const { data, error } = await supabase
+        .from("saved_posts")
+        .select("id,post_id,saved_at")
+        .eq("user_id", user.id)
+        .order("saved_at", { ascending: false })
+        .limit(100);
+
+      if (error) {
+        throw error;
+      }
+
+      const rows = (data ?? []) as Database["public"]["Tables"]["saved_posts"]["Row"][];
+
+      if (rows.length === 0) {
+        return [] as SavedPostWithContent[];
+      }
+
+      const postIds = Array.from(new Set(rows.map(row => row.post_id)));
+
+      const { data: postsData, error: postsError } = await supabase
+        .from("content_master")
+        .select("id,title,slug,page,language,published_at")
+        .in("id", postIds)
+        .in("page", ["research_blog", "edutech", "teacher_diary"]);
+
+      if (postsError) {
+        throw postsError;
+      }
+
+      const postsById = new Map(
+        (postsData ?? []).map(post => [post.id, post as SavedPostWithContent["content"]])
+      );
+
+      return rows.map(row => ({
+        ...row,
+        content: postsById.get(row.post_id) ?? null,
+      })) as SavedPostWithContent[];
+    },
+  });
+
+  const removeSavedPostMutation = useMutation({
+    mutationFn: async (postId: string) => {
+      if (!user?.id) {
+        throw new Error("Missing user");
+      }
+
+      const { error } = await supabase
+        .from("saved_posts")
+        .delete()
+        .eq("user_id", user.id)
+        .eq("post_id", postId);
+
+      if (error) {
+        throw error;
+      }
+    },
+    onMutate: (postId) => {
+      setRemovingPostId(postId);
+    },
+    onSuccess: (_data, postId) => {
+      queryClient.invalidateQueries({ queryKey: ["saved-posts", user?.id] });
+      queryClient.invalidateQueries({ queryKey: ["saved-post", user?.id, postId] });
+      toast({
+        title: t.blogPost.toast.successTitle,
+        description: t.account.savedPosts.toast.removed,
+      });
+    },
+    onError: () => {
+      toast({
+        title: t.blogPost.toast.errorTitle,
+        description: t.account.savedPosts.toast.removeError,
+        variant: "destructive",
+      });
+    },
+    onSettled: () => {
+      setRemovingPostId(null);
     },
   });
 
@@ -592,6 +686,10 @@ const Account = () => {
               <GraduationCap className="h-4 w-4" />
               Classes
             </TabsTrigger>
+            <TabsTrigger value="saved-posts" className="gap-2">
+              <Bookmark className="h-4 w-4" />
+              {t.account.tabs.savedPosts}
+            </TabsTrigger>
             <TabsTrigger value="security" className="gap-2">
               <Lock className="h-4 w-4" />
               {t.account.tabs.security}
@@ -850,6 +948,82 @@ const Account = () => {
 
           <TabsContent value="classes">
             <EnrolledClasses userId={user?.id} language={language} />
+          </TabsContent>
+
+          <TabsContent value="saved-posts" className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Bookmark className="h-5 w-5 text-primary" />
+                  {t.account.savedPosts.title}
+                </CardTitle>
+                <CardDescription>{t.account.savedPosts.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {savedPostsQuery.isLoading && (
+                  <div className="space-y-2">
+                    <Skeleton className="h-6 w-3/4" />
+                    <Skeleton className="h-6 w-2/3" />
+                    <Skeleton className="h-6 w-1/2" />
+                  </div>
+                )}
+
+                {!savedPostsQuery.isLoading && (savedPostsQuery.data?.length ?? 0) === 0 && (
+                  <p className="text-sm text-muted-foreground">{t.account.savedPosts.empty}</p>
+                )}
+
+                {!savedPostsQuery.isLoading && savedPostsQuery.data && savedPostsQuery.data.length > 0 && (
+                  <div className="space-y-4">
+                    {savedPostsQuery.data.map(savedPost => {
+                      const savedOn = format(new Date(savedPost.saved_at), "PPP");
+                      const post = savedPost.content;
+
+                      return (
+                        <div
+                          key={savedPost.id}
+                          className="flex flex-col gap-3 rounded-lg border p-4 md:flex-row md:items-center md:justify-between"
+                        >
+                          <div>
+                            <p className="font-medium">
+                              {post?.title ?? t.account.savedPosts.unavailable}
+                            </p>
+                            <p className="text-sm text-muted-foreground">
+                              {t.account.savedPosts.savedOn.replace("{date}", savedOn)}
+                            </p>
+                          </div>
+                          <div className="flex flex-col gap-2 md:flex-row">
+                            {post?.slug && (
+                              <Button
+                                variant="outline"
+                                onClick={() =>
+                                  navigate(
+                                    getLocalizedPath(
+                                      `/blog/${post.slug}`,
+                                      (post.language as string | null) ?? language
+                                    )
+                                  )
+                                }
+                              >
+                                {t.account.savedPosts.viewPost}
+                              </Button>
+                            )}
+                            <Button
+                              variant="ghost"
+                              onClick={() => removeSavedPostMutation.mutate(savedPost.post_id)}
+                              disabled={removeSavedPostMutation.isPending && removingPostId === savedPost.post_id}
+                            >
+                              {removeSavedPostMutation.isPending && removingPostId === savedPost.post_id
+                                ? t.common.loading
+                                : t.account.savedPosts.remove}
+                            </Button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
           </TabsContent>
 
           <TabsContent value="security">

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -747,6 +747,8 @@ export const en = {
   blogPost: {
     backToBlog: "Back to Blog",
     share: "Share",
+    save: "Save post",
+    saved: "Saved",
     comments: "Comments",
     commentPlaceholder: "Share your thoughts...",
     postComment: "Post Comment",
@@ -765,12 +767,17 @@ export const en = {
       authRequiredTitle: "Authentication required",
       authRequiredComment: "Please log in to comment",
       authRequiredReply: "Please log in to reply",
+      authRequiredSave: "Please log in to save posts",
       errorTitle: "Error",
       commentError: "Failed to post comment",
       replyError: "Failed to post reply",
+      saveError: "Failed to save post",
+      removeError: "Failed to remove saved post",
       successTitle: "Success",
       commentSuccess: "Comment posted successfully",
-      replySuccess: "Reply posted successfully"
+      replySuccess: "Reply posted successfully",
+      saveSuccess: "Post saved to your list",
+      removeSuccess: "Removed from saved posts"
     }
   },
   contact: {
@@ -1281,6 +1288,7 @@ export const en = {
     },
     tabs: {
       overview: "Overview",
+      savedPosts: "Saved posts",
       security: "Security",
       activity: "Activity"
     },
@@ -1430,6 +1438,19 @@ export const en = {
         "Review your account activity regularly for unfamiliar changes.",
         "Sign out on shared devices after each session."
       ]
+    },
+    savedPosts: {
+      title: "Saved posts",
+      description: "Quickly revisit the articles you've bookmarked.",
+      empty: "You haven't saved any posts yet.",
+      savedOn: "Saved on {date}",
+      viewPost: "View article",
+      remove: "Remove",
+      unavailable: "This post is no longer available.",
+      toast: {
+        removed: "Removed from saved posts",
+        removeError: "We couldn't remove that saved post"
+      }
     },
     comments: {
       title: "My comments",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -747,6 +747,8 @@ export const sq = {
   blogPost: {
     backToBlog: "Kthehu te Blogu",
     share: "Ndaj",
+    save: "Ruaj postimin",
+    saved: "E ruajtur",
     comments: "Komentet",
     commentPlaceholder: "Ndani mendimet tuaja...",
     postComment: "Posto Komentin",
@@ -765,12 +767,17 @@ export const sq = {
       authRequiredTitle: "Kërkohet autentifikimi",
       authRequiredComment: "Ju lutemi hyni për të komentuar",
       authRequiredReply: "Ju lutemi hyni për t'u përgjigjur",
+      authRequiredSave: "Ju lutemi hyni për të ruajtur postimet",
       errorTitle: "Gabim",
       commentError: "Dështoi publikimi i komentit",
       replyError: "Dështoi publikimi i përgjigjes",
+      saveError: "Dështoi ruajtja e postimit",
+      removeError: "Dështoi heqja e postimit të ruajtur",
       successTitle: "Sukses",
       commentSuccess: "Komenti u postua me sukses",
-      replySuccess: "Përgjigjja u postua me sukses"
+      replySuccess: "Përgjigjja u postua me sukses",
+      saveSuccess: "Postimi u ruajt në listën tuaj",
+      removeSuccess: "U hoq nga postimet e ruajtura"
     }
   },
   contact: {
@@ -1281,6 +1288,7 @@ export const sq = {
     },
     tabs: {
       overview: "Përmbledhje",
+      savedPosts: "Postimet e ruajtura",
       security: "Siguria",
       activity: "Aktiviteti"
     },
@@ -1430,6 +1438,19 @@ export const sq = {
         "Rishiko rregullisht aktivitetin e llogarisë për ndryshime të panjohura.",
         "Dil nga pajisjet e përbashkëta pasi të përfundosh."
       ]
+    },
+    savedPosts: {
+      title: "Postimet e ruajtura",
+      description: "Kthehuni shpejt te artikujt që keni shënuar.",
+      empty: "Nuk keni ruajtur ende asnjë postim.",
+      savedOn: "Ruajtur më {date}",
+      viewPost: "Shiko artikullin",
+      remove: "Hiq",
+      unavailable: "Ky postim nuk është më i disponueshëm.",
+      toast: {
+        removed: "U hoq nga postimet e ruajtura",
+        removeError: "Nuk mundëm ta hiqnim këtë postim të ruajtur"
+      }
     },
     comments: {
       title: "Komentet e mia",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -747,6 +747,8 @@ export const vi = {
   blogPost: {
     backToBlog: "Quay lại Blog",
     share: "Chia sẻ",
+    save: "Lưu bài viết",
+    saved: "Đã lưu",
     comments: "Bình luận",
     commentPlaceholder: "Chia sẻ suy nghĩ của bạn...",
     postComment: "Đăng bình luận",
@@ -765,12 +767,17 @@ export const vi = {
       authRequiredTitle: "Cần đăng nhập",
       authRequiredComment: "Vui lòng đăng nhập để bình luận",
       authRequiredReply: "Vui lòng đăng nhập để trả lời",
+      authRequiredSave: "Vui lòng đăng nhập để lưu bài viết",
       errorTitle: "Lỗi",
       commentError: "Không thể đăng bình luận",
       replyError: "Không thể đăng phản hồi",
+      saveError: "Không thể lưu bài viết",
+      removeError: "Không thể gỡ bài viết đã lưu",
       successTitle: "Thành công",
       commentSuccess: "Đăng bình luận thành công",
-      replySuccess: "Đăng phản hồi thành công"
+      replySuccess: "Đăng phản hồi thành công",
+      saveSuccess: "Bài viết đã được lưu vào danh sách",
+      removeSuccess: "Đã gỡ khỏi bài viết đã lưu"
     }
   },
   contact: {
@@ -1281,6 +1288,7 @@ export const vi = {
     },
     tabs: {
       overview: "Tổng quan",
+      savedPosts: "Bài viết đã lưu",
       security: "Bảo mật",
       activity: "Hoạt động"
     },
@@ -1430,6 +1438,19 @@ export const vi = {
         "Kiểm tra hoạt động tài khoản thường xuyên để phát hiện bất thường.",
         "Đăng xuất khỏi thiết bị dùng chung sau khi sử dụng."
       ]
+    },
+    savedPosts: {
+      title: "Bài viết đã lưu",
+      description: "Quay lại nhanh các bài viết bạn đã đánh dấu.",
+      empty: "Bạn chưa lưu bài viết nào.",
+      savedOn: "Đã lưu vào {date}",
+      viewPost: "Xem bài viết",
+      remove: "Gỡ",
+      unavailable: "Bài viết này không còn khả dụng.",
+      toast: {
+        removed: "Đã gỡ khỏi bài viết đã lưu",
+        removeError: "Không thể gỡ bài viết đã lưu đó"
+      }
     },
     comments: {
       title: "Bình luận của tôi",


### PR DESCRIPTION
## Summary
- add Supabase typings and blog post UI to support saving and unsaving posts with toasts and share-friendly button group
- introduce a Saved Posts tab in the account area with list, view, and remove actions backed by Supabase queries
- localize new strings for saved post interactions in English, Albanian, and Vietnamese

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d17296587c83319b5731ab73596df3