### PR TITLE
feat(admin): add research management tooling

### DIFF
--- a/api/admin/research/submissions/review.ts
+++ b/api/admin/research/submissions/review.ts
@@ -1,0 +1,112 @@
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowed,
+  normalizeMethod,
+  parseJsonBody,
+} from "../../../_lib/http";
+import { recordAuditLog } from "../../../_lib/audit";
+import { requireAdmin } from "../../../_lib/auth";
+import { createNotification } from "../../../_lib/notifications";
+
+interface ReviewPayload {
+  id?: string;
+  status?: string;
+  note?: string | null;
+}
+
+interface SubmissionRecord {
+  id: string;
+  project_id: string;
+  participant_id: string;
+  status: string;
+}
+
+const ALLOWED_STATUSES = new Set<"accepted" | "needs_changes">([
+  "accepted",
+  "needs_changes",
+]);
+
+export default async function handler(request: Request): Promise<Response> {
+  if (normalizeMethod(request.method) !== "POST") {
+    return methodNotAllowed(["POST"]);
+  }
+
+  const context = await requireAdmin(request);
+  if (context instanceof Response) {
+    return context;
+  }
+
+  const payload = (await parseJsonBody<ReviewPayload>(request)) ?? {};
+  const submissionId = typeof payload.id === "string" ? payload.id.trim() : "";
+  const status = typeof payload.status === "string" ? payload.status.trim() : "";
+  const note = typeof payload.note === "string" ? payload.note.trim() : null;
+
+  if (!submissionId) {
+    return errorResponse(400, "A submission id is required");
+  }
+
+  if (!ALLOWED_STATUSES.has(status as "accepted" | "needs_changes")) {
+    return errorResponse(400, "A valid status is required");
+  }
+
+  const { supabase, user } = context;
+
+  const existingResult = await supabase
+    .from<SubmissionRecord>("research_submissions")
+    .select("id, project_id, participant_id, status")
+    .eq("id", submissionId)
+    .maybeSingle();
+
+  if (existingResult.error) {
+    return errorResponse(500, "Failed to load submission");
+  }
+
+  if (!existingResult.data) {
+    return errorResponse(404, "Submission not found");
+  }
+
+  const now = new Date().toISOString();
+
+  const updateResult = await supabase
+    .from("research_submissions")
+    .update({
+      status,
+      review_note: note,
+      reviewed_by: user.id,
+      reviewed_at: now,
+    })
+    .eq("id", submissionId)
+    .select("id, project_id, participant_id, status, review_note, reviewed_by, reviewed_at")
+    .maybeSingle();
+
+  if (updateResult.error || !updateResult.data) {
+    return errorResponse(500, "Failed to update submission");
+  }
+
+  await createNotification(supabase, {
+    userId: updateResult.data.participant_id,
+    type: "research_submission_reviewed",
+    payload: {
+      submissionId,
+      projectId: updateResult.data.project_id,
+      status,
+      previousStatus: existingResult.data.status,
+      note,
+    },
+  });
+
+  await recordAuditLog(supabase, {
+    action: "admin.research.submissions.review",
+    actorId: user.id,
+    targetId: submissionId,
+    metadata: {
+      projectId: updateResult.data.project_id,
+      previousStatus: existingResult.data.status,
+      status,
+      note,
+    },
+  });
+
+  return jsonResponse({ success: true, submission: updateResult.data });
+}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -63,6 +63,7 @@ function mapPrefs(record: Record<string, any>, userId: string): NotificationPref
     resourceApproved: record.resource_approved ?? true,
     blogpostApproved: record.blogpost_approved ?? true,
     researchApplicationApproved: record.research_application_approved ?? true,
+    researchSubmissionReviewed: record.research_submission_reviewed ?? true,
     commentReply: record.comment_reply ?? true,
     updatedAt: record.updated_at ?? new Date().toISOString(),
   } satisfies NotificationPrefs;
@@ -134,6 +135,7 @@ export interface NotificationPrefsPatch {
   resourceApproved?: boolean;
   blogpostApproved?: boolean;
   researchApplicationApproved?: boolean;
+  researchSubmissionReviewed?: boolean;
   commentReply?: boolean;
 }
 
@@ -159,6 +161,9 @@ export async function updatePrefs(
   }
   if (patch.researchApplicationApproved !== undefined) {
     payload.research_application_approved = patch.researchApplicationApproved;
+  }
+  if (patch.researchSubmissionReviewed !== undefined) {
+    payload.research_submission_reviewed = patch.researchSubmissionReviewed;
   }
   if (patch.commentReply !== undefined) {
     payload.comment_reply = patch.commentReply;

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -110,6 +110,7 @@ function mapSubmission(record: Record<string, any>): ResearchSubmission {
     status: (record.status as ResearchSubmissionStatus | undefined) ?? "submitted",
     reviewedBy: record.reviewed_by ?? null,
     reviewedAt: record.reviewed_at ?? null,
+    reviewNote: record.review_note ?? record.reviewNote ?? null,
     submittedAt: record.submitted_at ?? record.created_at ?? null,
   } satisfies ResearchSubmission;
 }

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -4,10 +4,18 @@ import type { AdminOutletContext } from "./AdminLayout";
 import { AdminDashboardSkeleton, AdminSectionSkeleton } from "./components/AdminSkeletons";
 import AdminPostsPage from "./content/AdminPostsPage";
 import AdminResourcesPage from "./content/AdminResourcesPage";
