### PR TITLE
Revamp dashboard navigation and layout

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,8 +2,18 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
-import { Menu, Search, User, LogOut, Languages, BookOpen } from "lucide-react";
-import { useState, useEffect } from "react";
+import {
+  Menu,
+  Search,
+  User,
+  LogOut,
+  Languages,
+  BookOpen,
+  LayoutDashboard,
+  SquarePen,
+  GraduationCap,
+} from "lucide-react";
+import { useState, useEffect, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/integrations/supabase/client";
 import { User as SupabaseUser } from "@supabase/supabase-js";
@@ -37,14 +47,22 @@ const Navigation = () => {
     return () => subscription.unsubscribe();
   }, []);
 
-  const navItems = [
-    { name: t.nav.home, path: "/" },
-    { name: t.nav.blog, path: "/blog" },
-    { name: t.nav.builder, path: "/lesson-builder" },
-    { name: t.nav.events, path: "/events" },
-    { name: t.nav.services, path: "/services" },
-    { name: t.nav.about, path: "/about" },
-  ];
+  const navItems = useMemo(() => {
+    const items = [
+      { name: t.nav.home, path: "/" },
+      { name: t.nav.blog, path: "/blog" },
+      { name: t.nav.builder, path: "/lesson-builder" },
+      { name: t.nav.events, path: "/events" },
+      { name: t.nav.services, path: "/services" },
+      { name: t.nav.about, path: "/about" },
+    ];
+
+    if (user) {
+      items.splice(1, 0, { name: t.nav.profile, path: "/account" });
+    }
+
+    return items;
+  }, [t.nav.about, t.nav.blog, t.nav.builder, t.nav.events, t.nav.home, t.nav.profile, t.nav.services, user]);
   
   const getLocalizedNavPath = (path: string) => {
     return getLocalizedPath(path, language);
@@ -158,8 +176,20 @@ const Navigation = () => {
                   <DropdownMenuItem
                     onClick={() => navigate(getLocalizedNavPath("/account"))}
                   >
-                    <User className="mr-2 h-4 w-4" />
+                    <LayoutDashboard className="mr-2 h-4 w-4" />
                     {t.nav.profile}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => navigate(getLocalizedNavPath("/lesson-builder"))}
+                  >
+                    <SquarePen className="mr-2 h-4 w-4" />
+                    {t.nav.builder}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => navigate(getLocalizedNavPath("/account?tab=classes"))}
+                  >
+                    <GraduationCap className="mr-2 h-4 w-4" />
+                    {t.account.tabs.classes}
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={handleSignOut}>
@@ -257,6 +287,22 @@ const Navigation = () => {
                     >
                       <Button className="w-full" variant="secondary">
                         {t.nav.profile}
+                      </Button>
+                    </Link>
+                    <Link
+                      to={getLocalizedNavPath("/lesson-builder")}
+                      onClick={() => setIsOpen(false)}
+                    >
+                      <Button className="w-full" variant="outline">
+                        {t.nav.builder}
+                      </Button>
+                    </Link>
+                    <Link
+                      to={getLocalizedNavPath("/account?tab=classes")}
+                      onClick={() => setIsOpen(false)}
+                    >
+                      <Button className="w-full" variant="outline">
+                        {t.account.tabs.classes}
                       </Button>
                     </Link>
                     <Button

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -15,7 +15,7 @@ export const en = {
     signIn: "Sign In",
     signUp: "Sign Up",
     signOut: "Sign Out",
-    profile: "Profile"
+    profile: "My Dashboard"
   },
   hero: {
     title: "Empowering Education Through Innovation",
@@ -1303,9 +1303,12 @@ export const en = {
     },
     tabs: {
       overview: "Overview",
-      savedPosts: "Saved posts",
+      classes: "Classes",
+      lessonPlans: "Lesson Plans",
+      savedPosts: "Saved Posts",
+      activity: "Activity",
       security: "Security",
-      activity: "Activity"
+      settings: "Settings"
     },
     profile: {
       title: "Profile details",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -15,7 +15,7 @@ export const sq = {
     signIn: "Hyr",
     signUp: "Regjistrohu",
     signOut: "Dil",
-    profile: "Profili"
+    profile: "Pulti Im"
   },
   hero: {
     title: "Fuqizimi i Arsimit përmes Inovacionit",
@@ -1303,9 +1303,12 @@ export const sq = {
     },
     tabs: {
       overview: "Përmbledhje",
+      classes: "Klasat",
+      lessonPlans: "Planet e mësimit",
       savedPosts: "Postimet e ruajtura",
+      activity: "Aktiviteti",
       security: "Siguria",
-      activity: "Aktiviteti"
+      settings: "Cilësimet"
     },
     profile: {
       title: "Detajet e profilit",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -15,7 +15,7 @@ export const vi = {
     signIn: "Đăng nhập",
     signUp: "Đăng ký",
     signOut: "Đăng xuất",
-    profile: "Hồ sơ"
+    profile: "Bảng điều khiển của tôi"
   },
   hero: {
     title: "Trao quyền cho giáo dục thông qua đổi mới",
@@ -1303,9 +1303,12 @@ export const vi = {
     },
     tabs: {
       overview: "Tổng quan",
+      classes: "Lớp học",
+      lessonPlans: "Kế hoạch bài học",
       savedPosts: "Bài viết đã lưu",
+      activity: "Hoạt động",
       security: "Bảo mật",
-      activity: "Hoạt động"
+      settings: "Cài đặt"
     },
     profile: {
       title: "Thông tin hồ sơ",


### PR DESCRIPTION
## Summary
- reposition the My Dashboard link next to Home and expand the signed-in menu with quick links to classes and the lesson builder
- reorganize the account dashboard layout with a top-right profile card, borderless tabs, updated tab order, and new Activity/Security content
- enhance class creation with a calendar-based start date picker, time input, and translation updates for the new navigation labels

## Testing
- npm run lint *(warnings only from existing lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d735bc6083319822d532778deff3