### PR TITLE
Refine dashboard greeting and class management

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -56,7 +56,7 @@ const Navigation = () => {
     ];
 
     if (user) {
-      items.splice(1, 0, { name: t.nav.profile, path: "/account" });
+      items.unshift({ name: t.nav.profile, path: "/account" });
     }
 
     return items;

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,0 +1,14 @@
+export const createFileIdentifier = (): string => {
+  const cryptoRef = typeof globalThis !== "undefined" ? globalThis.crypto : undefined;
+
+  if (cryptoRef && typeof cryptoRef.randomUUID === "function") {
+    return cryptoRef.randomUUID();
+  }
+
+  if (cryptoRef && typeof cryptoRef.getRandomValues === "function") {
+    const randomBytes = cryptoRef.getRandomValues(new Uint8Array(16));
+    return Array.from(randomBytes, byte => byte.toString(16).padStart(2, "0")).join("");
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+};

--- a/src/pages/account/__tests__/AccountDashboard.test.tsx
+++ b/src/pages/account/__tests__/AccountDashboard.test.tsx
@@ -27,11 +27,9 @@ vi.mock("@/hooks/useMyProfile", () => ({
 }));
 
 vi.mock("@/lib/classes", () => ({
-  listMyClasses: vi.fn().mockResolvedValue([]),
-}));
-
-vi.mock("@/components/classes/ClassCreateDialog", () => ({
-  ClassCreateDialog: () => null,
+  listMyClassesWithPlanCount: vi.fn().mockResolvedValue([]),
+  createClass: vi.fn(),
+  updateClass: vi.fn(),
 }));
 
 vi.mock("@/pages/account/components/UpcomingLessonsCard", () => ({

--- a/src/pages/account/components/SettingsPanel.tsx
+++ b/src/pages/account/components/SettingsPanel.tsx
@@ -31,21 +31,13 @@ import {
   resolveAvatarReference,
   isHttpUrl,
 } from "@/lib/avatar";
+import { createFileIdentifier } from "@/lib/files";
 
 type ThemePreference = "system" | "light" | "dark";
 type LanguageOption = "en";
 
 type SettingsPanelProps = {
   user: User;
-};
-
-const createFileIdentifier = () => {
-  const cryptoRef = typeof globalThis !== "undefined" ? globalThis.crypto : undefined;
-  if (cryptoRef && "randomUUID" in cryptoRef) {
-    return cryptoRef.randomUUID();
-  }
-
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 };
 
 const isLanguageOption = (value: unknown): value is LanguageOption => value === "en";


### PR DESCRIPTION
## Summary
- reorder the authenticated navigation so My Dashboard appears before Home
- enhance the account dashboard hero with profile avatar upload, greeting, and research teaser card
- replace the class creation modal with inline create/edit forms and remove unused scheduling fields
- add a reusable file identifier helper and adjust the settings panel plus tests to use it

## Testing
- npm run test -- src/pages/account/__tests__/AccountDashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0c7688f1483319d4382265859475e