### PR TITLE
Fix class creation for mixed table schemas

### DIFF
--- a/test/lib-happy-path.test.ts
+++ b/test/lib-happy-path.test.ts
@@ -277,16 +277,39 @@ describe("classes data helpers", () => {
       classes: {
         selectOrder: () => Promise.resolve({ data: [classRow], error: null }),
         selectMaybeSingle: () => Promise.resolve({ data: classRow, error: null }),
-        insert: payload =>
-          Promise.resolve({
-            data: { ...classRow, id: "class-2", title: payload.title },
+        insert: payload => {
+          const recordPayload = payload as Record<string, unknown>;
+          const payloadNameValue = recordPayload["name"];
+          const payloadTitleValue = recordPayload["title"];
+          const payloadName = typeof payloadNameValue === "string" ? payloadNameValue : undefined;
+          const payloadTitle = typeof payloadTitleValue === "string" ? payloadTitleValue : undefined;
+
+          return Promise.resolve({
+            data: {
+              ...classRow,
+              id: "class-2",
+              title: payloadTitle ?? payloadName ?? classRow.title,
+              name: payloadName ?? payloadTitle ?? classRow.title,
+            },
             error: null,
-          }),
-        update: ({ payload }) =>
-          Promise.resolve({
-            data: { ...classRow, title: payload.title ?? classRow.title },
+          });
+        },
+        update: ({ payload }) => {
+          const recordPayload = payload as Record<string, unknown>;
+          const payloadNameValue = recordPayload["name"];
+          const payloadTitleValue = recordPayload["title"];
+          const payloadName = typeof payloadNameValue === "string" ? payloadNameValue : undefined;
+          const payloadTitle = typeof payloadTitleValue === "string" ? payloadTitleValue : undefined;
+
+          return Promise.resolve({
+            data: {
+              ...classRow,
+              title: payloadTitle ?? payloadName ?? classRow.title,
+              name: payloadName ?? payloadTitle ?? classRow.title,
+            },
             error: null,
-          }),
+          });
+        },
         delete: () => Promise.resolve({ error: null }),
       },
       class_lesson_plans: {


### PR DESCRIPTION
## Summary
- add schema-aware payload builder that can fall back to legacy column names when creating or updating classes
- retry class insert/update with the legacy column mapping when the modern schema columns are missing
- update the supabase client test doubles to understand both `name` and `title` payload fields

## Testing
- npm test -- test/lib-happy-path.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0dccf6d488331bed87fd01625b967