### PR TITLE
Refactor dashboard access and integrate lesson builder tab

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -20,7 +20,6 @@ import AccountResources from '@/pages/AccountResources';
 import AccountResourceNew from '@/pages/AccountResourceNew';
 import AccountResourceEdit from '@/pages/AccountResourceEdit';
 import LessonBuilderPage from '@/pages/lesson-builder/LessonBuilderPage';
-import AuthGuard from '@/components/auth/AuthGuard';
 import NotFound from '@/pages/NotFound';
 import Sitemap from '@/pages/Sitemap';
 import Navigation from '@/components/Navigation';
@@ -55,94 +54,22 @@ export const LocalizedRoutes = () => {
       <Route path="/services" element={<RouteWrapper><Services /></RouteWrapper>} />
       <Route path="/blog" element={<RouteWrapper><Blog /></RouteWrapper>} />
       <Route path="/blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
-      <Route
-        path="/builder/lesson-plans"
-        element={
-          <RouteWrapper>
-            <AuthGuard>
-              <BuilderLessonPlan />
-            </AuthGuard>
-          </RouteWrapper>
-        }
-      />
-      <Route
-        path="/builder/lesson-plans/:id"
-        element={
-          <RouteWrapper>
-            <AuthGuard>
-              <BuilderLessonPlanDetail />
-            </AuthGuard>
-          </RouteWrapper>
-        }
-      />
+      <Route path="/builder/lesson-plans" element={<RouteWrapper><BuilderLessonPlan /></RouteWrapper>} />
+      <Route path="/builder/lesson-plans/:id" element={<RouteWrapper><BuilderLessonPlanDetail /></RouteWrapper>} />
       <Route path="/lesson-plans/builder" element={<LegacyBuilderRedirect />} />
       <Route path="/lesson-plans/builder/:id" element={<LegacyBuilderRedirect />} />
-      <Route
-        path="/lesson-builder"
-        element={
-          <RouteWrapper>
-            <AuthGuard>
-              <LessonBuilderPage />
-            </AuthGuard>
-          </RouteWrapper>
-        }
-      />
+      <Route path="/lesson-builder" element={<RouteWrapper><LessonBuilderPage /></RouteWrapper>} />
       <Route path="/resources" element={<RouteWrapper><Resources /></RouteWrapper>} />
       <Route path="/events" element={<RouteWrapper><Events /></RouteWrapper>} />
       <Route path="/events/:slug" element={<RouteWrapper><EventDetail /></RouteWrapper>} />
       <Route path="/contact" element={<RouteWrapper><Contact /></RouteWrapper>} />
       <Route path="/faq" element={<RouteWrapper><FAQ /></RouteWrapper>} />
       <Route path="/auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
-      <Route
-        path="/account"
-        element={
-          <RouteWrapper>
-            <AuthGuard>
-              <Account />
-            </AuthGuard>
-          </RouteWrapper>
-        }
-      />
-      <Route
-        path="/account/classes/:id"
-        element={
-          <RouteWrapper>
-            <AuthGuard>
-              <ClassDashboard />
-            </AuthGuard>
-          </RouteWrapper>
-        }
-      />
-      <Route
-        path="/account/resources"
-        element={
-          <RouteWrapper>
-            <AuthGuard>
-              <AccountResources />
-            </AuthGuard>
-          </RouteWrapper>
-        }
-      />
-      <Route
-        path="/account/resources/new"
-        element={
-          <RouteWrapper>
-            <AuthGuard>
-              <AccountResourceNew />
-            </AuthGuard>
-          </RouteWrapper>
-        }
-      />
-      <Route
-        path="/account/resources/:id"
-        element={
-          <RouteWrapper>
-            <AuthGuard>
-              <AccountResourceEdit />
-            </AuthGuard>
-          </RouteWrapper>
-        }
-      />
+      <Route path="/account" element={<RouteWrapper><Account /></RouteWrapper>} />
+      <Route path="/account/classes/:id" element={<RouteWrapper><ClassDashboard /></RouteWrapper>} />
+      <Route path="/account/resources" element={<RouteWrapper><AccountResources /></RouteWrapper>} />
+      <Route path="/account/resources/new" element={<RouteWrapper><AccountResourceNew /></RouteWrapper>} />
+      <Route path="/account/resources/:id" element={<RouteWrapper><AccountResourceEdit /></RouteWrapper>} />
       <Route path="/sitemap" element={<RouteWrapper><Sitemap /></RouteWrapper>} />
       <Route path="/admin" element={<AdminLayout />}>
         <Route index element={<AdminPage />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -46,28 +46,22 @@ const Navigation = () => {
 
   const navItems = useMemo(() => {
     const items = [
-      { name: t.nav.dashboard, path: "/" },
-      { name: t.nav.home, path: "/home" },
+      { name: t.nav.profile, path: "/account" },
+      { name: t.nav.home, path: "/" },
       { name: t.nav.blog, path: "/blog" },
       { name: t.nav.events, path: "/events" },
       { name: t.nav.services, path: "/services" },
       { name: t.nav.about, path: "/about" },
     ];
 
-    if (user) {
-      items.push({ name: t.nav.profile, path: "/account" });
-    }
-
     return items;
   }, [
     t.nav.about,
     t.nav.blog,
-    t.nav.dashboard,
     t.nav.events,
     t.nav.home,
     t.nav.profile,
     t.nav.services,
-    user,
   ]);
   
   const getLocalizedNavPath = (path: string) => getLocalizedPath(path, "en");

--- a/src/hooks/useOptionalUser.ts
+++ b/src/hooks/useOptionalUser.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import type { User } from "@supabase/supabase-js";
+
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * Fetches the current Supabase user without enforcing authentication redirects.
+ * Useful for views that can render in a read-only mode for visitors.
+ */
+export function useOptionalUser() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      try {
+        const { data, error } = await supabase.auth.getSession();
+        if (!active) return;
+        if (error) {
+          console.error("Failed to load auth session", error);
+          setUser(null);
+        } else {
+          setUser(data.session?.user ?? null);
+        }
+      } catch (error) {
+        if (active) {
+          console.error("Unexpected auth lookup error", error);
+          setUser(null);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      active = false;
+      data.subscription.unsubscribe();
+    };
+  }, []);
+
+  return { user, loading };
+}

--- a/src/pages/account/LessonDocEditor.tsx
+++ b/src/pages/account/LessonDocEditor.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef } from "react";
+import { Bold, Heading1, Heading2, Italic, Link as LinkIcon, List, PaintBucket, Type, Underline, AlignLeft, AlignCenter, AlignRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+const backgroundStyles: Record<string, string> = {
+  default: "bg-background",
+  notebook: "bg-slate-50",
+  calm: "bg-emerald-50",
+  midnight: "bg-slate-900 text-slate-100",
+};
+
+interface LessonDocEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  background: string;
+  onBackgroundChange: (value: string) => void;
+}
+
+export const LessonDocEditor = ({ value, onChange, background, onBackgroundChange }: LessonDocEditorProps) => {
+  const editorRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const element = editorRef.current;
+    if (!element) {
+      return;
+    }
+    if (element.innerHTML !== value) {
+      element.innerHTML = value;
+    }
+  }, [value]);
+
+  const exec = (command: string, argument?: string) => {
+    editorRef.current?.focus();
+    document.execCommand(command, false, argument);
+    onChange(editorRef.current?.innerHTML ?? "");
+  };
+
+  const handleInput = () => {
+    onChange(editorRef.current?.innerHTML ?? "");
+  };
+
+  const handleLink = () => {
+    const url = window.prompt("Enter link URL");
+    if (url) {
+      exec("createLink", url);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/40 p-2 text-sm">
+        <Button type="button" variant="ghost" size="icon" onClick={() => exec("formatBlock", "H1")}> 
+          <Heading1 className="h-4 w-4" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => exec("formatBlock", "H2")}> 
+          <Heading2 className="h-4 w-4" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => exec("bold")}> 
+          <Bold className="h-4 w-4" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => exec("italic")}> 
+          <Italic className="h-4 w-4" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => exec("underline")}> 
+          <Underline className="h-4 w-4" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => exec("insertUnorderedList")}> 
+          <List className="h-4 w-4" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => exec("justifyLeft")}> 
+          <AlignLeft className="h-4 w-4" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => exec("justifyCenter")}> 
+          <AlignCenter className="h-4 w-4" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => exec("justifyRight")}> 
+          <AlignRight className="h-4 w-4" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={handleLink}>
+          <LinkIcon className="h-4 w-4" />
+        </Button>
+        <label className="flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs font-medium text-muted-foreground">
+          <Type className="h-3 w-3" />
+          <input
+            type="color"
+            aria-label="Text colour"
+            className="h-4 w-8 cursor-pointer border-0 bg-transparent p-0"
+            onChange={event => exec("foreColor", event.target.value)}
+          />
+        </label>
+        <label className="flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs font-medium text-muted-foreground">
+          <PaintBucket className="h-3 w-3" />
+          <input
+            type="color"
+            aria-label="Highlight colour"
+            className="h-4 w-8 cursor-pointer border-0 bg-transparent p-0"
+            onChange={event => exec("backColor", event.target.value)}
+          />
+        </label>
+        <Select value={background} onValueChange={onBackgroundChange}>
+          <SelectTrigger className="h-8 w-[130px] text-xs">
+            <SelectValue placeholder="Background" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="default">Default</SelectItem>
+            <SelectItem value="notebook">Notebook</SelectItem>
+            <SelectItem value="calm">Calm</SelectItem>
+            <SelectItem value="midnight">Midnight</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div
+        ref={editorRef}
+        className={cn(
+          "min-h-[320px] w-full rounded-xl border border-border p-6 shadow-sm focus:outline-none",
+          backgroundStyles[background] ?? backgroundStyles.default,
+          "prose prose-sm max-w-none dark:prose-invert",
+        )}
+        contentEditable
+        role="textbox"
+        aria-label="Lesson plan document editor"
+        suppressContentEditableWarning
+        onInput={handleInput}
+      />
+    </div>
+  );
+};

