### PR TITLE
Add research opt-in card and harden lesson builder scaffolding

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -63,15 +63,35 @@ export const LocalizedRoutes = () => {
       <Route path="/services" element={<RouteWrapper><Services /></RouteWrapper>} />
       <Route path="/blog" element={<RouteWrapper><Blog /></RouteWrapper>} />
       <Route path="/blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
-      <Route path="/builder/lesson-plans" element={<RouteWrapper><BuilderLessonPlan /></RouteWrapper>} />
-      <Route path="/builder/lesson-plans/:id" element={<RouteWrapper><BuilderLessonPlanDetail /></RouteWrapper>} />
+      <Route
+        path="/builder/lesson-plans"
+        element={
+          <RouteWrapper>
+            <AuthGuard>
+              <BuilderLessonPlan />
+            </AuthGuard>
+          </RouteWrapper>
+        }
+      />
+      <Route
+        path="/builder/lesson-plans/:id"
+        element={
+          <RouteWrapper>
+            <AuthGuard>
+              <BuilderLessonPlanDetail />
+            </AuthGuard>
+          </RouteWrapper>
+        }
+      />
       <Route path="/lesson-plans/builder" element={<LegacyBuilderRedirect />} />
       <Route path="/lesson-plans/builder/:id" element={<LegacyBuilderRedirect />} />
       <Route
         path="/lesson-builder"
         element={
           <RouteWrapper>
-            <LessonBuilderPage />
+            <AuthGuard>
+              <LessonBuilderPage />
+            </AuthGuard>
           </RouteWrapper>
         }
       />
@@ -136,15 +156,35 @@ export const LocalizedRoutes = () => {
         <Route path="services" element={<RouteWrapper><Services /></RouteWrapper>} />
         <Route path="blog" element={<RouteWrapper><Blog /></RouteWrapper>} />
         <Route path="blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
-        <Route path="builder/lesson-plans" element={<RouteWrapper><BuilderLessonPlan /></RouteWrapper>} />
-        <Route path="builder/lesson-plans/:id" element={<RouteWrapper><BuilderLessonPlanDetail /></RouteWrapper>} />
+        <Route
+          path="builder/lesson-plans"
+          element={
+            <RouteWrapper>
+              <AuthGuard>
+                <BuilderLessonPlan />
+              </AuthGuard>
+            </RouteWrapper>
+          }
+        />
+        <Route
+          path="builder/lesson-plans/:id"
+          element={
+            <RouteWrapper>
+              <AuthGuard>
+                <BuilderLessonPlanDetail />
+              </AuthGuard>
+            </RouteWrapper>
+          }
+        />
         <Route path="lesson-plans/builder" element={<LegacyBuilderRedirect includeLanguage />} />
         <Route path="lesson-plans/builder/:id" element={<LegacyBuilderRedirect includeLanguage />} />
         <Route
           path="lesson-builder"
           element={
             <RouteWrapper>
-              <LessonBuilderPage />
+              <AuthGuard>
+                <LessonBuilderPage />
+              </AuthGuard>
             </RouteWrapper>
           }
         />

--- a/src/components/classes/ClassLessonPlanViewer.tsx
+++ b/src/components/classes/ClassLessonPlanViewer.tsx
@@ -16,22 +16,6 @@ import { AttachLessonPlanDialog } from "@/components/classes/AttachLessonPlanDia
 import { useLanguage } from "@/contexts/LanguageContext";
 import { Calendar } from "@/components/ui/calendar";
 
-const formatDisplayDate = (value: string | null) => {
-  if (!value) {
-    return "No scheduled date";
-  }
-
-  try {
-    const parsed = parseISO(value);
-    if (!isValid(parsed)) {
-      return "No scheduled date";
-    }
-    return `Scheduled for ${format(parsed, "PPP")}`;
-  } catch {
-    return "No scheduled date";
-  }
-};
-
 export interface ClassLessonPlanViewerProps {
   classId: string;
   onUnlink: (lessonPlanId: string) => void;
@@ -54,6 +38,26 @@ export function ClassLessonPlanViewer({
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const { t } = useLanguage();
+
+  const formatPlanDate = (value: string | null) => {
+    if (!value) {
+      return t.account.classes.viewer.noScheduledDate;
+    }
+
+    try {
+      const parsed = parseISO(value);
+      if (!isValid(parsed)) {
+        return t.account.classes.viewer.noScheduledDate;
+      }
+
+      return t.account.classes.viewer.scheduledFor.replace(
+        "{date}",
+        format(parsed, "PPP"),
+      );
+    } catch {
+      return t.account.classes.viewer.noScheduledDate;
+    }
+  };
 
   useEffect(() => {
     setSelectedDate(undefined);
@@ -188,7 +192,9 @@ export function ClassLessonPlanViewer({
           }}
           className="mx-auto"
         />
-        <p className="mt-3 text-center text-xs text-muted-foreground">Select a date to filter plans.</p>
+        <p className="mt-3 text-center text-xs text-muted-foreground">
+          {t.account.classes.viewer.calendarHelper}
+        </p>
         <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <Button
             type="button"
@@ -197,7 +203,7 @@ export function ClassLessonPlanViewer({
             onClick={handleClearFilter}
             disabled={!selectedDate}
           >
-            Show all plans
+            {t.account.classes.viewer.showAll}
           </Button>
           <Button
             type="button"
@@ -205,11 +211,13 @@ export function ClassLessonPlanViewer({
             onClick={() => setIsAttachDialogOpen(true)}
           >
             <PlusCircle className="mr-2 h-4 w-4" />
-            Attach existing plan
+            {t.account.classes.viewer.attachExisting}
           </Button>
         </div>
       </div>
-      {isRefetching ? <p className="text-xs text-muted-foreground">Updating results…</p> : null}
+      {isRefetching ? (
+        <p className="text-xs text-muted-foreground">{t.account.classes.viewer.updating}</p>
+      ) : null}
 
       <ScrollArea className="h-[60vh] pr-2">
         {isPending ? (
@@ -219,12 +227,12 @@ export function ClassLessonPlanViewer({
           </div>
         ) : error ? (
           <Alert variant="destructive">
-            <AlertTitle>Unable to load linked plans</AlertTitle>
+            <AlertTitle>{t.account.classes.viewer.errorTitle}</AlertTitle>
             <AlertDescription>
-              {error.message}
+              {error.message || t.account.classes.viewer.errorDescription}
               <div className="mt-4">
                 <Button variant="outline" size="sm" onClick={() => refetch()}>
-                  Try again
+                  {t.account.classes.viewer.retry}
                 </Button>
               </div>
             </AlertDescription>
@@ -236,13 +244,18 @@ export function ClassLessonPlanViewer({
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <p className="font-medium">{plan.title}</p>
-                    <p className="text-sm text-muted-foreground">{formatDisplayDate(plan.date)}</p>
+                    <p className="text-sm text-muted-foreground">{formatPlanDate(plan.date)}</p>
                     {plan.duration ? (
-                      <p className="text-sm text-muted-foreground">Duration: {plan.duration}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {t.account.classes.viewer.durationLabel.replace("{duration}", plan.duration)}
+                      </p>
                     ) : null}
                     {plan.addedAt ? (
                       <p className="mt-2 text-xs text-muted-foreground/80">
-                        Linked on {format(new Date(plan.addedAt), "PPP p")}
+                        {t.account.classes.viewer.linkedOn.replace(
+                          "{date}",
+                          format(new Date(plan.addedAt), "PPP p"),
+                        )}
                       </p>
                     ) : null}
                   </div>
@@ -251,15 +264,15 @@ export function ClassLessonPlanViewer({
                     size="sm"
                     onClick={() => onUnlink(plan.id)}
                     disabled={isUnlinking && unlinkingPlanId === plan.id}
-                  >
-                    {isUnlinking && unlinkingPlanId === plan.id ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <>
-                        <Unlink className="mr-2 h-4 w-4" />
-                        Unlink
-                      </>
-                    )}
+                    >
+                      {isUnlinking && unlinkingPlanId === plan.id ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <>
+                          <Unlink className="mr-2 h-4 w-4" />
+                          {t.account.classes.viewer.unlink}
+                        </>
+                      )}
                   </Button>
                 </div>
               </div>
@@ -267,8 +280,8 @@ export function ClassLessonPlanViewer({
           </div>
         ) : (
           <div className="rounded-lg border border-dashed bg-muted/40 p-8 text-center text-sm text-muted-foreground">
-            <p>No lesson plans match the current date filter.</p>
-            <p className="mt-2">Clear the filter or attach an existing plan using the button above.</p>
+            <p>{t.account.classes.viewer.emptyTitle}</p>
+            <p className="mt-2">{t.account.classes.viewer.emptyDescription}</p>
           </div>
         )}
       </ScrollArea>

--- a/src/components/classes/__tests__/ClassLessonPlanViewer.test.tsx
+++ b/src/components/classes/__tests__/ClassLessonPlanViewer.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { ClassLessonPlanViewer } from "../ClassLessonPlanViewer";
+import { en } from "@/translations/en";
+
+vi.mock("@/lib/classes", () => {
+  return {
+    listClassLessonPlans: vi.fn(),
+    linkPlanToClass: vi.fn(),
+  };
+});
+
+vi.mock("@/components/classes/AttachLessonPlanDialog", () => ({
+  AttachLessonPlanDialog: ({ open, onSelect }: { open: boolean; onSelect: (id: string) => void }) =>
+    open ? (
+      <div>
+        <button type="button" onClick={() => onSelect("new-plan")}>Link mock plan</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/ui/calendar", () => ({
+  Calendar: ({ onSelect }: { onSelect?: (date?: Date) => void }) => (
+    <button type="button" onClick={() => onSelect?.(new Date(2024, 0, 1))}>
+      Select date
+    </button>
+  ),
+}));
+
+vi.mock("@/contexts/LanguageContext", () => ({
+  useLanguage: () => ({ language: "en", t: en }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+const { listClassLessonPlans, linkPlanToClass } = await import("@/lib/classes");
+
+describe("ClassLessonPlanViewer", () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  beforeEach(() => {
+    (listClassLessonPlans as unknown as vi.Mock).mockResolvedValue([
+      {
+        id: "plan-1",
+        title: "Sample plan",
+        date: "2024-01-15",
+        duration: "45 minutes",
+        addedAt: "2024-01-10T08:00:00.000Z",
+      },
+    ]);
+    (linkPlanToClass as unknown as vi.Mock).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  const renderViewer = () =>
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ClassLessonPlanViewer classId="class-1" onUnlink={() => undefined} />
+      </QueryClientProvider>,
+    );
+
+  it("renders linked plans and enables the filter after selecting a date", async () => {
+    const user = userEvent.setup();
+    renderViewer();
+
+    expect(await screen.findByText("Sample plan")).toBeInTheDocument();
+
+    const showAllButton = screen.getByRole("button", { name: /show all plans/i });
+    expect(showAllButton).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /select date/i }));
+
+    expect(showAllButton).not.toBeDisabled();
+  });
+
+  it("calls linkPlanToClass when attaching a plan", async () => {
+    const user = userEvent.setup();
+    renderViewer();
+
+    expect(await screen.findByText("Sample plan")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /attach existing plan/i }));
+    await user.click(await screen.findByRole("button", { name: /link mock plan/i }));
+
+    expect(linkPlanToClass).toHaveBeenCalledWith("new-plan", "class-1");
+  });
+});
+

--- a/src/pages/Builder/index.tsx
+++ b/src/pages/Builder/index.tsx
@@ -1,0 +1,15 @@
+import { MemoryRouter } from "react-router-dom";
+
+import { LanguageProvider } from "@/contexts/LanguageContext";
+
+import LessonBuilderPage from "../lesson-builder/LessonBuilderPage";
+
+const BuilderPage = () => (
+  <MemoryRouter>
+    <LanguageProvider>
+      <LessonBuilderPage />
+    </LanguageProvider>
+  </MemoryRouter>
+);
+
+export default BuilderPage;

--- a/src/pages/account/__tests__/AccountDashboard.test.tsx
+++ b/src/pages/account/__tests__/AccountDashboard.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HelmetProvider } from "react-helmet-async";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import AccountDashboard from "../index";
+import { en } from "@/translations/en";
+
+vi.mock("@/hooks/useRequireAuth", () => ({
+  useRequireAuth: () => ({
+    user: {
+      id: "user-1",
+      email: "user@example.com",
+      user_metadata: {},
+    },
+    loading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useMyProfile", () => ({
+  useMyProfile: () => ({
+    fullName: "Alex Teacher",
+    schoolName: "Learning Academy",
+    schoolLogoUrl: null,
+  }),
+}));
+
+vi.mock("@/lib/classes", () => ({
+  listMyClasses: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/components/classes/ClassCreateDialog", () => ({
+  ClassCreateDialog: () => null,
+}));
+
+vi.mock("@/pages/account/components/UpcomingLessonsCard", () => ({
+  UpcomingLessonsCard: () => <div>Upcoming lessons card</div>,
+}));
+
+vi.mock("@/components/SEO", () => ({
+  SEO: () => null,
+}));
+
+vi.mock("@/contexts/LanguageContext", () => ({
+  useLanguage: () => ({ language: "en", t: en }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+describe("AccountDashboard overview", () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  afterEach(() => {
+    cleanup();
+    queryClient.clear();
+  });
+
+  const renderDashboard = () =>
+    render(
+      <HelmetProvider>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <AccountDashboard />
+          </MemoryRouter>
+        </QueryClientProvider>
+      </HelmetProvider>,
+    );
+
+  it("shows research teaser and publishing shortcuts", async () => {
+    renderDashboard();
+
+    expect(await screen.findByText(/Research & Applications/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Post a blog/i })).toHaveAttribute("href", "/blog/new");
+    expect(screen.getByRole("link", { name: /Ask a question/i })).toHaveAttribute("href", "/forum/new");
+  });
+});
+

--- a/src/pages/account/components/UpcomingLessonsCard.tsx
+++ b/src/pages/account/components/UpcomingLessonsCard.tsx
@@ -16,9 +16,9 @@ import {
 } from "@/lib/data/lesson-plans";
 import { cn } from "@/lib/utils";
 
-const formatLessonDate = (value: string | null): string => {
+const formatLessonDate = (value: string | null, fallback: string): string => {
   if (!value) {
-    return "Date TBD";
+    return fallback;
   }
 
   try {
@@ -32,8 +32,11 @@ const formatLessonDate = (value: string | null): string => {
   }
 };
 
-const createLessonSummary = (lesson: UpcomingLessonPlanListItem): string[] => {
-  const date = formatLessonDate(lesson.date);
+const createLessonSummary = (
+  lesson: UpcomingLessonPlanListItem,
+  fallbackDateLabel: string,
+): string[] => {
+  const date = formatLessonDate(lesson.date, fallbackDateLabel);
   const classTitle = lesson.classTitle.trim();
   const lessonTitle = lesson.lessonTitle.trim();
 
@@ -46,7 +49,7 @@ export type UpcomingLessonsCardProps = {
 };
 
 export const UpcomingLessonsCard = ({ isEnabled, className }: UpcomingLessonsCardProps) => {
-  const { language } = useLanguage();
+  const { language, t } = useLanguage();
 
   const query = useQuery({
     queryKey: ["upcoming-lesson-plans"],
@@ -76,28 +79,33 @@ export const UpcomingLessonsCard = ({ isEnabled, className }: UpcomingLessonsCar
     );
   } else if (query.isError) {
     const message =
-      query.error instanceof Error ? query.error.message : "Unable to load upcoming lessons.";
+      query.error instanceof Error
+        ? query.error.message
+        : t.account.overview.upcoming.errorDescription;
 
     content = (
       <Alert variant="destructive">
-        <AlertTitle>Unable to load upcoming lessons</AlertTitle>
+        <AlertTitle>{t.account.overview.upcoming.errorTitle}</AlertTitle>
         <AlertDescription>
           {message}
           <div className="mt-4">
             <Button size="sm" variant="outline" onClick={handleRetry}>
-              Try again
+              {t.account.overview.upcoming.retry}
             </Button>
           </div>
         </AlertDescription>
       </Alert>
     );
   } else if (lessons.length === 0) {
-    content = <p className="text-sm text-muted-foreground">No upcoming lessons scheduled.</p>;
+    content = (
+      <p className="text-sm text-muted-foreground">{t.account.overview.upcoming.empty}</p>
+    );
   } else {
+    const fallbackDateLabel = t.account.overview.upcoming.dateTbd;
     content = (
       <ul className="space-y-2">
         {lessons.map(lesson => {
-          const summarySegments = createLessonSummary(lesson);
+          const summarySegments = createLessonSummary(lesson, fallbackDateLabel);
           const lessonBuilderPath = getLocalizedPath(
             `/lesson-builder?id=${encodeURIComponent(lesson.lessonId)}`,
             language,
@@ -149,8 +157,8 @@ export const UpcomingLessonsCard = ({ isEnabled, className }: UpcomingLessonsCar
     >
       <CardHeader className="flex flex-row items-start justify-between gap-4">
         <div className="space-y-1">
-          <CardTitle className="text-xl font-semibold">Upcoming lessons</CardTitle>
-          <CardDescription>Stay ready for what&apos;s next on your teaching calendar.</CardDescription>
+          <CardTitle className="text-xl font-semibold">{t.account.overview.upcoming.title}</CardTitle>
+          <CardDescription>{t.account.overview.upcoming.description}</CardDescription>
         </div>
         <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary shadow-[0_0_25px_hsl(var(--glow-primary)/0.2)]">
           <CalendarDays className="h-5 w-5 animate-pulse-glow" aria-hidden="true" />

--- a/src/pages/account/components/__tests__/UpcomingLessonsCard.test.tsx
+++ b/src/pages/account/components/__tests__/UpcomingLessonsCard.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UpcomingLessonsCard } from "../UpcomingLessonsCard";
+import { en } from "@/translations/en";
+
+vi.mock("@/lib/data/lesson-plans", () => ({
+  listUpcomingLessonPlans: vi.fn(),
+}));
+
+vi.mock("@/contexts/LanguageContext", () => ({
+  useLanguage: () => ({ language: "en", t: en }),
+}));
+
+const { listUpcomingLessonPlans } = await import("@/lib/data/lesson-plans");
+
+describe("UpcomingLessonsCard", () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  beforeEach(() => {
+    (listUpcomingLessonPlans as unknown as vi.Mock).mockResolvedValue([
+      {
+        lessonId: "lesson-1",
+        classTitle: "STEM Club",
+        lessonTitle: "Robotics basics",
+        date: "2024-02-01",
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  const renderCard = () =>
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <UpcomingLessonsCard isEnabled className="" />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+  it("shows upcoming lessons with links", async () => {
+    renderCard();
+
+    const link = await screen.findByRole("link", { name: /Robotics basics/i });
+    expect(link).toHaveAttribute("href", "/lesson-builder?id=lesson-1");
+  });
+
+  it("renders empty state when there are no lessons", async () => {
+    (listUpcomingLessonPlans as unknown as vi.Mock).mockResolvedValueOnce([]);
+
+    renderCard();
+
+    expect(
+      await screen.findByText(/No upcoming lessons scheduled./i),
+    ).toBeInTheDocument();
+  });
+});
+

--- a/src/pages/lesson-builder/LessonBuilderPage.tsx
+++ b/src/pages/lesson-builder/LessonBuilderPage.tsx
@@ -29,6 +29,7 @@ import { useMyClasses } from "@/hooks/useMyClasses";
 import { linkPlanToClass } from "@/lib/classes";
 import { LessonMetaForm, type LessonMetaFormValue } from "./components/LessonMetaForm";
 import { LessonPreviewPane } from "./components/LessonPreviewPane";
+import { LessonPreview } from "@/components/lesson-draft/LessonPreview";
 import type { LessonPlanMetaDraft } from "./types";
 import { createLessonPlan, getLessonPlan, updateLessonPlan } from "./api";
 
@@ -533,8 +534,9 @@ const LessonBuilderPage = () => {
               <p className="mt-3 text-sm text-muted-foreground">
                 This pane mirrors what teachers see. As you update details, the summary refreshes automatically.
               </p>
-              <div className="mt-6">
+              <div className="mt-6 space-y-6">
                 <LessonPreviewPane meta={meta} profile={previewProfile} />
+                <LessonPreview />
               </div>
             </aside>
           </div>
@@ -585,17 +587,21 @@ const LessonBuilderPage = () => {
                   classes.length === 0
                 }
               >
-                <SelectTrigger aria-label="Link lesson plan to a class">
+                <SelectTrigger aria-label={t.lessonBuilder.classLinking.ariaLabel}>
                   <SelectValue
                     placeholder={
-                      isLoadingClasses ? "Loading classes..." : "Link to class"
+                      isLoadingClasses
+                        ? t.lessonBuilder.classLinking.loading
+                        : t.lessonBuilder.classLinking.placeholder
                     }
                   />
                 </SelectTrigger>
                 <SelectContent>
                   {classes.length === 0 ? (
                     <SelectItem value="no-classes" disabled>
-                      {isLoadingClasses ? "Loading classes..." : "No classes available"}
+                      {isLoadingClasses
+                        ? t.lessonBuilder.classLinking.loading
+                        : t.lessonBuilder.classLinking.noClasses}
                     </SelectItem>
                   ) : (
                     classes.map(classItem => (
@@ -608,8 +614,8 @@ const LessonBuilderPage = () => {
               </Select>
               <p className="mt-2 text-xs text-muted-foreground">
                 {isAuthenticated
-                  ? "Linking a class adds this lesson to their schedule."
-                  : "Sign in to link this lesson to one of your classes."}
+                  ? t.lessonBuilder.classLinking.signedInHelp
+                  : t.lessonBuilder.classLinking.signedOutHelp}
               </p>
             </div>
             <p className="text-xs text-muted-foreground">

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1253,6 +1253,14 @@ export const en = {
       errorDescription: "Please try again in a moment.",
       retryLabel: "Try again",
     },
+    classLinking: {
+      ariaLabel: "Link lesson plan to a class",
+      placeholder: "Link to class",
+      loading: "Loading classes...",
+      noClasses: "No classes available",
+      signedInHelp: "Linking a class adds this lesson to their schedule.",
+      signedOutHelp: "Sign in to link this lesson to one of your classes.",
+    },
     activities: {
       title: "Find activities",
       placeholder: "Search by topic, tool, or outcome",
@@ -1308,7 +1316,44 @@ export const en = {
       savedPosts: "Saved Posts",
       activity: "Activity",
       security: "Security",
-      settings: "Settings"
+      settings: "Settings",
+      research: "Research"
+    },
+    overview: {
+      title: "My Dashboard",
+      subtitle: "Here’s a personalized snapshot of your SchoolTech Hub activity and upcoming lessons.",
+      ctas: {
+        postBlog: "Post a blog",
+        askQuestion: "Ask a question",
+      },
+      upcoming: {
+        title: "Upcoming lessons",
+        description: "Stay ready for what's next on your teaching calendar.",
+        empty: "No upcoming lessons scheduled.",
+        errorTitle: "Unable to load upcoming lessons",
+        errorDescription: "Please try again in a moment.",
+        retry: "Try again",
+        dateTbd: "Date TBD",
+      },
+    },
+    research: {
+      badge: "Coming soon",
+      cardTitle: "Research & Applications",
+      cardDescription: "Preview our upcoming research hub for educators and partners.",
+      cardBody:
+        "Opt in to hear about pilot opportunities, classroom research, and application windows as soon as they open.",
+      toggleLabel: "Notify me when applications open",
+      toggleDescription: "We'll send an email when new research projects accept participants.",
+      toggleAria: "Toggle research application notifications",
+      notificationsEnabledTitle: "Notifications enabled",
+      notificationsEnabledDescription: "We'll let you know as soon as new research applications open.",
+      notificationsDisabledTitle: "Notifications updated",
+      notificationsDisabledDescription: "You won't receive updates about new research opportunities.",
+      errorTitle: "Unable to update preference",
+      errorDescription: "Please try again in a moment.",
+      tabTitle: "Research workspace",
+      tabDescription: "We're preparing a dedicated space for research collaboration and applications.",
+      tabHelper: "Check back soon for project listings and application tools.",
     },
     profile: {
       title: "Profile details",
@@ -1464,6 +1509,24 @@ export const en = {
         "Review your account activity regularly for unfamiliar changes.",
         "Sign out on shared devices after each session."
       ]
+    },
+    classes: {
+      viewer: {
+        calendarHelper: "Select a date to filter plans.",
+        showAll: "Show all plans",
+        attachExisting: "Attach existing plan",
+        updating: "Updating results…",
+        errorTitle: "Unable to load linked plans",
+        errorDescription: "Please try again in a moment.",
+        retry: "Try again",
+        noScheduledDate: "No scheduled date",
+        scheduledFor: "Scheduled for {date}",
+        durationLabel: "Duration: {duration}",
+        linkedOn: "Linked on {date}",
+        unlink: "Unlink",
+        emptyTitle: "No lesson plans match the current date filter.",
+        emptyDescription: "Clear the filter or attach an existing plan using the button above.",
+      },
     },
     savedPosts: {
       title: "Saved posts",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -1253,6 +1253,14 @@ export const sq = {
       errorDescription: "Ju lutemi provoni përsëri pas pak.",
       retryLabel: "Riprovo",
     },
+    classLinking: {
+      ariaLabel: "Link lesson plan to a class",
+      placeholder: "Link to class",
+      loading: "Loading classes...",
+      noClasses: "No classes available",
+      signedInHelp: "Linking a class adds this lesson to their schedule.",
+      signedOutHelp: "Sign in to link this lesson to one of your classes.",
+    },
     activities: {
       title: "Gjej aktivitete",
       placeholder: "Kërko sipas temës, mjetit ose rezultatit",
@@ -1308,7 +1316,44 @@ export const sq = {
       savedPosts: "Postimet e ruajtura",
       activity: "Aktiviteti",
       security: "Siguria",
-      settings: "Cilësimet"
+      settings: "Cilësimet",
+      research: "Kërkim"
+    },
+    overview: {
+      title: "My Dashboard",
+      subtitle: "Here’s a personalized snapshot of your SchoolTech Hub activity and upcoming lessons.",
+      ctas: {
+        postBlog: "Post a blog",
+        askQuestion: "Ask a question",
+      },
+      upcoming: {
+        title: "Upcoming lessons",
+        description: "Stay ready for what's next on your teaching calendar.",
+        empty: "No upcoming lessons scheduled.",
+        errorTitle: "Unable to load upcoming lessons",
+        errorDescription: "Please try again in a moment.",
+        retry: "Try again",
+        dateTbd: "Date TBD",
+      },
+    },
+    research: {
+      badge: "Coming soon",
+      cardTitle: "Research & Applications",
+      cardDescription: "Preview our upcoming research hub for educators and partners.",
+      cardBody:
+        "Opt in to hear about pilot opportunities, classroom research, and application windows as soon as they open.",
+      toggleLabel: "Notify me when applications open",
+      toggleDescription: "We'll send an email when new research projects accept participants.",
+      toggleAria: "Toggle research application notifications",
+      notificationsEnabledTitle: "Notifications enabled",
+      notificationsEnabledDescription: "We'll let you know as soon as new research applications open.",
+      notificationsDisabledTitle: "Notifications updated",
+      notificationsDisabledDescription: "You won't receive updates about new research opportunities.",
+      errorTitle: "Unable to update preference",
+      errorDescription: "Please try again in a moment.",
+      tabTitle: "Research workspace",
+      tabDescription: "We're preparing a dedicated space for research collaboration and applications.",
+      tabHelper: "Check back soon for project listings and application tools.",
     },
     profile: {
       title: "Detajet e profilit",
@@ -1464,6 +1509,24 @@ export const sq = {
         "Rishiko rregullisht aktivitetin e llogarisë për ndryshime të panjohura.",
         "Dil nga pajisjet e përbashkëta pasi të përfundosh."
       ]
+    },
+    classes: {
+      viewer: {
+        calendarHelper: "Select a date to filter plans.",
+        showAll: "Show all plans",
+        attachExisting: "Attach existing plan",
+        updating: "Updating results…",
+        errorTitle: "Unable to load linked plans",
+        errorDescription: "Please try again in a moment.",
+        retry: "Try again",
+        noScheduledDate: "No scheduled date",
+        scheduledFor: "Scheduled for {date}",
+        durationLabel: "Duration: {duration}",
+        linkedOn: "Linked on {date}",
+        unlink: "Unlink",
+        emptyTitle: "No lesson plans match the current date filter.",
+        emptyDescription: "Clear the filter or attach an existing plan using the button above.",
+      },
     },
     savedPosts: {
       title: "Postimet e ruajtura",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -1253,6 +1253,14 @@ export const vi = {
       errorDescription: "Vui lòng thử lại sau.",
       retryLabel: "Thử lại",
     },
+    classLinking: {
+      ariaLabel: "Link lesson plan to a class",
+      placeholder: "Link to class",
+      loading: "Loading classes...",
+      noClasses: "No classes available",
+      signedInHelp: "Linking a class adds this lesson to their schedule.",
+      signedOutHelp: "Sign in to link this lesson to one of your classes.",
+    },
     activities: {
       title: "Tìm hoạt động",
       placeholder: "Tìm theo chủ đề, công cụ hoặc kết quả",
@@ -1308,7 +1316,44 @@ export const vi = {
       savedPosts: "Bài viết đã lưu",
       activity: "Hoạt động",
       security: "Bảo mật",
-      settings: "Cài đặt"
+      settings: "Cài đặt",
+      research: "Nghiên cứu"
+    },
+    overview: {
+      title: "My Dashboard",
+      subtitle: "Here’s a personalized snapshot of your SchoolTech Hub activity and upcoming lessons.",
+      ctas: {
+        postBlog: "Post a blog",
+        askQuestion: "Ask a question",
+      },
+      upcoming: {
+        title: "Upcoming lessons",
+        description: "Stay ready for what's next on your teaching calendar.",
+        empty: "No upcoming lessons scheduled.",
+        errorTitle: "Unable to load upcoming lessons",
+        errorDescription: "Please try again in a moment.",
+        retry: "Try again",
+        dateTbd: "Date TBD",
+      },
+    },
+    research: {
+      badge: "Coming soon",
+      cardTitle: "Research & Applications",
+      cardDescription: "Preview our upcoming research hub for educators and partners.",
+      cardBody:
+        "Opt in to hear about pilot opportunities, classroom research, and application windows as soon as they open.",
+      toggleLabel: "Notify me when applications open",
+      toggleDescription: "We'll send an email when new research projects accept participants.",
+      toggleAria: "Toggle research application notifications",
+      notificationsEnabledTitle: "Notifications enabled",
+      notificationsEnabledDescription: "We'll let you know as soon as new research applications open.",
+      notificationsDisabledTitle: "Notifications updated",
+      notificationsDisabledDescription: "You won't receive updates about new research opportunities.",
+      errorTitle: "Unable to update preference",
+      errorDescription: "Please try again in a moment.",
+      tabTitle: "Research workspace",
+      tabDescription: "We're preparing a dedicated space for research collaboration and applications.",
+      tabHelper: "Check back soon for project listings and application tools.",
     },
     profile: {
       title: "Thông tin hồ sơ",
@@ -1464,6 +1509,24 @@ export const vi = {
         "Kiểm tra hoạt động tài khoản thường xuyên để phát hiện bất thường.",
         "Đăng xuất khỏi thiết bị dùng chung sau khi sử dụng."
       ]
+    },
+    classes: {
+      viewer: {
+        calendarHelper: "Select a date to filter plans.",
+        showAll: "Show all plans",
+        attachExisting: "Attach existing plan",
+        updating: "Updating results…",
+        errorTitle: "Unable to load linked plans",
+        errorDescription: "Please try again in a moment.",
+        retry: "Try again",
+        noScheduledDate: "No scheduled date",
+        scheduledFor: "Scheduled for {date}",
+        durationLabel: "Duration: {duration}",
+        linkedOn: "Linked on {date}",
+        unlink: "Unlink",
+        emptyTitle: "No lesson plans match the current date filter.",
+        emptyDescription: "Clear the filter or attach an existing plan using the button above.",
+      },
     },
     savedPosts: {
       title: "Bài viết đã lưu",


### PR DESCRIPTION
## Summary
- introduce the research opt-in card, publication CTAs, and translations for the account dashboard alongside new tests
- secure builder-related routes and supply the builder shim with the language context required for isolated tests
- refresh the lesson builder UI with step form controls, accessible resource triggers, and lesson preview rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4df04f1e88331be00defeb15dba4a