### PR TITLE
Apply aerospace orange theme and simplify hero title

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,98 +8,94 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-    /* Futuristic tech colors */
-    --background: 222 47% 11%;
-    --foreground: 210 40% 98%;
-    
-    --card: 217 33% 17%;
-    --card-foreground: 210 40% 98%;
-    
-    --popover: 222 47% 11%;
-    --popover-foreground: 210 40% 98%;
-    
-    /* Primary - Electric cyan for futuristic feel */
-    --primary: 198 100% 50%;
-    --primary-foreground: 222 47% 11%;
-    
-    /* Secondary - Neon purple */
-    --secondary: 280 100% 65%;
-    --secondary-foreground: 222 47% 11%;
-    
-    --muted: 217 33% 17%;
-    --muted-foreground: 215 20% 65%;
-    
-    --accent: 162 100% 50%;
-    --accent-foreground: 222 47% 11%;
-    
-    --destructive: 350 100% 60%;
-    --destructive-foreground: 210 40% 98%;
-    
-    --border: 217 33% 25%;
-    --input: 217 33% 17%;
-    --ring: 198 100% 50%;
-    
+    /* Brand palette inspired by aerospace orange */
+    --background: 51 54% 3%; /* Smoky black */
+    --foreground: 0 0% 100%; /* White */
+
+    --card: 51 40% 8%;
+    --card-foreground: 0 0% 100%;
+
+    --popover: 51 54% 3%;
+    --popover-foreground: 0 0% 100%;
+
+    --primary: 19 100% 50%; /* Aerospace orange */
+    --primary-foreground: 51 54% 3%;
+
+    --secondary: 31 100% 50%; /* UT orange */
+    --secondary-foreground: 51 54% 3%;
+
+    --muted: 51 30% 15%;
+    --muted-foreground: 44 35% 75%;
+
+    --accent: 45 100% 58%; /* Sun glow */
+    --accent-foreground: 51 54% 3%;
+
+    --destructive: 2 74% 52%;
+    --destructive-foreground: 0 0% 100%;
+
+    --border: 51 25% 18%;
+    --input: 51 25% 18%;
+    --ring: 19 100% 50%;
+
     --radius: 0.75rem;
 
     /* Custom properties for glowing effects */
-    --glow-primary: 198 100% 50%;
-    --glow-secondary: 280 100% 65%;
-    --glow-accent: 162 100% 50%;
-    
-    --sidebar-background: 222 47% 9%;
-    --sidebar-foreground: 210 40% 90%;
-    --sidebar-primary: 198 100% 50%;
-    --sidebar-primary-foreground: 222 47% 11%;
-    --sidebar-accent: 217 33% 17%;
-    --sidebar-accent-foreground: 210 40% 90%;
-    --sidebar-border: 217 33% 25%;
-    --sidebar-ring: 198 100% 50%;
+    --glow-primary: 19 100% 50%;
+    --glow-secondary: 31 100% 50%;
+    --glow-accent: 45 100% 58%;
+
+    --sidebar-background: 51 54% 2%;
+    --sidebar-foreground: 0 0% 96%;
+    --sidebar-primary: 19 100% 50%;
+    --sidebar-primary-foreground: 51 54% 3%;
+    --sidebar-accent: 51 30% 12%;
+    --sidebar-accent-foreground: 0 0% 96%;
+    --sidebar-border: 51 25% 18%;
+    --sidebar-ring: 19 100% 50%;
   }
 
   .light {
-    --background: 210 40% 98%;
-    --foreground: 222 47% 11%;
-    
+    --background: 44 100% 92%; /* Crosstik */
+    --foreground: 51 54% 3%;
+
     --card: 0 0% 100%;
-    --card-foreground: 222 47% 11%;
-    
+    --card-foreground: 51 54% 3%;
+
     --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 11%;
-    
-    /* Primary - Deep tech blue for light mode */
-    --primary: 198 100% 35%;
-    --primary-foreground: 210 40% 98%;
-    
-    /* Secondary - Purple for light mode */
-    --secondary: 280 100% 50%;
-    --secondary-foreground: 210 40% 98%;
-    
-    --muted: 210 40% 96%;
-    --muted-foreground: 215 16% 47%;
-    
-    --accent: 162 100% 40%;
-    --accent-foreground: 210 40% 98%;
-    
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 210 40% 98%;
-    
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 198 100% 35%;
-    
+    --popover-foreground: 51 54% 3%;
+
+    --primary: 19 100% 45%;
+    --primary-foreground: 0 0% 100%;
+
+    --secondary: 31 100% 48%;
+    --secondary-foreground: 0 0% 100%;
+
+    --muted: 44 60% 80%;
+    --muted-foreground: 31 40% 35%;
+
+    --accent: 45 100% 55%;
+    --accent-foreground: 51 54% 3%;
+
+    --destructive: 2 74% 52%;
+    --destructive-foreground: 0 0% 100%;
+
+    --border: 44 45% 75%;
+    --input: 44 45% 75%;
+    --ring: 19 100% 45%;
+
     /* Custom properties for glowing effects */
-    --glow-primary: 198 100% 35%;
-    --glow-secondary: 280 100% 50%;
-    --glow-accent: 162 100% 40%;
-    
-    --sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 5% 26%;
-    --sidebar-primary: 198 100% 35%;
-    --sidebar-primary-foreground: 210 40% 98%;
-    --sidebar-accent: 240 5% 96%;
-    --sidebar-accent-foreground: 240 6% 10%;
-    --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 198 100% 35%;
+    --glow-primary: 19 100% 45%;
+    --glow-secondary: 31 100% 48%;
+    --glow-accent: 45 100% 55%;
+
+    --sidebar-background: 44 100% 94%;
+    --sidebar-foreground: 51 54% 3%;
+    --sidebar-primary: 19 100% 45%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 44 70% 85%;
+    --sidebar-accent-foreground: 51 54% 3%;
+    --sidebar-border: 44 45% 75%;
+    --sidebar-ring: 19 100% 45%;
   }
 }
 
@@ -113,7 +109,7 @@ All colors MUST be HSL.
   }
   
   h1, h2, h3, h4, h5, h6 {
-    @apply font-orbitron;
+    @apply font-orbitron text-white;
   }
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -172,10 +172,8 @@ const Index = () => {
               <span className="text-sm font-medium text-primary">{t.hero.subtitle}</span>
             </div>
             
-            <h1 className="mb-6 font-orbitron text-6xl font-bold tracking-tight text-foreground sm:text-7xl lg:text-8xl animate-in fade-in slide-in-from-bottom-4 duration-1000">
-              <span className="bg-gradient-to-r from-primary via-accent to-secondary bg-clip-text text-transparent animate-shimmer bg-[length:200%_100%]">
-                {t.hero.title}
-              </span>
+            <h1 className="mb-6 font-orbitron text-6xl font-bold tracking-tight text-white sm:text-7xl lg:text-8xl animate-in fade-in slide-in-from-bottom-4 duration-1000">
+              {t.hero.title}
             </h1>
             
             <p className="mb-8 text-xl text-muted-foreground font-space animate-in fade-in slide-in-from-bottom-4 duration-1000 delay-150">


### PR DESCRIPTION
## Summary
- retheme the global design tokens to use an aerospace-orange palette with smoky black backgrounds and white typography accents
- update base heading styles to enforce white titles and refresh sidebar color tokens for the new look
- simplify the home hero title styling to remove the glowing gradient in favour of solid white text

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3e69a25848331a02f79809cf6a143