### PR TITLE
Remove non-English localization from web UI

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,198 +2,70 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-        http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+  http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
   <!-- Core English pages -->
   <url>
     <loc>https://schooltechhub.com/</loc>
-    <lastmod>2025-09-23</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/about</loc>
-    <lastmod>2025-09-23</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/services</loc>
-    <lastmod>2025-09-23</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/blog</loc>
-    <lastmod>2025-09-23</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/events</loc>
-    <lastmod>2025-09-23</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/contact</loc>
-    <lastmod>2025-09-23</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/faq</loc>
-    <lastmod>2025-09-23</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/auth</loc>
-    <lastmod>2025-09-23</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/sitemap</loc>
-    <lastmod>2025-09-23</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
-  </url>
-
-  <!-- Albanian localized pages -->
-  <url>
-    <loc>https://schooltechhub.com/sq</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/sq/about</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/sq/services</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/sq/blog</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/sq/events</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/sq/contact</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/sq/faq</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/sq/auth</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.3</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/sq/sitemap</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.3</priority>
-  </url>
-
-  <!-- Vietnamese localized pages -->
-  <url>
-    <loc>https://schooltechhub.com/vi</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/vi/about</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/vi/services</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/vi/blog</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/vi/events</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/vi/contact</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/vi/faq</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/vi/auth</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.3</priority>
-  </url>
-
-  <url>
-    <loc>https://schooltechhub.com/vi/sitemap</loc>
-    <lastmod>2025-09-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.3</priority>
   </url>
 
 </urlset>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -10,87 +10,32 @@ const outputPath = resolve(__dirname, "../public/sitemap.xml");
 const today = new Date().toISOString().split("T")[0];
 
 const basePages = [
-  {
-    path: "",
-    changefreq: "weekly",
-    priority: { en: "1.0", default: "0.7" },
-  },
-  {
-    path: "about",
-    changefreq: "monthly",
-    priority: { en: "0.8", default: "0.6" },
-  },
-  {
-    path: "services",
-    changefreq: "monthly",
-    priority: { en: "0.8", default: "0.6" },
-  },
-  {
-    path: "blog",
-    changefreq: "weekly",
-    priority: { en: "0.7", default: "0.6" },
-  },
-  {
-    path: "events",
-    changefreq: "weekly",
-    priority: { en: "0.7", default: "0.6" },
-  },
-  {
-    path: "contact",
-    changefreq: "monthly",
-    priority: { en: "0.5", default: "0.4" },
-  },
-  {
-    path: "faq",
-    changefreq: "monthly",
-    priority: { en: "0.5", default: "0.4" },
-  },
-  {
-    path: "auth",
-    changefreq: "monthly",
-    priority: { en: "0.4", default: "0.3" },
-  },
-  {
-    path: "sitemap",
-    changefreq: "monthly",
-    priority: { en: "0.4", default: "0.3" },
-  },
+  { path: "", changefreq: "weekly", priority: "1.0" },
+  { path: "about", changefreq: "monthly", priority: "0.8" },
+  { path: "services", changefreq: "monthly", priority: "0.8" },
+  { path: "blog", changefreq: "weekly", priority: "0.7" },
+  { path: "events", changefreq: "weekly", priority: "0.7" },
+  { path: "contact", changefreq: "monthly", priority: "0.5" },
+  { path: "faq", changefreq: "monthly", priority: "0.5" },
+  { path: "auth", changefreq: "monthly", priority: "0.4" },
+  { path: "sitemap", changefreq: "monthly", priority: "0.4" },
 ];
 
