### PR TITLE
Refine teacher workspace dashboard integrations

### DIFF
--- a/docs/teacher-dashboard-supabase-schema.md
+++ b/docs/teacher-dashboard-supabase-schema.md
@@ -25,6 +25,27 @@ The following schema powers the SchoolTech Hub teacher dashboard. It keeps lesso
 | `notes` | `text` | Private teacher notes. |
 | `created_at` | `timestamptz` | Defaults to `now()`. |
 
+### `student_behavior_logs`
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key. |
+| `student_id` | `uuid` | References `students.id`. |
+| `class_id` | `uuid` | Optional reference to `classes.id`. |
+| `note` | `text` | Behaviour observation or context. |
+| `sentiment` | `text` | Enum: `positive`, `neutral`, `needs_support`. |
+| `recorded_by` | `uuid` | Teacher author, references `teachers.id`. |
+| `recorded_at` | `timestamptz` | Defaults to `now()`. |
+
+### `student_appraisals`
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key. |
+| `student_id` | `uuid` | References `students.id`. |
+| `class_id` | `uuid` | Optional reference to `classes.id`. |
+| `highlight` | `text` | Celebration or note about achievement. |
+| `recorded_by` | `uuid` | Teacher author, references `teachers.id`. |
+| `recorded_at` | `timestamptz` | Defaults to `now()`. |
+
 ### `classes`
 | Column | Type | Description |
 | --- | --- | --- |
@@ -109,6 +130,17 @@ The following schema powers the SchoolTech Hub teacher dashboard. It keeps lesso
 | `note` | `text` | Reflection or qualitative feedback. |
 | `recorded_at` | `timestamptz` | Defaults to `now()`. |
 
+### `student_reports`
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key. |
+| `student_id` | `uuid` | References `students.id`. |
+| `requested_by` | `uuid` | Teacher requesting report. |
+| `status` | `text` | Enum: `pending`, `processing`, `ready`, `failed`. |
+| `generated_url` | `text` | Optional link to generated document. |
+| `requested_at` | `timestamptz` | Defaults to `now()`. |
+| `completed_at` | `timestamptz` | Set when report is ready. |
+
 ## Content Publishing & Resources
 
 ### `resources`
@@ -141,6 +173,14 @@ The following schema powers the SchoolTech Hub teacher dashboard. It keeps lesso
 | `id` | `uuid` | Primary key. |
 | `blog_post_id` | `uuid` | References `blog_posts.id`. |
 | `tag` | `text` | Individual tag value. |
+
+### `saved_posts`
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key. |
+| `user_id` | `uuid` | References `teachers.id`/`auth.users.id`. |
+| `post_id` | `uuid` | References `blog_posts.id`. |
+| `created_at` | `timestamptz` | Defaults to `now()`. |
 
 ## Teacher Queries & Collaboration
 
@@ -193,6 +233,51 @@ The following schema powers the SchoolTech Hub teacher dashboard. It keeps lesso
 | `action` | `text` | Enum: `lesson_created`, `calendar_updated`, `query_posted`, etc. |
 | `metadata` | `jsonb` | Context payload. |
 | `created_at` | `timestamptz` | Defaults to `now()`. |
+
+### `curriculum_items`
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key. |
+| `class_id` | `uuid` | References `classes.id`. |
+| `title` | `text` | Lesson or unit title. |
+| `topic` | `text` | Focus area for the week. |
+| `stage` | `text` | Curriculum stage or key stage. |
+| `subject` | `text` | Subject name. |
+| `week` | `integer` | Term week number. |
+| `date` | `date` | Scheduled delivery date. |
+| `created_at` | `timestamptz` | Defaults to `now()`. |
+
+### `curriculum_lessons`
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key. |
+| `curriculum_item_id` | `uuid` | References `curriculum_items.id`. |
+| `lesson_plan_id` | `uuid` | References `lesson_plans.id`. |
+| `status` | `text` | Enum: `draft`, `published`, `archived`. |
+| `view_url` | `text` | Optional link to public view. |
+| `created_at` | `timestamptz` | Defaults to `now()`. |
+
+### `assessments`
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key. |
+| `class_id` | `uuid` | References `classes.id`. |
+| `title` | `text` | Assessment title. |
+| `description` | `text` | Instructions or guidance. |
+| `due_date` | `date` | Optional due date. |
+| `grading_scale` | `text` | Enum: `letter`, `percentage`, `points`, `rubric`. |
+| `created_at` | `timestamptz` | Defaults to `now()`. |
+| `updated_at` | `timestamptz` | Updated via trigger. |
+
+### `assessment_submissions`
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key. |
+| `assessment_id` | `uuid` | References `assessments.id`. |
+| `student_id` | `uuid` | References `students.id`. |
+| `status` | `text` | Enum: `not_started`, `in_progress`, `submitted`. |
+| `submitted_at` | `timestamptz` | Timestamp of submission. |
+| `attachments` | `jsonb` | Array of uploaded artefacts. |
 
 ## Suggested Views & Policies
 