+import AdminResearchProjectsPage from "./research/AdminResearchProjectsPage";
+import AdminResearchDocumentsPage from "./research/AdminResearchDocumentsPage";
+import AdminResearchParticipantsPage from "./research/AdminResearchParticipantsPage";
+import AdminResearchSubmissionsPage from "./research/AdminResearchSubmissionsPage";
 
 const PAGE_COMPONENTS: Record<string, () => JSX.Element> = {
   "content/posts": AdminPostsPage,
   "content/resources": AdminResourcesPage,
+  "research/projects": AdminResearchProjectsPage,
+  "research/documents": AdminResearchDocumentsPage,
+  "research/participants": AdminResearchParticipantsPage,
+  "research/submissions": AdminResearchSubmissionsPage,
 };
 
 export default function AdminPage() {

--- a/src/pages/admin/research/AdminResearchDocumentsPage.tsx
+++ b/src/pages/admin/research/AdminResearchDocumentsPage.tsx
@@ -1,0 +1,513 @@
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { supabase } from "@/integrations/supabase/client";
+import type {
+  ResearchDocument,
+  ResearchDocumentStatus,
+  ResearchDocumentType,
+  ResearchProject,
+} from "@/types/platform";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useToast } from "@/components/ui/use-toast";
+import { fetchResearchProjects, PROJECT_QUERY_KEY } from "./queries";
+
+const DOCUMENTS_QUERY_KEY = ["admin", "research", "documents"] as const;
+
+const DOC_TYPES: Array<{ value: ResearchDocumentType; label: string }> = [
+  { value: "protocol", label: "Protocol" },
+  { value: "consent", label: "Consent" },
+  { value: "dataset", label: "Dataset" },
+  { value: "report", label: "Report" },
+  { value: "misc", label: "Other" },
+];
+
+const DOC_STATUSES: Array<{ value: ResearchDocumentStatus; label: string }> = [
+  { value: "internal", label: "Internal" },
+  { value: "participant", label: "Participant" },
+  { value: "public", label: "Public" },
+];
+
+interface DocumentRecord {
+  id?: string;
+  project_id?: string;
+  projectId?: string;
+  title?: string | null;
+  doc_type?: ResearchDocumentType | null;
+  storage_path?: string | null;
+  storagePath?: string | null;
+  status?: ResearchDocumentStatus | null;
+  created_at?: string;
+}
+
+interface DocumentFormValues {
+  projectId: string;
+  title: string;
+  docType: ResearchDocumentType | "";
+  status: ResearchDocumentStatus;
+}
+
+interface FormDialogState {
+  open: boolean;
+  document: ResearchDocument | null;
+}
+
+interface DeleteDialogState {
+  open: boolean;
+  document: ResearchDocument | null;
+}
+
+function toDocument(record: DocumentRecord): ResearchDocument {
+  return {
+    id: String(record.id ?? ""),
+    projectId: record.project_id ?? record.projectId ?? "",
+    title: record.title ?? null,
+    docType: (record.doc_type as ResearchDocumentType | undefined) ?? null,
+    storagePath: record.storage_path ?? record.storagePath ?? null,
+    status: (record.status as ResearchDocumentStatus | undefined) ?? "participant",
+    createdAt: record.created_at ?? new Date().toISOString(),
+  } satisfies ResearchDocument;
+}
+
+async function fetchDocuments(): Promise<ResearchDocument[]> {
+  const { data, error } = await supabase
+    .from("research_documents")
+    .select("id,project_id,title,doc_type,storage_path,status,created_at")
+    .order("created_at", { ascending: false, nullsLast: true });
+
+  if (error) {
+    throw new Error(error.message || "Failed to load documents");
+  }
+
+  return (data ?? []).map(toDocument);
+}
+
+async function uploadDocument(values: DocumentFormValues, file: File | null): Promise<ResearchDocument> {
+  if (!file) {
+    throw new Error("A file is required for upload");
+  }
+
+  const formData = new FormData();
+  formData.append("projectId", values.projectId);
+  formData.append("file", file);
+  if (values.title.trim()) {
+    formData.append("title", values.title.trim());
+  }
+  if (values.docType) {
+    formData.append("docType", values.docType);
+  }
+  formData.append("status", values.status);
+
+  const response = await fetch("/api/admin/research/documents/upload", {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to upload document");
+  }
+
+  const payload = (await response.json()) as { document?: DocumentRecord };
+  if (!payload.document) {
+    throw new Error("Upload response missing document data");
+  }
+
+  return toDocument(payload.document);
+}
+
+async function saveDocument(values: DocumentFormValues, existing: ResearchDocument | null): Promise<ResearchDocument> {
+  if (!existing) {
+    throw new Error("Document not found");
+  }
+
+  const { data, error } = await supabase
+    .from("research_documents")
+    .update({
+      project_id: values.projectId,
+      title: values.title.trim() || null,
+      doc_type: values.docType || null,
+      status: values.status,
+    })
+    .eq("id", existing.id)
+    .select("id,project_id,title,doc_type,storage_path,status,created_at")
+    .maybeSingle();
+
+  if (error || !data) {
+    throw new Error(error?.message ?? "Failed to update document");
+  }
+
+  return toDocument(data);
+}
+
+async function deleteDocument(document: ResearchDocument): Promise<void> {
+  const { error } = await supabase.from("research_documents").delete().eq("id", document.id);
+
+  if (error) {
+    throw new Error(error.message || "Failed to delete document");
+  }
+}
+
+function defaultValues(projects: ResearchProject[], document: ResearchDocument | null): DocumentFormValues {
+  const fallbackProjectId = projects[0]?.id ?? "";
+  return {
+    projectId: document?.projectId ?? fallbackProjectId,
+    title: document?.title ?? "",
+    docType: document?.docType ?? "",
+    status: document?.status ?? "participant",
+  } satisfies DocumentFormValues;
+}
+
+export default function AdminResearchDocumentsPage(): JSX.Element {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [file, setFile] = useState<File | null>(null);
+  const [formState, setFormState] = useState<FormDialogState>({ open: false, document: null });
+  const [deleteState, setDeleteState] = useState<DeleteDialogState>({ open: false, document: null });
+
+  const {
+    data: projects = [],
+    isLoading: loadingProjects,
+  } = useQuery<ResearchProject[], Error>({
+    queryKey: PROJECT_QUERY_KEY,
+    queryFn: fetchResearchProjects,
+  });
+
+  const {
+    data: documents = [],
+    isLoading: loadingDocuments,
+    error: documentsError,
+  } = useQuery<ResearchDocument[], Error>({
+    queryKey: DOCUMENTS_QUERY_KEY,
+    queryFn: fetchDocuments,
+  });
+
+  const form = useForm<DocumentFormValues>({
+    defaultValues: defaultValues(projects, null),
+  });
+
+  useEffect(() => {
+    if (formState.open) {
+      form.reset(defaultValues(projects, formState.document));
+      setFile(null);
+    }
+  }, [formState, form, projects]);
+
+  useEffect(() => {
+    if (!formState.open) {
+      setFile(null);
+    }
+  }, [formState.open]);
+
+  const uploadMutation = useMutation({
+    mutationFn: (values: DocumentFormValues) => uploadDocument(values, file),
+    onSuccess: async document => {
+      await queryClient.invalidateQueries({ queryKey: DOCUMENTS_QUERY_KEY });
+      setFormState({ open: false, document: null });
+      toast({ title: "Document uploaded", description: document.title ?? "Document available to participants." });
+    },
+    onError: err => {
+      toast({
+        title: "Upload failed",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (values: DocumentFormValues) => saveDocument(values, formState.document),
+    onSuccess: async document => {
+      await queryClient.invalidateQueries({ queryKey: DOCUMENTS_QUERY_KEY });
+      setFormState({ open: false, document: null });
+      toast({ title: "Document updated", description: document.title ?? "Document metadata saved." });
+    },
+    onError: err => {
+      toast({
+        title: "Unable to save document",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => (deleteState.document ? deleteDocument(deleteState.document) : Promise.resolve()),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: DOCUMENTS_QUERY_KEY });
+      setDeleteState({ open: false, document: null });
+      toast({ title: "Document removed", description: "The document has been deleted." });
+    },
+    onError: err => {
+      toast({
+        title: "Unable to delete document",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const projectLookup = useMemo(() => {
+    const map = new Map<string, ResearchProject>();
+    for (const project of projects) {
+      map.set(project.id, project);
+    }
+    return map;
+  }, [projects]);
+
+  const tableContent = useMemo(() => {
+    if (loadingDocuments) {
+      return (
+        <TableRow>
+          <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
+            Loading documents…
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    if (documentsError) {
+      return (
+        <TableRow>
+          <TableCell colSpan={6} className="text-center text-sm text-destructive">
+            Failed to load documents.
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    if (documents.length === 0) {
+      return (
+        <TableRow>
+          <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
+            No documents uploaded yet.
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    return documents.map(document => {
+      const project = projectLookup.get(document.projectId);
+      return (
+        <TableRow key={document.id}>
+          <TableCell>
+            <div className="font-medium">{document.title ?? "Untitled document"}</div>
+            <div className="text-xs text-muted-foreground">{document.storagePath ?? "Untracked path"}</div>
+          </TableCell>
+          <TableCell>{project ? project.title : "Unknown project"}</TableCell>
+          <TableCell className="capitalize">{document.docType ?? "–"}</TableCell>
+          <TableCell>
+            <Badge variant={document.status === "internal" ? "secondary" : document.status === "public" ? "default" : "outline"}>
+              {document.status}
+            </Badge>
+          </TableCell>
+          <TableCell className="text-sm text-muted-foreground">{new Date(document.createdAt).toLocaleString()}</TableCell>
+          <TableCell className="flex justify-end gap-2">
+            <Button variant="outline" size="sm" onClick={() => setFormState({ open: true, document })}>
+              Edit
+            </Button>
+            <Button variant="destructive" size="sm" onClick={() => setDeleteState({ open: true, document })}>
+              Delete
+            </Button>
+          </TableCell>
+        </TableRow>
+      );
+    });
+  }, [documents, documentsError, loadingDocuments, projectLookup]);
+
+  const projectOptions = projects.map(project => (
+    <SelectItem key={project.id} value={project.id}>
+      {project.title}
+    </SelectItem>
+  ));
+
+  const docTypeValue = form.watch("docType") ?? "";
+  const statusValue = form.watch("status") ?? "participant";
+  const projectValue = form.watch("projectId") ?? "";
+
+  const submitting = formState.document ? updateMutation.isPending : uploadMutation.isPending;
+
+  const dialogTitle = formState.document ? "Edit document" : "Upload document";
+  const handleSubmit = (values: DocumentFormValues) => {
+    if (formState.document) {
+      updateMutation.mutate(values);
+    } else {
+      uploadMutation.mutate(values);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between gap-4">
+          <div className="space-y-1">
+            <CardTitle>Research documents</CardTitle>
+            <CardDescription>Store consent forms, protocols, and participant resources securely.</CardDescription>
+          </div>
+          <Dialog
+            open={formState.open}
+            onOpenChange={open => setFormState(current => ({ open, document: open ? current.document : null }))}
+          >
+            <DialogTrigger asChild>
+              <Button onClick={() => setFormState({ open: true, document: null })} disabled={loadingProjects || projects.length === 0}>
+                Upload document
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-lg">
+              <DialogHeader>
+                <DialogTitle>{dialogTitle}</DialogTitle>
+              </DialogHeader>
+              {projects.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  Create a project before uploading documents so they can be organised correctly.
+                </p>
+              ) : (
+                <form
+                  onSubmit={event => {
+                    event.preventDefault();
+                    void form.handleSubmit(handleSubmit)(event);
+                  }}
+                  className="space-y-4"
+                >
+                  <div className="space-y-2">
+                    <Label>Project</Label>
+                    <Select value={projectValue} onValueChange={value => form.setValue("projectId", value)}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a project" />
+                      </SelectTrigger>
+                      <SelectContent>{projectOptions}</SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="document-title">Title</Label>
+                    <Input id="document-title" placeholder="Document title" {...form.register("title")} />
+                  </div>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label>Document type</Label>
+                      <Select value={docTypeValue} onValueChange={value => form.setValue("docType", value as ResearchDocumentType | "")}> 
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select type" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="">Unspecified</SelectItem>
+                          {DOC_TYPES.map(option => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Status</Label>
+                      <Select value={statusValue} onValueChange={value => form.setValue("status", value as ResearchDocumentStatus)}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select status" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {DOC_STATUSES.map(option => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  {!formState.document && (
+                    <div className="space-y-2">
+                      <Label htmlFor="document-file">File</Label>
+                      <Input
+                        id="document-file"
+                        type="file"
+                        onChange={event => setFile(event.target.files?.[0] ?? null)}
+                        required={!formState.document}
+                      />
+                      <p className="text-xs text-muted-foreground">Files are stored privately in the research bucket.</p>
+                    </div>
+                  )}
+                  <DialogFooter>
+                    <Button type="submit" disabled={submitting || (!formState.document && !file)}>
+                      {submitting ? "Saving…" : formState.document ? "Save changes" : "Upload"}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              )}
+            </DialogContent>
+          </Dialog>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Document</TableHead>
+                  <TableHead>Project</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>{tableContent}</TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <AlertDialog
+        open={deleteState.open}
+        onOpenChange={open => setDeleteState(current => ({ open, document: open ? current.document : null }))}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete document?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove the document record from the project. Storage files must be deleted manually if no longer required.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  if (!deleteState.document) return;
+                  deleteMutation.mutate();
+                }}
+                disabled={deleteMutation.isPending}
+              >
+                {deleteMutation.isPending ? "Deleting…" : "Delete"}
+              </Button>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/pages/admin/research/AdminResearchParticipantsPage.tsx
+++ b/src/pages/admin/research/AdminResearchParticipantsPage.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { supabase } from "@/integrations/supabase/client";
+import type { ResearchParticipant, ResearchProject } from "@/types/platform";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { fetchResearchProjects, PROJECT_QUERY_KEY } from "./queries";
+import { fetchProfilesByIds } from "./profileHelpers";
+
+const PARTICIPANTS_QUERY_KEY = ["admin", "research", "participants"] as const;
+
+interface ParticipantRecord {
+  id?: string;
+  project_id?: string;
+  projectId?: string;
+  user_id?: string;
+  userId?: string;
+  joined_at?: string;
+}
+
+function mapParticipant(record: ParticipantRecord): ResearchParticipant {
+  return {
+    id: String(record.id ?? ""),
+    projectId: record.project_id ?? record.projectId ?? "",
+    userId: record.user_id ?? record.userId ?? "",
+    joinedAt: record.joined_at ?? new Date().toISOString(),
+  } satisfies ResearchParticipant;
+}
+
+async function fetchParticipants(projectId: string): Promise<ResearchParticipant[]> {
+  const { data, error } = await supabase
+    .from("research_participants")
+    .select("id,project_id,user_id,joined_at")
+    .eq("project_id", projectId)
+    .order("joined_at", { ascending: true, nullsLast: false });
+
+  if (error) {
+    throw new Error(error.message || "Failed to load participants");
+  }
+
+  return (data ?? []).map(mapParticipant);
+}
+
+async function removeParticipant(participant: ResearchParticipant): Promise<void> {
+  const { error } = await supabase.from("research_participants").delete().eq("id", participant.id);
+
+  if (error) {
+    throw new Error(error.message || "Failed to remove participant");
+  }
+}
+
+export default function AdminResearchParticipantsPage(): JSX.Element {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [selectedProjectId, setSelectedProjectId] = useState<string | "">("");
+  const [confirming, setConfirming] = useState<ResearchParticipant | null>(null);
+
+  const {
+    data: projects = [],
+    isLoading: loadingProjects,
+  } = useQuery<ResearchProject[], Error>({
+    queryKey: PROJECT_QUERY_KEY,
+    queryFn: fetchResearchProjects,
+  });
+
+  useEffect(() => {
+    if (!selectedProjectId && projects.length > 0) {
+      setSelectedProjectId(projects[0].id);
+    }
+  }, [projects, selectedProjectId]);
+
+  const {
+    data: participants = [],
+    isLoading: loadingParticipants,
+    error: participantsError,
+  } = useQuery<ResearchParticipant[], Error>({
+    queryKey: [...PARTICIPANTS_QUERY_KEY, selectedProjectId],
+    queryFn: () => fetchParticipants(selectedProjectId),
+    enabled: Boolean(selectedProjectId),
+  });
+
+  const profileQuery = useQuery({
+    queryKey: [...PARTICIPANTS_QUERY_KEY, "profiles", selectedProjectId, participants.map(p => p.userId).join("-")],
+    queryFn: () => fetchProfilesByIds(participants.map(p => p.userId)),
+    enabled: Boolean(selectedProjectId) && participants.length > 0,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => (confirming ? removeParticipant(confirming) : Promise.resolve()),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: [...PARTICIPANTS_QUERY_KEY, selectedProjectId] });
+      setConfirming(null);
+      toast({ title: "Participant removed", description: "Access has been revoked." });
+    },
+    onError: err => {
+      toast({
+        title: "Unable to remove participant",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const participantRows = useMemo(() => {
+    if (!selectedProjectId) {
+      return (
+        <TableRow>
+          <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
+            Select a project to view participants.
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    if (loadingParticipants) {
+      return (
+        <TableRow>
+          <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
+            Loading participants…
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    if (participantsError) {
+      return (
+        <TableRow>
+          <TableCell colSpan={4} className="text-center text-sm text-destructive">
+            Failed to load participants.
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    if (participants.length === 0) {
+      return (
+        <TableRow>
+          <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
+            No participants enrolled in this project yet.
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    const profiles = profileQuery.data ?? new Map();
+
+    return participants.map(participant => {
+      const profile = profiles.get(participant.userId);
+      return (
+        <TableRow key={participant.id}>
+          <TableCell>
+            <div className="font-medium">{profile?.fullName ?? "Unknown educator"}</div>
+            <div className="text-xs text-muted-foreground">{profile?.email ?? participant.userId}</div>
+          </TableCell>
+          <TableCell>
+            <Badge variant="outline">{participant.userId}</Badge>
+          </TableCell>
+          <TableCell className="text-sm text-muted-foreground">
+            {new Date(participant.joinedAt).toLocaleString()}
+          </TableCell>
+          <TableCell className="flex justify-end">
+            <Button variant="destructive" size="sm" onClick={() => setConfirming(participant)}>
+              Remove
+            </Button>
+          </TableCell>
+        </TableRow>
+      );
+    });
+  }, [selectedProjectId, loadingParticipants, participantsError, participants, profileQuery.data]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+      <Card>
+        <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle>Research participants</CardTitle>
+            <CardDescription>Review who has access to each project and revoke participation when needed.</CardDescription>
+          </div>
+          <div className="w-full max-w-xs">
+            <Select value={selectedProjectId} onValueChange={value => setSelectedProjectId(value)} disabled={loadingProjects || projects.length === 0}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a project" />
+              </SelectTrigger>
+              <SelectContent>
+                {projects.map(project => (
+                  <SelectItem key={project.id} value={project.id}>
+                    {project.title}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Participant</TableHead>
+                  <TableHead>User ID</TableHead>
+                  <TableHead>Joined</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>{participantRows}</TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={Boolean(confirming)} onOpenChange={open => !open && setConfirming(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove participant?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This educator will lose access to project documents and submission tools.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  if (!confirming) return;
+                  deleteMutation.mutate();
+                }}
+                disabled={deleteMutation.isPending}
+              >
+                {deleteMutation.isPending ? "Removing…" : "Remove"}
+              </Button>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/pages/admin/research/AdminResearchProjectsPage.tsx
+++ b/src/pages/admin/research/AdminResearchProjectsPage.tsx
@@ -1,0 +1,416 @@
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { supabase } from "@/integrations/supabase/client";
+import type { ResearchProject, ResearchProjectStatus, ResearchProjectVisibility } from "@/types/platform";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+import { fetchResearchProjects, PROJECT_QUERY_KEY } from "./queries";
+
+const STATUS_OPTIONS: Array<{ value: ResearchProjectStatus; label: string }> = [
+  { value: "draft", label: "Draft" },
+  { value: "open", label: "Open" },
+  { value: "closed", label: "Closed" },
+];
+
+const VISIBILITY_OPTIONS: Array<{ value: ResearchProjectVisibility; label: string }> = [
+  { value: "list_public", label: "Listed (Public)" },
+  { value: "private", label: "Private" },
+];
+
+interface ProjectFormValues {
+  title: string;
+  slug: string;
+  summary: string;
+  status: ResearchProjectStatus;
+  visibility: ResearchProjectVisibility;
+}
+
+interface FormDialogState {
+  open: boolean;
+  project: ResearchProject | null;
+}
+
+interface DeleteDialogState {
+  open: boolean;
+  project: ResearchProject | null;
+}
+
+function initialFormValues(project: ResearchProject | null): ProjectFormValues {
+  return {
+    title: project?.title ?? "",
+    slug: project?.slug ?? "",
+    summary: project?.summary ?? "",
+    status: project?.status ?? "draft",
+    visibility: project?.visibility ?? "list_public",
+  } satisfies ProjectFormValues;
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120);
+}
+
+async function saveProject(values: ProjectFormValues, existing?: ResearchProject | null): Promise<ResearchProject> {
+  const title = values.title.trim();
+  if (!title) {
+    throw new Error("A project title is required");
+  }
+
+  const rawSlug = values.slug.trim();
+  const slugCandidate = rawSlug || slugify(title);
+  const payload = {
+    title,
+    slug: slugCandidate.length > 0 ? slugCandidate : null,
+    summary: values.summary.trim() || null,
+    status: values.status,
+    visibility: values.visibility,
+  } satisfies Partial<ResearchProject> & { title: string; status: ResearchProjectStatus; visibility: ResearchProjectVisibility };
+
+  if (existing) {
+    const { data, error } = await supabase
+      .from("research_projects")
+      .update(payload)
+      .eq("id", existing.id)
+      .select("id,title,slug,summary,status,visibility,created_by,created_at")
+      .maybeSingle();
+
+    if (error || !data) {
+      throw new Error(error?.message ?? "Failed to update project");
+    }
+
+    return {
+      id: String(data.id ?? existing.id),
+      title: data.title ?? title,
+      slug: data.slug ?? payload.slug,
+      summary: data.summary ?? payload.summary,
+      status: (data.status as ResearchProjectStatus | undefined) ?? payload.status,
+      visibility: (data.visibility as ResearchProjectVisibility | undefined) ?? payload.visibility,
+      createdBy: data.created_by ?? existing.createdBy ?? null,
+      createdAt: data.created_at ?? existing.createdAt,
+    } satisfies ResearchProject;
+  }
+
+  const { data: userResult } = await supabase.auth.getUser();
+  const userId = userResult?.user?.id ?? null;
+
+  const { data, error } = await supabase
+    .from("research_projects")
+    .insert({
+      ...payload,
+      created_by: userId,
+    })
+    .select("id,title,slug,summary,status,visibility,created_by,created_at")
+    .maybeSingle();
+
+  if (error || !data) {
+    throw new Error(error?.message ?? "Failed to create project");
+  }
+
+  return {
+    id: String(data.id ?? ""),
+    title: data.title ?? title,
+    slug: data.slug ?? payload.slug,
+    summary: data.summary ?? payload.summary,
+    status: (data.status as ResearchProjectStatus | undefined) ?? payload.status,
+    visibility: (data.visibility as ResearchProjectVisibility | undefined) ?? payload.visibility,
+    createdBy: data.created_by ?? userId,
+    createdAt: data.created_at ?? new Date().toISOString(),
+  } satisfies ResearchProject;
+}
+
+async function deleteProject(project: ResearchProject): Promise<void> {
+  const { error } = await supabase.from("research_projects").delete().eq("id", project.id);
+
+  if (error) {
+    throw new Error(error.message || "Failed to delete project");
+  }
+}
+
+export default function AdminResearchProjectsPage(): JSX.Element {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [formState, setFormState] = useState<FormDialogState>({ open: false, project: null });
+  const [deleteState, setDeleteState] = useState<DeleteDialogState>({ open: false, project: null });
+
+  const {
+    data: projects = [],
+    isLoading,
+    error,
+  } = useQuery<ResearchProject[], Error>({
+    queryKey: PROJECT_QUERY_KEY,
+    queryFn: fetchResearchProjects,
+  });
+
+  const form = useForm<ProjectFormValues>({
+    defaultValues: initialFormValues(null),
+  });
+
+  useEffect(() => {
+    if (formState.open) {
+      form.reset(initialFormValues(formState.project));
+    }
+  }, [formState, form]);
+
+  const statusValue = form.watch("status") ?? "draft";
+  const visibilityValue = form.watch("visibility") ?? "list_public";
+
+  const mutation = useMutation({
+    mutationFn: (values: ProjectFormValues) => saveProject(values, formState.project),
+    onSuccess: async project => {
+      await queryClient.invalidateQueries({ queryKey: PROJECT_QUERY_KEY });
+      setFormState({ open: false, project: null });
+      toast({ title: "Project saved", description: `${project.title} is now ${project.status}.` });
+    },
+    onError: err => {
+      toast({ title: "Unable to save project", description: err instanceof Error ? err.message : "Unknown error", variant: "destructive" });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => (deleteState.project ? deleteProject(deleteState.project) : Promise.resolve()),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: PROJECT_QUERY_KEY });
+      setDeleteState({ open: false, project: null });
+      toast({ title: "Project removed", description: "The project has been deleted." });
+    },
+    onError: err => {
+      toast({
+        title: "Unable to delete project",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const tableContent = useMemo(() => {
+    if (isLoading) {
+      return (
+        <TableRow>
+          <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+            Loading projects…
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    if (error) {
+      return (
+        <TableRow>
+          <TableCell colSpan={5} className="text-center text-sm text-destructive">
+            Failed to load projects.
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    if (projects.length === 0) {
+      return (
+        <TableRow>
+          <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+            No research projects have been created yet.
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    return projects.map(project => (
+      <TableRow key={project.id}>
+        <TableCell>
+          <div className="font-medium">{project.title}</div>
+          <div className="text-xs text-muted-foreground">Created {new Date(project.createdAt).toLocaleString()}</div>
+        </TableCell>
+        <TableCell className="text-sm text-muted-foreground">{project.slug ?? <span className="italic">Not set</span>}</TableCell>
+        <TableCell>
+          <Badge variant={project.status === "open" ? "default" : project.status === "closed" ? "secondary" : "outline"}>
+            {project.status === "draft" ? "Draft" : project.status === "open" ? "Open" : "Closed"}
+          </Badge>
+        </TableCell>
+        <TableCell>
+          <Badge variant={project.visibility === "list_public" ? "outline" : "secondary"}>
+            {project.visibility === "list_public" ? "Listed" : "Private"}
+          </Badge>
+        </TableCell>
+        <TableCell className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setFormState({ open: true, project })}
+          >
+            Edit
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => setDeleteState({ open: true, project })}
+          >
+            Delete
+          </Button>
+        </TableCell>
+      </TableRow>
+    ));
+  }, [projects, isLoading, error]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between gap-4">
+          <div className="space-y-1">
+            <CardTitle>Research projects</CardTitle>
+            <CardDescription>Define active studies, configure visibility, and track their lifecycle.</CardDescription>
+          </div>
+          <Dialog
+            open={formState.open}
+            onOpenChange={open => setFormState(current => ({ open, project: open ? current.project : null }))}
+          >
+            <DialogTrigger asChild>
+              <Button onClick={() => setFormState({ open: true, project: null })}>New project</Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-lg">
+              <DialogHeader>
+                <DialogTitle>{formState.project ? "Edit project" : "Create project"}</DialogTitle>
+              </DialogHeader>
+              <form
+                onSubmit={event => {
+                  event.preventDefault();
+                  void form.handleSubmit(values => mutation.mutate(values))(event);
+                }}
+                className="space-y-4"
+              >
+                <div className="space-y-2">
+                  <Label htmlFor="project-title">Title</Label>
+                  <Input id="project-title" placeholder="AI in the classroom" {...form.register("title")} required />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="project-slug">Slug</Label>
+                  <Input id="project-slug" placeholder="ai-in-the-classroom" {...form.register("slug")} />
+                  <p className="text-xs text-muted-foreground">Leave blank to generate from the title.</p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="project-summary">Summary</Label>
+                  <Textarea id="project-summary" rows={3} placeholder="Short description" {...form.register("summary")} />
+                </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label>Status</Label>
+                    <Select value={statusValue} onValueChange={value => form.setValue("status", value as ResearchProjectStatus)}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select status" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {STATUS_OPTIONS.map(option => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Visibility</Label>
+                    <Select
+                      value={visibilityValue}
+                      onValueChange={value => form.setValue("visibility", value as ResearchProjectVisibility)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select visibility" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {VISIBILITY_OPTIONS.map(option => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button type="submit" disabled={mutation.isPending}>
+                    {mutation.isPending ? "Saving…" : "Save project"}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </DialogContent>
+          </Dialog>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Project</TableHead>
+                  <TableHead>Slug</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Visibility</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>{tableContent}</TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <AlertDialog
+        open={deleteState.open}
+        onOpenChange={open => setDeleteState(current => ({ open, project: open ? current.project : null }))}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove project?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the project{deleteState.project ? ` "${deleteState.project.title}"` : ""} and any
+              associated records.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  if (!deleteState.project) return;
+                  deleteMutation.mutate();
+                }}
+                disabled={deleteMutation.isPending}
+              >
+                {deleteMutation.isPending ? "Deleting…" : "Delete"}
+              </Button>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/pages/admin/research/AdminResearchSubmissionsPage.tsx
+++ b/src/pages/admin/research/AdminResearchSubmissionsPage.tsx
@@ -1,0 +1,434 @@
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { supabase } from "@/integrations/supabase/client";
+import type {
+  ResearchProject,
+  ResearchSubmission,
+  ResearchSubmissionStatus,
+} from "@/types/platform";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { fetchResearchProjects, PROJECT_QUERY_KEY } from "./queries";
+import { fetchProfilesByIds } from "./profileHelpers";
+
+const SUBMISSIONS_QUERY_KEY = ["admin", "research", "submissions"] as const;
+
+type StatusFilterOption = "all" | ResearchSubmissionStatus;
+
+interface ReviewFormValues {
+  status: Exclude<ResearchSubmissionStatus, "submitted">;
+  note: string;
+}
+
+interface SubmissionFilters {
+  projectId?: string;
+  status?: ResearchSubmissionStatus;
+}
+
+interface SubmissionRecord {
+  id?: string;
+  project_id?: string;
+  projectId?: string;
+  participant_id?: string;
+  participantId?: string;
+  title?: string | null;
+  description?: string | null;
+  storage_path?: string | null;
+  storagePath?: string | null;
+  status?: ResearchSubmissionStatus | null;
+  review_note?: string | null;
+  reviewNote?: string | null;
+  reviewed_by?: string | null;
+  reviewed_at?: string | null;
+  submitted_at?: string | null;
+  created_at?: string | null;
+}
+
+function toSubmission(record: SubmissionRecord): ResearchSubmission {
+  return {
+    id: String(record.id ?? ""),
+    projectId: record.project_id ?? record.projectId ?? "",
+    participantId: record.participant_id ?? record.participantId ?? "",
+    title: record.title ?? null,
+    description: record.description ?? null,
+    storagePath: record.storage_path ?? record.storagePath ?? null,
+    status: (record.status as ResearchSubmissionStatus | undefined) ?? "submitted",
+    reviewedBy: record.reviewed_by ?? null,
+    reviewedAt: record.reviewed_at ?? null,
+    reviewNote: record.review_note ?? record.reviewNote ?? null,
+    submittedAt: record.submitted_at ?? record.created_at ?? null,
+  } satisfies ResearchSubmission;
+}
+
+async function fetchSubmissions(filters: SubmissionFilters): Promise<ResearchSubmission[]> {
+  let query = supabase
+    .from("research_submissions")
+    .select("id,project_id,participant_id,title,description,storage_path,status,review_note,reviewed_by,reviewed_at,submitted_at,created_at")
+    .order("submitted_at", { ascending: false, nullsLast: true });
+
+  if (filters.projectId) {
+    query = query.eq("project_id", filters.projectId);
+  }
+
+  if (filters.status) {
+    query = query.eq("status", filters.status);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(error.message || "Failed to load submissions");
+  }
+
+  return (data ?? []).map(toSubmission);
+}
+
+async function reviewSubmission(
+  submissionId: string,
+  values: ReviewFormValues,
+): Promise<ResearchSubmission> {
+  const response = await fetch("/api/admin/research/submissions/review", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      id: submissionId,
+      status: values.status,
+      note: values.note.trim() || null,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to update submission");
+  }
+
+  const payload = (await response.json()) as { submission?: SubmissionRecord };
+  if (!payload.submission) {
+    throw new Error("Response missing submission data");
+  }
+
+  return toSubmission(payload.submission);
+}
+
+function statusVariant(status: ResearchSubmissionStatus): "default" | "secondary" | "outline" | "destructive" {
+  switch (status) {
+    case "accepted":
+      return "default";
+    case "needs_changes":
+      return "destructive";
+    case "submitted":
+    default:
+      return "secondary";
+  }
+}
+
+export default function AdminResearchSubmissionsPage(): JSX.Element {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [projectFilter, setProjectFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilterOption>("submitted");
+  const [activeSubmission, setActiveSubmission] = useState<ResearchSubmission | null>(null);
+
+  const {
+    data: projects = [],
+  } = useQuery<ResearchProject[], Error>({
+    queryKey: PROJECT_QUERY_KEY,
+    queryFn: fetchResearchProjects,
+  });
+
+  const filters: SubmissionFilters = useMemo(() => {
+    const payload: SubmissionFilters = {};
+    if (projectFilter !== "all") {
+      payload.projectId = projectFilter;
+    }
+    if (statusFilter !== "all") {
+      payload.status = statusFilter;
+    }
+    return payload;
+  }, [projectFilter, statusFilter]);
+
+  const {
+    data: submissions = [],
+    isLoading: loadingSubmissions,
+    error: submissionsError,
+  } = useQuery<ResearchSubmission[], Error>({
+    queryKey: [...SUBMISSIONS_QUERY_KEY, filters.projectId ?? "all", filters.status ?? "all"],
+    queryFn: () => fetchSubmissions(filters),
+  });
+
+  const profileQuery = useQuery({
+    queryKey: [...SUBMISSIONS_QUERY_KEY, "profiles", submissions.map(item => item.participantId).join("-")],
+    queryFn: () => fetchProfilesByIds(submissions.map(item => item.participantId)),
+    enabled: submissions.length > 0,
+  });
+
+  const form = useForm<ReviewFormValues>({
+    defaultValues: {
+      status: "accepted",
+      note: "",
+    },
+  });
+
+  useEffect(() => {
+    if (activeSubmission) {
+      form.reset({
+        status: activeSubmission.status === "submitted" ? "accepted" : activeSubmission.status,
+        note: activeSubmission.reviewNote ?? "",
+      });
+    }
+  }, [activeSubmission, form]);
+
+  const reviewStatus = form.watch("status");
+
+  const reviewMutation = useMutation({
+    mutationFn: (values: ReviewFormValues) => {
+      if (!activeSubmission) {
+        return Promise.reject(new Error("No submission selected"));
+      }
+      return reviewSubmission(activeSubmission.id, values);
+    },
+    onSuccess: async submission => {
+      await queryClient.invalidateQueries({ queryKey: [...SUBMISSIONS_QUERY_KEY, filters.projectId ?? "all", filters.status ?? "all"] });
+      setActiveSubmission(null);
+      toast({
+        title: "Submission updated",
+        description: submission.status === "accepted" ? "Marked as accepted." : "Requested changes from participant.",
+      });
+    },
+    onError: err => {
+      toast({
+        title: "Unable to review submission",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const projectLookup = useMemo(() => {
+    const map = new Map<string, ResearchProject>();
+    for (const project of projects) {
+      map.set(project.id, project);
+    }
+    return map;
+  }, [projects]);
+
+  const rows = useMemo(() => {
+    if (loadingSubmissions) {
+      return (
+        <TableRow>
+          <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
+            Loading submissions…
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    if (submissionsError) {
+      return (
+        <TableRow>
+          <TableCell colSpan={6} className="text-center text-sm text-destructive">
+            Failed to load submissions.
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    if (submissions.length === 0) {
+      return (
+        <TableRow>
+          <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
+            No submissions match the selected filters.
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    const profiles = profileQuery.data ?? new Map();
+
+    return submissions.map(submission => {
+      const participantProfile = profiles.get(submission.participantId);
+      const project = projectLookup.get(submission.projectId);
+      return (
+        <TableRow key={submission.id}>
+          <TableCell>
+            <div className="font-medium">{submission.title ?? "Untitled submission"}</div>
+            <div className="text-xs text-muted-foreground">{project?.title ?? submission.projectId}</div>
+          </TableCell>
+          <TableCell>
+            <div className="font-medium">{participantProfile?.fullName ?? submission.participantId}</div>
+            <div className="text-xs text-muted-foreground">{participantProfile?.email ?? "No email"}</div>
+          </TableCell>
+          <TableCell>
+            <Badge variant={statusVariant(submission.status)} className="uppercase">
+              {submission.status.replace("_", " ")}
+            </Badge>
+          </TableCell>
+          <TableCell className="text-sm text-muted-foreground">
+            {submission.reviewedAt ? new Date(submission.reviewedAt).toLocaleString() : "Awaiting review"}
+          </TableCell>
+          <TableCell className="text-sm text-muted-foreground">
+            {submission.submittedAt ? new Date(submission.submittedAt).toLocaleString() : "Unknown"}
+          </TableCell>
+          <TableCell className="flex flex-col items-end gap-2">
+            {submission.reviewNote && (
+              <p className="max-w-xs text-right text-xs text-muted-foreground">Note: {submission.reviewNote}</p>
+            )}
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setActiveSubmission(submission)}
+              >
+                Review
+              </Button>
+            </div>
+          </TableCell>
+        </TableRow>
+      );
+    });
+  }, [loadingSubmissions, submissionsError, submissions, profileQuery.data, projectLookup]);
+
+  const projectFilterOptions = [
+    <SelectItem key="all" value="all">
+      All projects
+    </SelectItem>,
+    ...projects.map(project => (
+      <SelectItem key={project.id} value={project.id}>
+        {project.title}
+      </SelectItem>
+    )),
+  ];
+
+  const statusFilterOptions = [
+    <SelectItem key="all" value="all">
+      All statuses
+    </SelectItem>,
+    <SelectItem key="submitted" value="submitted">
+      Submitted
+    </SelectItem>,
+    <SelectItem key="accepted" value="accepted">
+      Accepted
+    </SelectItem>,
+    <SelectItem key="needs_changes" value="needs_changes">
+      Needs changes
+    </SelectItem>,
+  ];
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+      <Card>
+        <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-1">
+            <CardTitle>Research submissions</CardTitle>
+            <CardDescription>Review participant uploads, approve results, or request follow-up.</CardDescription>
+          </div>
+          <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-end sm:justify-end">
+            <div className="sm:w-44">
+              <Select value={projectFilter} onValueChange={value => setProjectFilter(value)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Filter by project" />
+                </SelectTrigger>
+                <SelectContent>{projectFilterOptions}</SelectContent>
+              </Select>
+            </div>
+            <div className="sm:w-44">
+              <Select value={statusFilter} onValueChange={value => setStatusFilter(value as StatusFilterOption)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Filter by status" />
+                </SelectTrigger>
+                <SelectContent>{statusFilterOptions}</SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Submission</TableHead>
+                  <TableHead>Participant</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Reviewed</TableHead>
+                  <TableHead>Submitted</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>{rows}</TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={Boolean(activeSubmission)} onOpenChange={open => !open && setActiveSubmission(null)}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Review submission</DialogTitle>
+          </DialogHeader>
+          {activeSubmission ? (
+            <form
+              onSubmit={event => {
+                event.preventDefault();
+                void form.handleSubmit(values => reviewMutation.mutate(values))(event);
+              }}
+              className="space-y-4"
+            >
+              <div>
+                <p className="text-sm font-medium">{activeSubmission.title ?? "Untitled submission"}</p>
+                {activeSubmission.description && (
+                  <p className="mt-1 text-sm text-muted-foreground">{activeSubmission.description}</p>
+                )}
+                {activeSubmission.storagePath && (
+                  <p className="mt-2 text-xs text-muted-foreground">Storage path: {activeSubmission.storagePath}</p>
+                )}
+              </div>
+              <div>
+                <label className="text-sm font-medium">Status</label>
+                <Select value={reviewStatus} onValueChange={value => form.setValue("status", value as ReviewFormValues["status"])}>
+                  <SelectTrigger className="mt-1">
+                    <SelectValue placeholder="Select status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="accepted">Accepted</SelectItem>
+                    <SelectItem value="needs_changes">Needs changes</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium" htmlFor="submission-note">
+                  Note to participant (optional)
+                </label>
+                <Textarea
+                  id="submission-note"
+                  rows={4}
+                  placeholder="Share feedback or next steps"
+                  {...form.register("note")}
+                />
+              </div>
+              <DialogFooter>
+                <Button type="submit" disabled={reviewMutation.isPending}>
+                  {reviewMutation.isPending ? "Saving…" : "Save review"}
+                </Button>
+              </DialogFooter>
+            </form>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/admin/research/profileHelpers.ts
+++ b/src/pages/admin/research/profileHelpers.ts
@@ -1,0 +1,37 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface AdminProfileSummary {
+  id: string;
+  fullName: string | null;
+  email: string | null;
+}
+
+export async function fetchProfilesByIds(userIds: string[]): Promise<Map<string, AdminProfileSummary>> {
+  if (userIds.length === 0) {
+    return new Map();
+  }
+
+  const uniqueIds = Array.from(new Set(userIds.filter(Boolean)));
+  if (uniqueIds.length === 0) {
+    return new Map();
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id,full_name,email")
+    .in("id", uniqueIds);
+
+  if (error) {
+    throw new Error(error.message || "Failed to load user profiles");
+  }
+
+  const map = new Map<string, AdminProfileSummary>();
+  for (const row of data ?? []) {
+    map.set(row.id, {
+      id: row.id,
+      fullName: row.full_name ?? null,
+      email: row.email ?? null,
+    });
+  }
+  return map;
+}

--- a/src/pages/admin/research/queries.ts
+++ b/src/pages/admin/research/queries.ts
@@ -1,0 +1,26 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { ResearchProject } from "@/types/platform";
+
+export const PROJECT_QUERY_KEY = ["admin", "research", "projects"] as const;
+
+export async function fetchResearchProjects(): Promise<ResearchProject[]> {
+  const { data, error } = await supabase
+    .from("research_projects")
+    .select("id,title,slug,summary,status,visibility,created_by,created_at")
+    .order("created_at", { ascending: false, nullsLast: true });
+
+  if (error) {
+    throw new Error(error.message || "Failed to load research projects");
+  }
+
+  return (data ?? []).map(record => ({
+    id: String(record.id ?? ""),
+    title: record.title ?? "Untitled project",
+    slug: record.slug ?? null,
+    summary: record.summary ?? null,
+    status: (record.status as ResearchProject["status"]) ?? "open",
+    visibility: (record.visibility as ResearchProject["visibility"]) ?? "list_public",
+    createdBy: record.created_by ?? null,
+    createdAt: record.created_at ?? new Date().toISOString(),
+  }));
+}

--- a/supabase/migrations/20251201000000_add_review_note_and_submission_notifications.sql
+++ b/supabase/migrations/20251201000000_add_review_note_and_submission_notifications.sql
@@ -1,0 +1,26 @@
+-- Add optional review note for research submissions and extend notification support
+alter table public.research_submissions
+  add column if not exists review_note text;
+
+-- Allow notifications for submission reviews
+alter table public.notifications
+  drop constraint if exists notifications_type_check;
+
+alter table public.notifications
+  add constraint notifications_type_check
+    check (
+      type in (
+        'resource_approved',
+        'blogpost_approved',
+        'research_application_approved',
+        'comment_reply',
+        'research_submission_reviewed'
+      )
+    );
+
+-- Track preferences for submission review notifications
+alter table public.notification_prefs
+  add column if not exists research_submission_reviewed boolean not null default true;
+
+update public.notification_prefs
+  set research_submission_reviewed = coalesce(research_submission_reviewed, true);

--- a/test/lib-happy-path.test.ts
+++ b/test/lib-happy-path.test.ts
@@ -378,6 +378,7 @@ describe("notification helpers", () => {
     resource_approved: true,
     blogpost_approved: true,
     research_application_approved: true,
+    research_submission_reviewed: true,
     comment_reply: true,
     updated_at: "2024-01-11T00:00:00Z",
   };
@@ -457,6 +458,7 @@ describe("research helpers", () => {
     status: "submitted",
     reviewed_by: null,
     reviewed_at: null,
+    review_note: null,
     submitted_at: "2024-02-04T00:00:00Z",
   };
 

--- a/types/platform.ts
+++ b/types/platform.ts
@@ -68,6 +68,7 @@ export type NotificationType =
   | "resource_approved"
   | "blogpost_approved"
   | "research_application_approved"
+  | "research_submission_reviewed"
   | "comment_reply";
 
 export interface Notification {
@@ -86,6 +87,7 @@ export interface NotificationPrefs {
   resourceApproved: boolean;
   blogpostApproved: boolean;
   researchApplicationApproved: boolean;
+  researchSubmissionReviewed: boolean;
   commentReply: boolean;
   updatedAt: string;
 }
@@ -158,5 +160,6 @@ export interface ResearchSubmission {
   status: ResearchSubmissionStatus;
   reviewedBy: string | null;
   reviewedAt: string | null;
+  reviewNote: string | null;
   submittedAt: string | null;
 }


### PR DESCRIPTION
## Summary
- add admin dashboards to create research projects, upload documents, manage participants, and review submissions
- extend research submission workflow with review notes, notifications, and Supabase schema updates
- wire new admin pages into navigation and update shared types and tests

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d171ff04d883318d5665764033ca15