--- a/src/pages/account/__tests__/AccountDashboard.test.tsx
+++ b/src/pages/account/__tests__/AccountDashboard.test.tsx
@@ -7,8 +7,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import AccountDashboard from "../index";
 import { en } from "@/translations/en";
 
-vi.mock("@/hooks/useRequireAuth", () => ({
-  useRequireAuth: () => ({
+vi.mock("@/hooks/useOptionalUser", () => ({
+  useOptionalUser: () => ({
     user: {
       id: "user-1",
       email: "user@example.com",
@@ -30,6 +30,26 @@ vi.mock("@/lib/classes", () => ({
   listMyClassesWithPlanCount: vi.fn().mockResolvedValue([]),
   createClass: vi.fn(),
   updateClass: vi.fn(),
+}));
+
+vi.mock("@/lib/data/students", () => ({
+  listMyStudents: vi.fn().mockResolvedValue([]),
+  getStudentProfile: vi.fn(),
+  recordStudentReportRequest: vi.fn(),
+  saveStudentAppraisalNote: vi.fn(),
+  saveStudentBehaviorNote: vi.fn(),
+}));
+
+vi.mock("@/lib/data/curriculum", () => ({
+  listCurriculumItems: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/data/assessments", () => ({
+  listAssessments: vi.fn().mockResolvedValue([]),
+  listAssessmentSubmissions: vi.fn().mockResolvedValue([]),
+  listAssessmentGrades: vi.fn().mockResolvedValue([]),
+  createAssessment: vi.fn(),
+  recordAssessmentGrade: vi.fn(),
 }));
 
 vi.mock("@/pages/account/components/UpcomingLessonsCard", () => ({


### PR DESCRIPTION
## Summary
- allow public viewing of the account dashboard by switching to an optional auth hook and guarding write actions
- embed a new lesson builder tab with a doc-style editor and remove the old modal workflow
- update navigation and routes to surface the dashboard link first and drop auth guards on dashboard-related pages
- add visitor messaging and disable management actions when no user is signed in

## Testing
- npm run test -- AccountDashboard

------
https://chatgpt.com/codex/tasks/task_e_68e0cea2640c8331b055acea8bb19571