--- a/src/lib/data/assessments.ts
+++ b/src/lib/data/assessments.ts
@@ -1,0 +1,271 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { AssessmentGrade, AssessmentSubmission, AssessmentTemplate, GradeScale } from "@/types/platform";
+
+const randomId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+};
+
+type Client = SupabaseClient;
+
+const toStringOrNull = (value: unknown): string | null => {
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseFloat(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+};
+
+const DEMO_ASSESSMENTS: AssessmentTemplate[] = [
+  {
+    id: "demo-assessment-1",
+    classId: "demo-class-1",
+    title: "Forces and Motion Quiz",
+    description: "Short multiple-choice quiz covering Newton's laws.",
+    dueDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 5).toISOString(),
+    gradingScale: "percentage",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: "demo-assessment-2",
+    classId: "demo-class-1",
+    title: "Narrative Draft",
+    description: "Students submit a 500-word story draft for review.",
+    dueDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 9).toISOString(),
+    gradingScale: "rubric",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+];
+
+const DEMO_GRADES: AssessmentGrade[] = [
+  {
+    id: "demo-grade-1",
+    assessmentId: "demo-assessment-1",
+    studentId: "demo-student-1",
+    gradeValue: "92%",
+    gradeNumeric: 92,
+    scale: "percentage",
+    gradedAt: new Date().toISOString(),
+    feedback: "Great job explaining balanced forces.",
+    recordedBy: "demo-teacher",
+  },
+];
+
+const DEMO_SUBMISSIONS: AssessmentSubmission[] = [
+  {
+    id: "demo-submission-1",
+    assessmentId: "demo-assessment-2",
+    studentId: "demo-student-1",
+    status: "submitted",
+    submittedAt: new Date().toISOString(),
+    attachments: [
+      { id: "demo-attachment-1", name: "Narrative Draft.docx", url: null },
+    ],
+  },
+];
+
+function isTableMissing(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as { code?: string }).code;
+  return code === "42P01" || code === "42703";
+}
+
+function mapScale(value: unknown): GradeScale {
+  if (value === "letter" || value === "percentage" || value === "points" || value === "rubric") {
+    return value;
+  }
+  return "letter";
+}
+
+function mapAssessment(record: Record<string, unknown>): AssessmentTemplate {
+  return {
+    id: String(record.id ?? randomId()),
+    classId: String(record.class_id ?? record.classId ?? ""),
+    title: toStringOrNull(record.title) ?? "Untitled assessment",
+    description: toStringOrNull(record.description) ?? toStringOrNull(record.summary),
+    dueDate: toStringOrNull(record.due_date) ?? toStringOrNull(record.dueDate),
+    gradingScale: mapScale(record.grading_scale ?? record.gradingScale),
+    createdAt: toStringOrNull(record.created_at) ?? toStringOrNull(record.createdAt),
+    updatedAt: toStringOrNull(record.updated_at) ?? toStringOrNull(record.updatedAt),
+  } satisfies AssessmentTemplate;
+}
+
+function mapGrade(record: Record<string, unknown>): AssessmentGrade {
+  return {
+    id: String(record.id ?? randomId()),
+    assessmentId: String(record.assessment_id ?? record.assessmentId ?? ""),
+    studentId: String(record.student_id ?? record.studentId ?? ""),
+    gradeValue: toStringOrNull(record.grade_value) ?? toStringOrNull(record.grade),
+    gradeNumeric: toNumberOrNull(record.grade_numeric) ?? toNumberOrNull(record.gradeNumeric),
+    scale: mapScale(record.scale),
+    gradedAt: toStringOrNull(record.graded_at) ?? toStringOrNull(record.gradedAt),
+    feedback: toStringOrNull(record.feedback),
+    recordedBy: toStringOrNull(record.recorded_by) ?? toStringOrNull(record.recordedBy),
+  } satisfies AssessmentGrade;
+}
+
+function mapSubmission(record: Record<string, unknown>): AssessmentSubmission {
+  const attachments = Array.isArray(record.attachments)
+    ? record.attachments.map((attachment: unknown) => {
+        const item = (attachment && typeof attachment === "object"
+          ? (attachment as Record<string, unknown>)
+          : {}) as Record<string, unknown>;
+        return {
+          id: String(item.id ?? randomId()),
+          name: toStringOrNull(item.name) ?? "Attachment",
+          url: toStringOrNull(item.url),
+        };
+      })
+    : [];
+
+  return {
+    id: String(record.id ?? randomId()),
+    assessmentId: String(record.assessment_id ?? record.assessmentId ?? ""),
+    studentId: String(record.student_id ?? record.studentId ?? ""),
+    status:
+      record.status === "in_progress" || record.status === "submitted"
+        ? record.status
+        : "not_started",
+    submittedAt: toStringOrNull(record.submitted_at) ?? toStringOrNull(record.submittedAt),
+    attachments,
+  } satisfies AssessmentSubmission;
+}
+
+export async function listAssessments(client: Client = supabase): Promise<AssessmentTemplate[]> {
+  const { data, error } = await client.from("assessments").select("*").order("due_date", { ascending: true });
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("assessments table missing, returning demo assessments", error);
+      return DEMO_ASSESSMENTS;
+    }
+    throw error;
+  }
+
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return data.map(mapAssessment);
+}
+
+export async function createAssessment(
+  input: { classId: string; title: string; description?: string | null; dueDate?: string | null; gradingScale?: GradeScale },
+  client: Client = supabase,
+): Promise<AssessmentTemplate> {
+  const payload = {
+    class_id: input.classId,
+    title: input.title,
+    description: input.description ?? null,
+    due_date: input.dueDate ?? null,
+    grading_scale: input.gradingScale ?? "letter",
+  };
+
+  const { data, error } = await client.from("assessments").insert(payload).select().maybeSingle();
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("assessments table missing, returning demo assessment", error);
+      return mapAssessment({ ...payload, id: randomId(), created_at: new Date().toISOString() });
+    }
+    throw error;
+  }
+
+  return mapAssessment(data ?? payload);
+}
+
+export async function recordAssessmentGrade(
+  input: { assessmentId: string; studentId: string; gradeValue: string | null; gradeNumeric?: number | null; scale: GradeScale; feedback?: string | null },
+  client: Client = supabase,
+): Promise<AssessmentGrade> {
+  const payload = {
+    assessment_id: input.assessmentId,
+    student_id: input.studentId,
+    grade_value: input.gradeValue,
+    grade_numeric: input.gradeNumeric ?? null,
+    scale: input.scale,
+    feedback: input.feedback ?? null,
+  };
+
+  const { data, error } = await client.from("assessment_grades").insert(payload).select().maybeSingle();
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("assessment_grades table missing, returning demo grade", error);
+      return mapGrade({ ...payload, id: randomId(), graded_at: new Date().toISOString() });
+    }
+    throw error;
+  }
+
+  return mapGrade(data ?? payload);
+}
+
+export async function listAssessmentGrades(
+  assessmentId: string,
+  client: Client = supabase,
+): Promise<AssessmentGrade[]> {
+  const { data, error } = await client
+    .from("assessment_grades")
+    .select("*")
+    .eq("assessment_id", assessmentId)
+    .order("graded_at", { ascending: false });
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("assessment_grades table missing, returning demo grades", error);
+      return DEMO_GRADES.filter(grade => grade.assessmentId === assessmentId);
+    }
+    throw error;
+  }
+
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return data.map(mapGrade);
+}
+
+export async function listAssessmentSubmissions(
+  assessmentId: string,
+  client: Client = supabase,
+): Promise<AssessmentSubmission[]> {
+  const { data, error } = await client
+    .from("assessment_submissions")
+    .select("*")
+    .eq("assessment_id", assessmentId)
+    .order("submitted_at", { ascending: false });
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("assessment_submissions table missing, returning demo submissions", error);
+      return DEMO_SUBMISSIONS.filter(submission => submission.assessmentId === assessmentId);
+    }
+    throw error;
+  }
+
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return data.map(mapSubmission);
+}
+
+export function getDemoAssessmentGrades(): AssessmentGrade[] {
+  return DEMO_GRADES;
+}
+
+export function getDemoAssessmentSubmissions(): AssessmentSubmission[] {
+  return DEMO_SUBMISSIONS;
+}