-const locales = [
-  { code: "en", label: "Core English pages", prefix: "" },
-  { code: "sq", label: "Albanian localized pages", prefix: "sq" },
-  { code: "vi", label: "Vietnamese localized pages", prefix: "vi" },
-];
-
-const buildUrl = (prefix, path) => {
-  const segments = [];
-  if (prefix) segments.push(prefix);
-  if (path) segments.push(path);
-  const joined = segments.filter(Boolean).join("/");
-  return joined ? `${siteUrl}/${joined}` : `${siteUrl}/`;
-};
-
-const sections = locales
-  .map(locale => {
-    const urls = basePages.map(page => {
-      const loc = buildUrl(locale.prefix, page.path);
-      const priority = locale.code === "en" ? page.priority.en : page.priority.default;
-      return [
-        "  <url>",
-        `    <loc>${loc}</loc>`,
-        `    <lastmod>${today}</lastmod>`,
-        `    <changefreq>${page.changefreq}</changefreq>`,
-        `    <priority>${priority}</priority>`,
-        "  </url>",
-      ].join("\n");
-    });
-
-    return [`  <!-- ${locale.label} -->`, urls.join("\n\n")].join("\n");
+const urls = basePages
+  .map(page => {
+    const loc = page.path ? `${siteUrl}/${page.path}` : `${siteUrl}/`;
+    return [
+      "  <url>",
+      `    <loc>${loc}</loc>`,
+      `    <lastmod>${today}</lastmod>`,
+      `    <changefreq>${page.changefreq}</changefreq>`,
+      `    <priority>${page.priority}</priority>`,
+      "  </url>",
+    ].join("\n");
   })
   .join("\n\n");
 
-const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9\n        http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">\n\n${sections}\n\n</urlset>\n`;
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9\n  http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">\n\n  <!-- Core English pages -->\n${urls}\n\n</urlset>\n`;
 
 await writeFile(outputPath, xml, "utf8");
 

--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -27,30 +27,19 @@ import Footer from '@/components/Footer';
 import AdminLayout from '@/pages/admin/AdminLayout';
 import AdminPage from '@/pages/admin/AdminPage';
 
-const RouteWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { lang } = useParams<{ lang?: string }>();
-  const validLangs = ['en', 'sq', 'vi'];
-  
-  // If lang is provided but invalid, redirect to English version
-  if (lang && !validLangs.includes(lang)) {
-    return <Navigate to="/" replace />;
-  }
-  
-  return (
-    <>
-      <Navigation />
-      {children}
-      <Footer />
-    </>
-  );
-};
+const RouteWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <>
+    <Navigation />
+    {children}
+    <Footer />
+  </>
+);
 
