### PR TITLE
Add calendar filtering for class lessons

### DIFF
--- a/src/pages/account/components/UpcomingLessonsCard.tsx
+++ b/src/pages/account/components/UpcomingLessonsCard.tsx
@@ -50,7 +50,7 @@ export const UpcomingLessonsCard = ({ isEnabled, className }: UpcomingLessonsCar
 
   const query = useQuery({
     queryKey: ["upcoming-lesson-plans"],
-    queryFn: () => listUpcomingLessonPlans(),
+    queryFn: () => listUpcomingLessonPlans(5),
     enabled: isEnabled,
     staleTime: 1000 * 60 * 5,
   });


### PR DESCRIPTION
## Summary
- show the next scheduled lesson plans in the dashboard overview card with direct lesson builder links
- normalize optional date filters in `listClassLessonPlans` so Supabase queries can target a single day
- add a calendar-driven filter experience in class details with clear highlighting and filter controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4dc700ba88331b0ac21faa9cfa94f