--- a/src/lib/data/curriculum.ts
+++ b/src/lib/data/curriculum.ts
@@ -1,0 +1,192 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { CurriculumItem, CurriculumLessonLink } from "@/types/platform";
+
+const randomId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+};
+
+type Client = SupabaseClient;
+
+const toStringOrNull = (value: unknown): string | null => {
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+};
+
+const DEMO_CURRICULUM: CurriculumItem[] = [
+  {
+    id: "demo-curriculum-1",
+    classId: "demo-class-1",
+    title: "Forces and Motion",
+    stage: "Primary",
+    subject: "Science",
+    week: 5,
+    topic: "Physics basics",
+    date: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: "demo-curriculum-2",
+    classId: "demo-class-1",
+    title: "Narrative Writing",
+    stage: "Primary",
+    subject: "English",
+    week: 6,
+    topic: "Story arcs",
+    date: new Date(Date.now() + 1000 * 60 * 60 * 24 * 14).toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+];
+
+const DEMO_LINKS: CurriculumLessonLink[] = [
+  {
+    id: "demo-link-1",
+    curriculumItemId: "demo-curriculum-1",
+    lessonPlanId: "demo-plan-1",
+    status: "draft",
+    viewUrl: null,
+    createdAt: new Date().toISOString(),
+  },
+];
+
+function isTableMissing(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as { code?: string }).code;
+  return code === "42P01" || code === "42703";
+}
+
+function mapCurriculum(record: Record<string, unknown>): CurriculumItem {
+  const classId = record.class_id ?? record.classId ?? "";
+  const stage = toStringOrNull(record.stage) ?? toStringOrNull(record.level);
+  const subject = toStringOrNull(record.subject);
+  const week = toNumberOrNull(record.week);
+  const topic = toStringOrNull(record.topic) ?? toStringOrNull(record.focus);
+  const date = toStringOrNull(record.date) ?? toStringOrNull(record.scheduled_for);
+  const createdAt = toStringOrNull(record.created_at) ?? toStringOrNull(record.createdAt);
+  const updatedAt = toStringOrNull(record.updated_at) ?? toStringOrNull(record.updatedAt);
+
+  return {
+    id: String(record.id ?? randomId()),
+    classId: String(classId ?? ""),
+    title: toStringOrNull(record.title) ?? "Untitled lesson",
+    stage,
+    subject,
+    week,
+    topic,
+    date,
+    createdAt,
+    updatedAt,
+  } satisfies CurriculumItem;
+}
+
+function mapLink(record: Record<string, unknown>): CurriculumLessonLink {
+  const statusValue = toStringOrNull(record.status);
+  return {
+    id: String(record.id ?? randomId()),
+    curriculumItemId: String(record.curriculum_item_id ?? record.curriculumItemId ?? ""),
+    lessonPlanId: String(record.lesson_plan_id ?? record.lessonPlanId ?? ""),
+    status: statusValue === "published" || statusValue === "archived" ? statusValue : "draft",
+    viewUrl: toStringOrNull(record.view_url) ?? toStringOrNull(record.viewUrl),
+    createdAt: toStringOrNull(record.created_at) ?? toStringOrNull(record.createdAt),
+  } satisfies CurriculumLessonLink;
+}
+
+export async function listCurriculumItems(client: Client = supabase): Promise<CurriculumItem[]> {
+  const { data, error } = await client
+    .from("curriculum_items")
+    .select("*")
+    .order("date", { ascending: true, nullsFirst: false });
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("curriculum_items table missing, returning demo curriculum", error);
+      return DEMO_CURRICULUM;
+    }
+    throw error;
+  }
+
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return data.map(mapCurriculum);
+}
+
+export async function saveCurriculumItem(
+  input: Partial<CurriculumItem> & { classId: string; title: string },
+  client: Client = supabase,
+): Promise<CurriculumItem> {
+  const payload = {
+    id: input.id ?? undefined,
+    class_id: input.classId,
+    title: input.title,
+    stage: input.stage ?? null,
+    subject: input.subject ?? null,
+    week: input.week ?? null,
+    topic: input.topic ?? null,
+    date: input.date ?? null,
+  };
+
+  const query = input.id
+    ? client.from("curriculum_items").update(payload).eq("id", input.id).select().maybeSingle()
+    : client.from("curriculum_items").insert(payload).select().maybeSingle();
+
+  const { data, error } = await query;
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("curriculum_items table missing, returning demo curriculum item", error);
+      return mapCurriculum({ ...payload, id: input.id ?? randomId(), created_at: new Date().toISOString() });
+    }
+    throw error;
+  }
+
+  return mapCurriculum(data ?? payload);
+}
+
+export async function linkCurriculumToLesson(
+  input: { curriculumItemId: string; lessonPlanId: string; viewUrl?: string | null; status?: CurriculumLessonLink["status"]; },
+  client: Client = supabase,
+): Promise<CurriculumLessonLink> {
+  const payload = {
+    curriculum_item_id: input.curriculumItemId,
+    lesson_plan_id: input.lessonPlanId,
+    view_url: input.viewUrl ?? null,
+    status: input.status ?? "draft",
+  };
+
+  const { data, error } = await client
+    .from("curriculum_lessons")
+    .insert(payload)
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("curriculum_lessons table missing, returning demo link", error);
+      return mapLink({ ...payload, id: randomId(), created_at: new Date().toISOString() });
+    }
+    throw error;
+  }
+
+  return mapLink(data ?? payload);
+}
+
+export function getDemoCurriculumLinks(): CurriculumLessonLink[] {
+  return DEMO_LINKS;
+}

