### PR TITLE
Restore dashboard as primary landing page

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Routes, Route, Navigate, useParams } from 'react-router-dom';
 import Index from '@/pages/Index';
+import Home from '@/pages/Home';
 import About from '@/pages/About';
 import Services from '@/pages/Services';
 import Blog from '@/pages/Blog';
@@ -49,6 +50,7 @@ export const LocalizedRoutes = () => {
     <Routes>
       {/* English routes (default) */}
       <Route path="/" element={<RouteWrapper><Index /></RouteWrapper>} />
+      <Route path="/home" element={<RouteWrapper><Home /></RouteWrapper>} />
       <Route path="/about" element={<RouteWrapper><About /></RouteWrapper>} />
       <Route path="/services" element={<RouteWrapper><Services /></RouteWrapper>} />
       <Route path="/blog" element={<RouteWrapper><Blog /></RouteWrapper>} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -46,7 +46,8 @@ const Navigation = () => {
 
   const navItems = useMemo(() => {
     const items = [
-      { name: t.nav.home, path: "/" },
+      { name: t.nav.dashboard, path: "/" },
+      { name: t.nav.home, path: "/home" },
       { name: t.nav.blog, path: "/blog" },
       { name: t.nav.events, path: "/events" },
       { name: t.nav.services, path: "/services" },
@@ -54,11 +55,20 @@ const Navigation = () => {
     ];
 
     if (user) {
-      items.unshift({ name: t.nav.profile, path: "/account" });
+      items.push({ name: t.nav.profile, path: "/account" });
     }
 
     return items;
-  }, [t.nav.about, t.nav.blog, t.nav.events, t.nav.home, t.nav.profile, t.nav.services, user]);
+  }, [
+    t.nav.about,
+    t.nav.blog,
+    t.nav.dashboard,
+    t.nav.events,
+    t.nav.home,
+    t.nav.profile,
+    t.nav.services,
+    user,
+  ]);
   
   const getLocalizedNavPath = (path: string) => getLocalizedPath(path, "en");
 

--- a/src/components/home/HomeLanding.tsx
+++ b/src/components/home/HomeLanding.tsx
@@ -30,9 +30,10 @@ import heroImage from "@/assets/futuristic-classroom-hero.jpg";
 
 type HomeLandingProps = {
   embedded?: boolean;
+  canonicalUrl?: string;
 };
 
-export const HomeLanding = ({ embedded = false }: HomeLandingProps) => {
+export const HomeLanding = ({ embedded = false, canonicalUrl = "https://schooltechhub.com" }: HomeLandingProps) => {
   const [counters, setCounters] = useState({ lessons: 0, vr: 0, engagement: 0 });
   const statsRef = useRef<HTMLDivElement>(null);
   const [hasAnimated, setHasAnimated] = useState(false);
@@ -126,7 +127,7 @@ export const HomeLanding = ({ embedded = false }: HomeLandingProps) => {
             title="Home"
             description="Transform your classroom with SchoolTech Hub's AI-powered educational technology. Explore VR labs, gamification tools, and teacher management software. Get started for free today"
             keywords="AI education platform, virtual reality classroom, gamification in education, teacher management software, student tracking system, curriculum development tools, educational technology Albania, auto graded homework, classroom management software"
-            canonicalUrl="https://schooltechhub.com"
+            canonicalUrl={canonicalUrl}
           />
           <StructuredData type="Organization" data={{}} />
         </>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,7 @@
+import { HomeLanding } from "@/components/home/HomeLanding";
+
+const Home = () => {
+  return <HomeLanding canonicalUrl="https://schooltechhub.com/home" />;
+};
+
+export default Home;

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -20,7 +20,8 @@ type DynamicLink = RouteLink & {
 type TranslationDictionary = typeof en;
 
 const createStaticRoutes = (dictionary: TranslationDictionary): RouteLink[] => [
-  { title: dictionary.nav.home, url: "/" },
+  { title: dictionary.nav.dashboard, url: "/" },
+  { title: dictionary.nav.home, url: "/home" },
   { title: dictionary.nav.about, url: "/about" },
   { title: dictionary.nav.services, url: "/services" },
   { title: dictionary.nav.blog, url: "/blog" },

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,5 +1,6 @@
 export const en = {
   nav: {
+    dashboard: "Dashboard",
     home: "Home",
     about: "About",
     services: "Services",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -1,5 +1,6 @@
 export const sq = {
   nav: {
+    dashboard: "Pulti",
     home: "Ballina",
     about: "Rreth Nesh",
     services: "Shërbimet",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -1,5 +1,6 @@
 export const vi = {
   nav: {
+    dashboard: "Bảng điều khiển",
     home: "Trang chủ",
     about: "Về chúng tôi",
     services: "Dịch vụ",


### PR DESCRIPTION
## Summary
- add a dedicated /home page that reuses the existing marketing landing experience while keeping the dashboard at the root route
- reorder navigation to surface the dashboard link first, include the new home link, and expose the updated labels in all translations
- update the sitemap and home landing canonical handling to reflect the new routes

## Testing
- npm run build *(fails: npm is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cc61b7488331a577fbee4ec7332d