-const LegacyBuilderRedirect: React.FC<{ includeLanguage?: boolean }> = ({ includeLanguage = false }) => {
-  const params = useParams<{ lang?: string; id?: string }>();
-  const langPrefix = includeLanguage && params.lang ? `/${params.lang}` : '';
+const LegacyBuilderRedirect: React.FC = () => {
+  const params = useParams<{ id?: string }>();
   const destination = params.id
-    ? `${langPrefix}/builder/lesson-plans/${params.id}`
-    : `${langPrefix}/builder/lesson-plans`;
+    ? `/builder/lesson-plans/${params.id}`
+    : `/builder/lesson-plans`;
 
   return <Navigate to={destination} replace />;
 };
@@ -160,104 +149,11 @@ export const LocalizedRoutes = () => {
         <Route path=":segment/:subSegment/:child" element={<AdminPage />} />
       </Route>
 
-      {/* Localized routes for Albanian and Vietnamese */}
-      <Route path="/:lang">
-        <Route index element={<RouteWrapper><Index /></RouteWrapper>} />
-        <Route path="about" element={<RouteWrapper><About /></RouteWrapper>} />
-        <Route path="services" element={<RouteWrapper><Services /></RouteWrapper>} />
-        <Route path="blog" element={<RouteWrapper><Blog /></RouteWrapper>} />
-        <Route path="blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
-        <Route
-          path="builder/lesson-plans"
-          element={
-            <RouteWrapper>
-              <AuthGuard>
-                <BuilderLessonPlan />
-              </AuthGuard>
-            </RouteWrapper>
-          }
-        />
-        <Route
-          path="builder/lesson-plans/:id"
-          element={
-            <RouteWrapper>
-              <AuthGuard>
-                <BuilderLessonPlanDetail />
-              </AuthGuard>
-            </RouteWrapper>
-          }
-        />
-        <Route path="lesson-plans/builder" element={<LegacyBuilderRedirect includeLanguage />} />
-        <Route path="lesson-plans/builder/:id" element={<LegacyBuilderRedirect includeLanguage />} />
-        <Route
-          path="lesson-builder"
-          element={
-            <RouteWrapper>
-              <AuthGuard>
-                <LessonBuilderPage />
-              </AuthGuard>
-            </RouteWrapper>
-          }
-        />
-        <Route path="resources" element={<RouteWrapper><Resources /></RouteWrapper>} />
-        <Route path="events" element={<RouteWrapper><Events /></RouteWrapper>} />
-        <Route path="events/:slug" element={<RouteWrapper><EventDetail /></RouteWrapper>} />
-        <Route path="contact" element={<RouteWrapper><Contact /></RouteWrapper>} />
-        <Route path="faq" element={<RouteWrapper><FAQ /></RouteWrapper>} />
-        <Route path="auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
-        <Route
-          path="account"
-          element={
-            <RouteWrapper>
-              <AuthGuard>
-                <Account />
-              </AuthGuard>
-            </RouteWrapper>
-          }
-        />
-        <Route
-          path="account/classes/:id"
-          element={
-            <RouteWrapper>
-              <AuthGuard>
-                <ClassDashboard />
-              </AuthGuard>
-            </RouteWrapper>
-          }
-        />
-        <Route
-          path="account/resources"
-          element={
-            <RouteWrapper>
-              <AuthGuard>
-                <AccountResources />
-              </AuthGuard>
-            </RouteWrapper>
-          }
-        />
-        <Route
-          path="account/resources/new"
-          element={
-            <RouteWrapper>
-              <AuthGuard>
-                <AccountResourceNew />
-              </AuthGuard>
-            </RouteWrapper>
-          }
-        />
-        <Route
-          path="account/resources/:id"
-          element={
-            <RouteWrapper>
-              <AuthGuard>
-                <AccountResourceEdit />
-              </AuthGuard>
-            </RouteWrapper>
-          }
-        />
-        <Route path="sitemap" element={<RouteWrapper><Sitemap /></RouteWrapper>} />
-      </Route>
-      
+      <Route path="/sq" element={<Navigate to="/" replace />} />
+      <Route path="/sq/*" element={<Navigate to="/" replace />} />
+      <Route path="/vi" element={<Navigate to="/" replace />} />
+      <Route path="/vi/*" element={<Navigate to="/" replace />} />
+
       <Route path="*" element={<RouteWrapper><NotFound /></RouteWrapper>} />
     </Routes>
   );

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -7,7 +7,6 @@ import {
   Search,
   User,
   LogOut,
-  Languages,
   BookOpen,
   LayoutDashboard,
   SquarePen,
@@ -24,7 +23,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 const Navigation = () => {
@@ -33,7 +31,7 @@ const Navigation = () => {
   const [user, setUser] = useState<SupabaseUser | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
-  const { language, setLanguage, t } = useLanguage();
+  const { t } = useLanguage();
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -64,9 +62,7 @@ const Navigation = () => {
     return items;
   }, [t.nav.about, t.nav.blog, t.nav.builder, t.nav.events, t.nav.home, t.nav.profile, t.nav.services, user]);
   
-  const getLocalizedNavPath = (path: string) => {
-    return getLocalizedPath(path, language);
-  };
+  const getLocalizedNavPath = (path: string) => getLocalizedPath(path, "en");
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -142,25 +138,6 @@ const Navigation = () => {
 
           {/* Desktop actions */}
           <div className="hidden items-center gap-3 md:flex">
-            <Select
-              value={language}
-              onValueChange={(val) => {
-                setLanguage(val as "en" | "sq" | "vi");
-              }}
-            >
-              <SelectTrigger className="h-10 min-w-[5.5rem] px-3 lg:min-w-[6.5rem]">
-                <div className="flex items-center gap-1">
-                  <Languages className="h-4 w-4" />
-                  <SelectValue placeholder="Lang" />
-                </div>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="en">English</SelectItem>
-                <SelectItem value="sq">Shqip</SelectItem>
-                <SelectItem value="vi">Tiếng Việt</SelectItem>
-              </SelectContent>
-            </Select>
-
             {user ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -254,29 +231,6 @@ const Navigation = () => {
                     </Link>
                   );
                 })}
-
-                {/* Language Select mobile */}
-                <div className="pt-2">
-                  <Select
-                    value={language}
-                    onValueChange={(val) => {
-                      setLanguage(val as "en" | "sq" | "vi");
-                      setIsOpen(false);
-                    }}
-                  >
-                    <SelectTrigger className="w-full">
-                      <div className="flex items-center gap-2">
-                        <Languages className="h-4 w-4" />
-                        <SelectValue placeholder="Language" />
-                      </div>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="en">English</SelectItem>
-                      <SelectItem value="sq">Shqip</SelectItem>
-                      <SelectItem value="vi">Tiếng Việt</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
 
                 {user ? (
                   <div className="border-t pt-4 space-y-3">

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -13,13 +13,11 @@ interface SEOProps {
   section?: string;
   tags?: string[];
   canonicalUrl?: string;
-  lang?: "en" | "sq" | "vi";
+  lang?: "en";
 }
 
-const SUPPORTED_LANGS = ["en", "sq", "vi"] as const;
-const LOCALIZED_PREFIXES = new Set<typeof SUPPORTED_LANGS[number]>(
-  SUPPORTED_LANGS.filter(locale => locale !== "en"),
-);
+const SUPPORTED_LANGS = ["en"] as const;
+const LOCALIZED_PREFIXES = new Set<typeof SUPPORTED_LANGS[number]>();
 
 const normalizePathname = (path: string | undefined | null) => {
   if (!path) {
@@ -59,8 +57,8 @@ export function SEO({
 }: SEOProps) {
   const siteName = "SchoolTech Hub";
   const fullTitle = `${title} | ${siteName} - AI Education Solutions`;
-  const langLabel = lang === "sq" ? "Albanian" : lang === "vi" ? "Vietnamese" : "English";
-  const ogLocale = lang === "sq" ? "sq_AL" : lang === "vi" ? "vi_VN" : "en_US";
+  const langLabel = "English";
+  const ogLocale = "en_US";
 
   let origin = "";
   let pathname = "/";
@@ -98,8 +96,6 @@ export function SEO({
   const normalizedBasePath = basePath === "" ? "/" : basePath;
 
   const englishPath = normalizedBasePath;
-  const albanianPath = normalizedBasePath === "/" ? "/sq" : `/sq${normalizedBasePath}`;
-  const vietnamesePath = normalizedBasePath === "/" ? "/vi" : `/vi${normalizedBasePath}`;
 
   const canonicalPath = rawPathname || "/";
   const canonical =
@@ -108,8 +104,6 @@ export function SEO({
 
   const alternateLinks = {
     en: buildAbsoluteUrl(origin, englishPath),
-    sq: buildAbsoluteUrl(origin, albanianPath),
-    vi: buildAbsoluteUrl(origin, vietnamesePath),
   };
 
   const ogUrl = canonical || url;
@@ -130,8 +124,6 @@ export function SEO({
       {canonical && <link rel="canonical" href={canonical} />}
       {/* Alternate locales */}
       <link rel="alternate" hrefLang="en" href={alternateLinks.en} />
-      <link rel="alternate" hrefLang="sq" href={alternateLinks.sq} />
-      <link rel="alternate" hrefLang="vi" href={alternateLinks.vi} />
       <link rel="alternate" hrefLang="x-default" href={alternateLinks.en} />
       
       {/* Open Graph / Facebook */}
@@ -142,7 +134,6 @@ export function SEO({
       <meta property="og:image" content={image} />
       <meta property="og:site_name" content={siteName} />
       <meta property="og:locale" content={ogLocale} />
-      <meta property="og:locale:alternate" content="sq_AL" />
       
       {/* Article specific tags */}
       {type === "article" && (

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -23,7 +23,7 @@ export function StructuredData({ type, data }: StructuredDataProps) {
             "telephone": "+355-69-123-4567",
             "contactType": "customer service",
             "areaServed": ["AL", "XK", "MK", "ME"],
-            "availableLanguage": ["English", "Albanian"]
+          "availableLanguage": ["English"]
           },
           "sameAs": [
             "https://facebook.com/schooltechhub",

--- a/src/components/__tests__/SEO.test.tsx
+++ b/src/components/__tests__/SEO.test.tsx
@@ -4,19 +4,17 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { SEO } from '../SEO';
 
-type SupportedLang = NonNullable<Parameters<typeof SEO>[0]['lang']>;
-
 const defaultProps = {
   title: 'Test Page',
   description: 'Testing alternate language links.',
 };
 
-const renderSEO = (path: string, lang: SupportedLang) => {
+const renderSEO = (path: string) => {
   window.history.replaceState({}, '', path);
 
   render(
     <HelmetProvider>
-      <SEO {...defaultProps} lang={lang} />
+      <SEO {...defaultProps} />
     </HelmetProvider>,
   );
 };
@@ -48,43 +46,16 @@ describe('SEO locale alternates', () => {
     });
   });
 
-  it('emits localized alternates for English routes', async () => {
-    renderSEO('/services', 'en');
+  it('emits only English alternates for routes', async () => {
+    renderSEO('/services');
 
     await waitFor(() => {
       const alternateLinks = getAlternateLinks();
       expect(alternateLinks.en).toBe(withOrigin('/services'));
-      expect(alternateLinks.sq).toBe(withOrigin('/sq/services'));
-      expect(alternateLinks.vi).toBe(withOrigin('/vi/services'));
       expect(alternateLinks['x-default']).toBe(withOrigin('/services'));
+      expect(Object.keys(alternateLinks)).toHaveLength(2);
 
       expect(getCanonicalLink()).toBe(withOrigin('/services'));
-    });
-  });
-
-  it('keeps localized canonical and alternates for Albanian routes', async () => {
-    renderSEO('/sq/services', 'sq');
-
-    await waitFor(() => {
-      const alternateLinks = getAlternateLinks();
-      expect(alternateLinks.en).toBe(withOrigin('/services'));
-      expect(alternateLinks.sq).toBe(withOrigin('/sq/services'));
-      expect(alternateLinks.vi).toBe(withOrigin('/vi/services'));
-
-      expect(getCanonicalLink()).toBe(withOrigin('/sq/services'));
-    });
-  });
-
-  it('keeps localized canonical and alternates for Vietnamese routes', async () => {
-    renderSEO('/vi/services', 'vi');
-
-    await waitFor(() => {
-      const alternateLinks = getAlternateLinks();
-      expect(alternateLinks.en).toBe(withOrigin('/services'));
-      expect(alternateLinks.sq).toBe(withOrigin('/sq/services'));
-      expect(alternateLinks.vi).toBe(withOrigin('/vi/services'));
-
-      expect(getCanonicalLink()).toBe(withOrigin('/vi/services'));
     });
   });
 });

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,10 +1,8 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { en } from '../translations/en';
-import { sq } from '../translations/sq';
-import { vi } from '../translations/vi';
 
-type Language = 'en' | 'sq' | 'vi';
+type Language = 'en';
 type Translations = typeof en;
 
 interface LanguageContextType {
@@ -15,10 +13,7 @@ interface LanguageContextType {
 
 const translations: Record<Language, Translations> = {
   en,
-  sq,
-  vi
 };
-const supportedLanguages = Object.keys(translations) as Language[];
 
 const defaultLanguageContext: LanguageContextType = {
   language: 'en',
@@ -36,47 +31,29 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const navigate = useNavigate();
   const location = useLocation();
 
-  const getLanguageFromPath = (pathname: string): Language => {
-    const [, maybeLang] = pathname.split('/');
-    return supportedLanguages.includes(maybeLang as Language)
-      ? (maybeLang as Language)
-      : 'en';
-  };
+  const getLanguageFromPath = () => 'en';
 
-  const [language, setLanguageState] = useState<Language>(() => getLanguageFromPath(location.pathname));
+  const [language, setLanguageState] = useState<Language>(() => getLanguageFromPath());
 
   useEffect(() => {
     setLanguageState((current) => {
-      const urlLang = getLanguageFromPath(location.pathname);
+      const urlLang = getLanguageFromPath();
       return current === urlLang ? current : urlLang;
     });
   }, [location.pathname]);
 
-  const setLanguage = (newLang: Language) => {
-    if (newLang === language) {
-      return;
-    }
-
-    setLanguageState(newLang);
-
-    // Get current path without language prefix
+  const setLanguage = (_newLang: Language) => {
+    setLanguageState('en');
+    // Only English is supported, so we simply ensure the URL does not contain
+    // any legacy language prefixes and keep the navigation within the current path.
     let currentPath = location.pathname;
-    
-    // Remove existing language prefix if present
-    const langPrefixRegex = new RegExp(`^/(${supportedLanguages.join('|')})(/|$)`);
+    const langPrefixRegex = new RegExp('^/(sq|vi)(/|$)');
     if (langPrefixRegex.test(currentPath)) {
       currentPath = currentPath.replace(langPrefixRegex, '/');
     }
 
     const searchAndHash = `${location.search}${location.hash}`;
-
-    // Navigate to new language path
-    if (newLang === 'en') {
-      navigate(`${currentPath}${searchAndHash}`);
-    } else {
-      const localizedPath = currentPath === '/' ? `/${newLang}` : `/${newLang}${currentPath}`;
-      navigate(`${localizedPath}${searchAndHash}`);
-    }
+    navigate(`${currentPath}${searchAndHash}`);
   };
 
   const t = translations[language];

--- a/src/pages/account/components/SettingsPanel.tsx
+++ b/src/pages/account/components/SettingsPanel.tsx
@@ -33,7 +33,7 @@ import {
 } from "@/lib/avatar";
 
 type ThemePreference = "system" | "light" | "dark";
-type LanguageOption = "en" | "sq" | "vi";
+type LanguageOption = "en";
 
 type SettingsPanelProps = {
   user: User;
@@ -48,8 +48,7 @@ const createFileIdentifier = () => {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 };
 
-const isLanguageOption = (value: unknown): value is LanguageOption =>
-  value === "en" || value === "sq" || value === "vi";
+const isLanguageOption = (value: unknown): value is LanguageOption => value === "en";
 
 const isThemePreference = (value: unknown): value is ThemePreference =>
   value === "light" || value === "dark" || value === "system";
@@ -499,15 +498,6 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
     }
   };
 
-  const languageOptions = useMemo(
-    () => [
-      { value: "en" as LanguageOption, label: t.sitemap.languages.en },
-      { value: "sq" as LanguageOption, label: t.sitemap.languages.sq },
-      { value: "vi" as LanguageOption, label: t.sitemap.languages.vi },
-    ],
-    [t]
-  );
-
   return (
     <div className="space-y-6">
       <Card>
@@ -713,18 +703,9 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
             </div>
             <div className="grid gap-2">
               <Label>{t.account.settings.language}</Label>
-              <Select value={languagePreference} onValueChange={value => setLanguagePreference(value as LanguageOption)}>
-                <SelectTrigger>
-                  <SelectValue placeholder={t.account.settings.languagePlaceholder} />
-                </SelectTrigger>
-                <SelectContent>
-                  {languageOptions.map(option => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <div className="rounded-md border border-input bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+                {t.sitemap.languages.en}
+              </div>
             </div>
             <div className="grid gap-2">
               <Label>{t.account.settings.theme}</Label>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1166,9 +1166,7 @@ export const en = {
       sitemap: "Sitemap"
     },
     languages: {
-      en: "English",
-      sq: "Albanian",
-      vi: "Vietnamese"
+      en: "English"
     }
   },
   lessonBuilder: {


### PR DESCRIPTION
## Summary
- remove Albanian and Vietnamese localization hooks from navigation, routing, and language context so the UI only exposes English
- simplify sitemap generation, SEO metadata, and structured data to stop advertising alternate locales and clean up related tests
- streamline account settings and sitemap page content to reflect the single-language experience

## Testing
- npm test *(fails: existing builder and class lesson plan viewer suites due to timeouts and missing mock data)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b5e48fec8331b8ed45e7175303d0