--- a/src/lib/data/students.ts
+++ b/src/lib/data/students.ts
@@ -1,0 +1,634 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  AssessmentGrade,
+  GradeScale,
+  StudentAppraisalEntry,
+  StudentAssignmentSummary,
+  StudentBehaviorEntry,
+  StudentProfile,
+  StudentProgressSnapshot,
+  StudentReport,
+  StudentSummary,
+} from "@/types/platform";
+
+const FALLBACK_SCALE: GradeScale = "letter";
+
+type Client = SupabaseClient;
+
+const toRecord = (value: unknown): Record<string, unknown> => {
+  if (value && typeof value === "object") {
+    return value as Record<string, unknown>;
+  }
+  return {};
+};
+
+const randomId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+};
+
+function mapGradeScale(value: unknown): GradeScale {
+  if (value === "percentage" || value === "points" || value === "rubric") {
+    return value;
+  }
+  return "letter";
+}
+
+function mapBehaviorEntry(record: Record<string, unknown>): StudentBehaviorEntry {
+  return {
+    id: String(record.id ?? randomId()),
+    studentId: String(record.student_id ?? record.studentId ?? ""),
+    classId: record.class_id ?? record.classId ?? null,
+    note: typeof record.note === "string" ? record.note : "",
+    recordedAt: record.recorded_at ?? record.recordedAt ?? new Date().toISOString(),
+    recordedBy: record.recorded_by ?? record.recordedBy ?? null,
+    sentiment:
+      record.sentiment === "positive" || record.sentiment === "needs_support"
+        ? record.sentiment
+        : "neutral",
+  } satisfies StudentBehaviorEntry;
+}
+
+function mapAppraisalEntry(record: Record<string, unknown>): StudentAppraisalEntry {
+  return {
+    id: String(record.id ?? randomId()),
+    studentId: String(record.student_id ?? record.studentId ?? ""),
+    classId: record.class_id ?? record.classId ?? null,
+    highlight: typeof record.highlight === "string" ? record.highlight : "",
+    recordedAt: record.recorded_at ?? record.recordedAt ?? new Date().toISOString(),
+    recordedBy: record.recorded_by ?? record.recordedBy ?? null,
+  } satisfies StudentAppraisalEntry;
+}
+
+function mapAssessmentGrade(record: Record<string, unknown>): AssessmentGrade {
+  return {
+    id: String(record.id ?? randomId()),
+    assessmentId: String(record.assessment_id ?? record.assessmentId ?? ""),
+    studentId: String(record.student_id ?? record.studentId ?? ""),
+    gradeValue: record.grade_value ?? record.gradeValue ?? null,
+    gradeNumeric: typeof record.grade_numeric === "number" ? record.grade_numeric : record.gradeNumeric ?? null,
+    scale: mapGradeScale(record.scale),
+    gradedAt: record.graded_at ?? record.gradedAt ?? null,
+    feedback: record.feedback ?? null,
+    recordedBy: record.recorded_by ?? record.recordedBy ?? null,
+  } satisfies AssessmentGrade;
+}
+
+function mapAssignment(record: Record<string, unknown>): StudentAssignmentSummary {
+  const scale = mapGradeScale(record.grade_scale ?? record.gradingScale);
+  return {
+    id: String(record.id ?? randomId()),
+    title: typeof record.title === "string" && record.title.length > 0 ? record.title : "Untitled assignment",
+    status:
+      record.status === "submitted" || record.status === "graded" || record.status === "missing"
+        ? record.status
+        : "assigned",
+    dueDate: record.due_date ?? record.dueDate ?? null,
+    grade: record.grade ?? record.grade_value ?? null,
+    gradeScale: record.grade === null && record.grade_value === null ? null : scale,
+  } satisfies StudentAssignmentSummary;
+}
+
+function mapProgressEntry(record: Record<string, unknown>): StudentProgressSnapshot {
+  return {
+    metric: typeof record.metric === "string" ? record.metric : "Progress",
+    value: typeof record.value === "number" ? record.value : Number(record.value ?? 0),
+    trend: record.trend === "up" || record.trend === "down" ? record.trend : "steady",
+    capturedAt: record.captured_at ?? record.capturedAt ?? new Date().toISOString(),
+  } satisfies StudentProgressSnapshot;
+}
+
+function mapStudentSummary(record: Record<string, unknown>): StudentSummary {
+  const classes = Array.isArray(record.class_students)
+    ? record.class_students
+        .map((entry: unknown) => {
+          const entryRecord = toRecord(entry);
+          const classCandidate = entryRecord.classes ?? entryRecord.class ?? entry;
+          const classRecord = toRecord(classCandidate);
+          if (!classRecord.id && !classRecord.title && !classRecord.name) {
+            return null;
+          }
+
+          const titleValue =
+            typeof classRecord.title === "string" && classRecord.title.length > 0
+              ? classRecord.title
+              : typeof classRecord.name === "string" && classRecord.name.length > 0
+                ? classRecord.name
+                : "Untitled class";
+
+          return {
+            id: String(classRecord.id ?? ""),
+            title: titleValue,
+            stage: (classRecord.stage ?? classRecord.level ?? null) as string | null,
+            subject: (classRecord.subject ?? null) as string | null,
+          };
+        })
+        .filter((value): value is NonNullable<typeof value> => Boolean(value))
+    : [];
+
+  const behaviorNotes = Array.isArray(record.student_behavior_logs)
+    ? record.student_behavior_logs.map(mapBehaviorEntry)
+    : [];
+  const appraisalNotes = Array.isArray(record.student_appraisals)
+    ? record.student_appraisals.map(mapAppraisalEntry)
+    : [];
+  const assessments = Array.isArray(record.assessment_grades)
+    ? record.assessment_grades.map(mapAssessmentGrade)
+    : [];
+
+  const latestBehaviorNote = behaviorNotes.length > 0 ? behaviorNotes[0] : null;
+  const latestAppraisalNote = appraisalNotes.length > 0 ? appraisalNotes[0] : null;
+  const latestAssessment = assessments.length > 0 ? assessments[0] : null;
+
+  const classIds = classes.map(cls => cls!.id);
+
+  return {
+    id: String(record.id ?? crypto.randomUUID()),
+    firstName: typeof record.first_name === "string" ? record.first_name : "",
+    lastName: typeof record.last_name === "string" ? record.last_name : "",
+    preferredName:
+      typeof record.preferred_name === "string" && record.preferred_name.length > 0
+        ? record.preferred_name
+        : null,
+    email: typeof record.email === "string" ? record.email : null,
+    avatarUrl: typeof record.avatar_url === "string" ? record.avatar_url : null,
+    classIds,
+    createdAt: record.created_at ?? record.createdAt ?? null,
+    updatedAt: record.updated_at ?? record.updatedAt ?? null,
+    classes: classes as StudentSummary["classes"],
+    latestBehaviorNote,
+    latestAppraisalNote,
+    latestAssessment,
+  } satisfies StudentSummary;
+}
+
+const DEMO_BEHAVIOR: StudentBehaviorEntry = {
+  id: "demo-behavior-1",
+  studentId: "demo-student-1",
+  classId: "demo-class-1",
+  note: "Ava collaborated thoughtfully during group science experiments.",
+  recordedAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+  recordedBy: "demo-teacher",
+  sentiment: "positive",
+};
+
+const DEMO_APPRAISAL: StudentAppraisalEntry = {
+  id: "demo-appraisal-1",
+  studentId: "demo-student-1",
+  classId: "demo-class-1",
+  highlight: "Consistently submits assignments early with thorough responses.",
+  recordedAt: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString(),
+  recordedBy: "demo-teacher",
+};
+
+const DEMO_ASSESSMENT: AssessmentGrade = {
+  id: "demo-grade-1",
+  assessmentId: "demo-assessment-1",
+  studentId: "demo-student-1",
+  gradeValue: "A",
+  gradeNumeric: 95,
+  scale: "letter",
+  gradedAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString(),
+  feedback: "Excellent understanding of the core concepts.",
+  recordedBy: "demo-teacher",
+};
+
+const DEMO_ASSIGNMENTS: StudentAssignmentSummary[] = [
+  {
+    id: "demo-assignment-1",
+    title: "Solar System Presentation",
+    status: "graded",
+    dueDate: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(),
+    grade: "A",
+    gradeScale: FALLBACK_SCALE,
+  },
+  {
+    id: "demo-assignment-2",
+    title: "Reading Reflection",
+    status: "submitted",
+    dueDate: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
+    grade: null,
+    gradeScale: null,
+  },
+];
+
+const DEMO_PROGRESS: StudentProgressSnapshot[] = [
+  { metric: "Participation", value: 88, trend: "up", capturedAt: new Date().toISOString() },
+  { metric: "Homework", value: 92, trend: "steady", capturedAt: new Date().toISOString() },
+  { metric: "Quizzes", value: 85, trend: "up", capturedAt: new Date().toISOString() },
+];
+
+const DEMO_REPORT: StudentReport = {
+  id: "demo-report-1",
+  studentId: "demo-student-1",
+  requestedBy: "demo-teacher",
+  status: "ready",
+  generatedUrl: null,
+  requestedAt: new Date(Date.now() - 1000 * 60 * 60 * 4).toISOString(),
+  completedAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
+};
+
+const FALLBACK_STUDENTS: StudentSummary[] = [
+  {
+    id: "demo-student-1",
+    firstName: "Ava",
+    lastName: "Nguyen",
+    preferredName: "Ava",
+    email: "ava.nguyen@example.com",
+    avatarUrl: null,
+    classIds: ["demo-class-1"],
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString(),
+    updatedAt: new Date().toISOString(),
+    classes: [
+      { id: "demo-class-1", title: "Year 5 Science", stage: "Primary", subject: "Science" },
+    ],
+    latestBehaviorNote: DEMO_BEHAVIOR,
+    latestAppraisalNote: DEMO_APPRAISAL,
+    latestAssessment: DEMO_ASSESSMENT,
+  },
+];
+
+const FALLBACK_PROFILES: Record<string, StudentProfile> = {
+  "demo-student-1": {
+    student: {
+      id: "demo-student-1",
+      firstName: "Ava",
+      lastName: "Nguyen",
+      preferredName: "Ava",
+      email: "ava.nguyen@example.com",
+      avatarUrl: null,
+      classIds: ["demo-class-1"],
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    classes: [{ id: "demo-class-1", title: "Year 5 Science", stage: "Primary", subject: "Science" }],
+    assignments: DEMO_ASSIGNMENTS,
+    progress: DEMO_PROGRESS,
+    behaviorNotes: [DEMO_BEHAVIOR],
+    appraisalNotes: [DEMO_APPRAISAL],
+    reportStatus: DEMO_REPORT,
+  },
+};
+
+function isTableMissing(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as { code?: string }).code;
+  return code === "42P01" || code === "42P07" || code === "42703";
+}
+
+async function requireUserId(client: Client): Promise<string> {
+  const { data, error } = await client.auth.getSession();
+  if (error) {
+    throw error;
+  }
+  const userId = data.session?.user?.id;
+  if (!userId) {
+    throw new Error("You must be signed in to manage students.");
+  }
+  return userId;
+}
+
+export async function listMyStudents(client: Client = supabase): Promise<StudentSummary[]> {
+  try {
+    await requireUserId(client);
+  } catch (error) {
+    console.warn("listMyStudents falling back to demo data", error);
+    return FALLBACK_STUDENTS;
+  }
+
+  const { data, error } = await client
+    .from("students")
+    .select(
+      `
+        id,
+        first_name,
+        last_name,
+        preferred_name,
+        email,
+        avatar_url,
+        created_at,
+        updated_at,
+        class_students:class_students (
+          class_id,
+          classes (
+            id,
+            title,
+            subject,
+            stage
+          )
+        ),
+        student_behavior_logs (
+          id,
+          student_id,
+          class_id,
+          note,
+          recorded_at,
+          recorded_by,
+          sentiment
+        ),
+        student_appraisals (
+          id,
+          student_id,
+          class_id,
+          highlight,
+          recorded_at,
+          recorded_by
+        ),
+        assessment_grades (
+          id,
+          assessment_id,
+          student_id,
+          grade_value,
+          grade_numeric,
+          scale,
+          graded_at,
+          feedback,
+          recorded_by
+        )
+      `,
+    )
+    .order("last_name", { ascending: true })
+    .order("first_name", { ascending: true });
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("Students table not available, returning demo data", error);
+      return FALLBACK_STUDENTS;
+    }
+    throw error;
+  }
+
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return data.map(mapStudentSummary);
+}
+
+export async function getStudentProfile(
+  studentId: string,
+  client: Client = supabase,
+): Promise<StudentProfile> {
+  if (!studentId) {
+    throw new Error("Student identifier is required.");
+  }
+
+  try {
+    await requireUserId(client);
+  } catch (error) {
+    const fallback = FALLBACK_PROFILES[studentId];
+    if (fallback) {
+      return fallback;
+    }
+      console.warn("getStudentProfile falling back to demo data", error);
+    return FALLBACK_PROFILES["demo-student-1"];
+  }
+
+  const { data, error } = await client
+    .from("students")
+    .select(
+      `
+        id,
+        first_name,
+        last_name,
+        preferred_name,
+        email,
+        avatar_url,
+        created_at,
+        updated_at,
+        class_students:class_students (
+          class_id,
+          classes (
+            id,
+            title,
+            subject,
+            stage
+          )
+        ),
+        student_behavior_logs (
+          id,
+          student_id,
+          class_id,
+          note,
+          recorded_at,
+          recorded_by,
+          sentiment
+        ),
+        student_appraisals (
+          id,
+          student_id,
+          class_id,
+          highlight,
+          recorded_at,
+          recorded_by
+        ),
+        assessment_grades (
+          id,
+          assessment_id,
+          student_id,
+          grade_value,
+          grade_numeric,
+          scale,
+          graded_at,
+          feedback,
+          recorded_by
+        ),
+        student_assignments (
+          id,
+          title,
+          status,
+          due_date,
+          grade,
+          grade_scale
+        ),
+        student_progress_entries (
+          metric,
+          value,
+          trend,
+          captured_at
+        ),
+        student_reports (
+          id,
+          requested_by,
+          status,
+          generated_url,
+          requested_at,
+          completed_at
+        )
+      `,
+    )
+    .eq("id", studentId)
+    .maybeSingle();
+
+  if (error) {
+    if (isTableMissing(error)) {
+      const fallback = FALLBACK_PROFILES[studentId] ?? FALLBACK_PROFILES["demo-student-1"];
+      console.warn("Student profile table not available, returning demo profile", error);
+      return fallback;
+    }
+    throw error;
+  }
+
+  if (!data) {
+    throw new Error("Student not found");
+  }
+
+  const summary = mapStudentSummary(data);
+
+  const assignments = Array.isArray(data.student_assignments)
+    ? data.student_assignments.map(mapAssignment)
+    : [];
+  const progress = Array.isArray(data.student_progress_entries)
+    ? data.student_progress_entries.map(mapProgressEntry)
+    : [];
+  const behaviorNotes = Array.isArray(data.student_behavior_logs)
+    ? data.student_behavior_logs.map(mapBehaviorEntry)
+    : [];
+  const appraisalNotes = Array.isArray(data.student_appraisals)
+    ? data.student_appraisals.map(mapAppraisalEntry)
+    : [];
+  const reportRecord = Array.isArray(data.student_reports) ? data.student_reports[0] : data.student_reports;
+  const reportStatus: StudentReport | null = reportRecord
+    ? {
+        id: String(reportRecord.id ?? randomId()),
+        studentId: summary.id,
+        requestedBy: reportRecord.requested_by ?? reportRecord.requestedBy ?? "",
+        status:
+          reportRecord.status === "processing" || reportRecord.status === "ready" || reportRecord.status === "failed"
+            ? reportRecord.status
+            : "pending",
+        generatedUrl: reportRecord.generated_url ?? reportRecord.generatedUrl ?? null,
+        requestedAt: reportRecord.requested_at ?? reportRecord.requestedAt ?? new Date().toISOString(),
+        completedAt: reportRecord.completed_at ?? reportRecord.completedAt ?? null,
+      }
+    : null;
+
+  return {
+    student: summary,
+    classes: summary.classes,
+    assignments,
+    progress,
+    behaviorNotes,
+    appraisalNotes,
+    reportStatus,
+  } satisfies StudentProfile;
+}
+
+export async function saveStudentBehaviorNote(
+  input: { studentId: string; classId?: string | null; note: string; sentiment?: StudentBehaviorEntry["sentiment"]; },
+  client: Client = supabase,
+): Promise<StudentBehaviorEntry> {
+  const payload = {
+    student_id: input.studentId,
+    class_id: input.classId ?? null,
+    note: input.note,
+    sentiment: input.sentiment ?? "neutral",
+  };
+
+  const { data, error } = await client
+    .from("student_behavior_logs")
+    .insert(payload)
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("student_behavior_logs table missing, returning local entry", error);
+      return {
+        ...DEMO_BEHAVIOR,
+        id: randomId(),
+        studentId: input.studentId,
+        classId: input.classId ?? null,
+        note: input.note,
+        recordedAt: new Date().toISOString(),
+        sentiment: input.sentiment ?? "neutral",
+      } satisfies StudentBehaviorEntry;
+    }
+    throw error;
+  }
+
+  return mapBehaviorEntry(data ?? payload);
+}
+
+export async function saveStudentAppraisalNote(
+  input: { studentId: string; classId?: string | null; highlight: string },
+  client: Client = supabase,
+): Promise<StudentAppraisalEntry> {
+  const payload = {
+    student_id: input.studentId,
+    class_id: input.classId ?? null,
+    highlight: input.highlight,
+  };
+
+  const { data, error } = await client
+    .from("student_appraisals")
+    .insert(payload)
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("student_appraisals table missing, returning local entry", error);
+      return {
+        ...DEMO_APPRAISAL,
+        id: randomId(),
+        studentId: input.studentId,
+        classId: input.classId ?? null,
+        highlight: input.highlight,
+        recordedAt: new Date().toISOString(),
+      } satisfies StudentAppraisalEntry;
+    }
+    throw error;
+  }
+
+  return mapAppraisalEntry(data ?? payload);
+}
+
+export async function recordStudentReportRequest(
+  input: { studentId: string; requestedBy: string },
+  client: Client = supabase,
+): Promise<StudentReport> {
+  const payload = {
+    student_id: input.studentId,
+    requested_by: input.requestedBy,
+    status: "pending",
+  };
+
+  const { data, error } = await client
+    .from("student_reports")
+    .insert(payload)
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    if (isTableMissing(error)) {
+      console.warn("student_reports table missing, returning local placeholder", error);
+      return {
+        id: randomId(),
+        studentId: input.studentId,
+        requestedBy: input.requestedBy,
+        status: "pending",
+        generatedUrl: null,
+        requestedAt: new Date().toISOString(),
+        completedAt: null,
+      } satisfies StudentReport;
+    }
+    throw error;
+  }
+
+  return {
+    id: String(data?.id ?? randomId()),
+    studentId: input.studentId,
+    requestedBy: input.requestedBy,
+    status:
+      data?.status === "processing" || data?.status === "ready" || data?.status === "failed"
+        ? data.status
+        : "pending",
+    generatedUrl: data?.generated_url ?? null,
+    requestedAt: data?.requested_at ?? new Date().toISOString(),
+    completedAt: data?.completed_at ?? null,
+  } satisfies StudentReport;
+}

--- a/types/platform.ts
+++ b/types/platform.ts
@@ -34,6 +34,90 @@ export interface Class {
   updatedAt: string | null;
 }
 
+export interface Student {
+  id: string;
+  firstName: string;
+  lastName: string;
+  preferredName: string | null;
+  email: string | null;
+  avatarUrl: string | null;
+  classIds: string[];
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface StudentSummary extends Student {
+  classes: Array<{
+    id: string;
+    title: string;
+    stage: string | null;
+    subject: string | null;
+  }>;
+  latestBehaviorNote: StudentBehaviorEntry | null;
+  latestAppraisalNote: StudentAppraisalEntry | null;
+  latestAssessment: AssessmentGrade | null;
+}
+
+export interface StudentAssignmentSummary {
+  id: string;
+  title: string;
+  status: "assigned" | "submitted" | "graded" | "missing";
+  dueDate: string | null;
+  grade: string | null;
+  gradeScale: GradeScale | null;
+}
+
+export interface StudentProgressSnapshot {
+  metric: string;
+  value: number;
+  trend: "up" | "down" | "steady";
+  capturedAt: string;
+}
+
+export interface StudentBehaviorEntry {
+  id: string;
+  studentId: string;
+  classId: string | null;
+  note: string;
+  recordedAt: string;
+  recordedBy: string | null;
+  sentiment: "positive" | "neutral" | "needs_support";
+}
+
+export interface StudentAppraisalEntry {
+  id: string;
+  studentId: string;
+  classId: string | null;
+  highlight: string;
+  recordedAt: string;
+  recordedBy: string | null;
+}
+
+export interface StudentProfile {
+  student: Student;
+  classes: Array<{
+    id: string;
+    title: string;
+    stage: string | null;
+    subject: string | null;
+  }>;
+  assignments: StudentAssignmentSummary[];
+  progress: StudentProgressSnapshot[];
+  behaviorNotes: StudentBehaviorEntry[];
+  appraisalNotes: StudentAppraisalEntry[];
+  reportStatus: StudentReport | null;
+}
+
+export interface StudentReport {
+  id: string;
+  studentId: string;
+  requestedBy: string;
+  status: "pending" | "processing" | "ready" | "failed";
+  generatedUrl: string | null;
+  requestedAt: string;
+  completedAt: string | null;
+}
+
 export interface LessonPlan {
   id: string;
   ownerId: string;
@@ -162,4 +246,68 @@ export interface ResearchSubmission {
   reviewedAt: string | null;
   reviewNote: string | null;
   submittedAt: string | null;
+}
+
+export interface CurriculumItem {
+  id: string;
+  classId: string;
+  title: string;
+  stage: string | null;
+  subject: string | null;
+  week: number | null;
+  topic: string | null;
+  date: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface CurriculumLessonLink {
+  id: string;
+  curriculumItemId: string;
+  lessonPlanId: string;
+  status: "draft" | "published" | "archived";
+  viewUrl: string | null;
+  createdAt: string | null;
+}
+
+export type GradeScale = "letter" | "percentage" | "points" | "rubric";
+
+export interface GradeScaleOption {
+  id: string;
+  scale: GradeScale;
+  label: string;
+  value: string;
+  numericValue: number | null;
+}
+
+export interface AssessmentTemplate {
+  id: string;
+  classId: string;
+  title: string;
+  description: string | null;
+  dueDate: string | null;
+  gradingScale: GradeScale;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface AssessmentGrade {
+  id: string;
+  assessmentId: string;
+  studentId: string;
+  gradeValue: string | null;
+  gradeNumeric: number | null;
+  scale: GradeScale;
+  gradedAt: string | null;
+  feedback: string | null;
+  recordedBy: string | null;
+}
+
+export interface AssessmentSubmission {
+  id: string;
+  assessmentId: string;
+  studentId: string;
+  status: "not_started" | "in_progress" | "submitted";
+  submittedAt: string | null;
+  attachments: Array<{ id: string; name: string; url: string | null }>;
 }


### PR DESCRIPTION
## Summary
- replace the account landing page with a functional teacher workspace including classes, students, curriculum, lesson builder, and assessment tracking tabs
- extend the embedded lesson builder so dashboard hand-offs can prefill metadata and class context
- expand the blog hub with saved post, activity, and research highlight cards plus typed Supabase helpers and document the supporting Supabase schema

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0bd7958f08331a1a97ac68ee07529