### PR TITLE
Add teacher profile page and update account navigation

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -15,6 +15,7 @@ import BuilderLessonPlan from '@/pages/BuilderLessonPlan';
 import BuilderLessonPlanDetail from '@/pages/BuilderLessonPlanDetail';
 import Auth from '@/pages/Auth';
 import Account from '@/pages/account';
+import Profile from '@/pages/Profile';
 import ClassDashboard from '@/pages/account/ClassDashboard';
 import AccountResources from '@/pages/AccountResources';
 import AccountResourceNew from '@/pages/AccountResourceNew';
@@ -68,6 +69,7 @@ export const LocalizedRoutes = () => {
       <Route path="/faq" element={<RouteWrapper><FAQ /></RouteWrapper>} />
       <Route path="/auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
       <Route path="/account" element={<RouteWrapper><Account /></RouteWrapper>} />
+      <Route path="/profile" element={<RouteWrapper><Profile /></RouteWrapper>} />
       <Route path="/account/classes/:id" element={<RouteWrapper><ClassDashboard /></RouteWrapper>} />
       <Route path="/account/resources" element={<RouteWrapper><AccountResources /></RouteWrapper>} />
       <Route path="/account/resources/new" element={<RouteWrapper><AccountResourceNew /></RouteWrapper>} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,7 +8,7 @@ import {
   User,
   LogOut,
   BookOpen,
-  LayoutDashboard,
+  IdCard,
   GraduationCap,
 } from "lucide-react";
 import { useState, useEffect, useMemo } from "react";
@@ -46,7 +46,7 @@ const Navigation = () => {
 
   const navItems = useMemo(() => {
     const items = [
-      { name: t.nav.profile, path: "/account" },
+      { name: t.nav.profile, path: "/profile" },
       { name: t.nav.home, path: "/" },
       { name: t.nav.blog, path: "/blog" },
       { name: t.nav.curriculum ?? "Curriculum", path: "/curriculum" },
@@ -155,9 +155,9 @@ const Navigation = () => {
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
-                    onClick={() => navigate(getLocalizedNavPath("/account"))}
+                    onClick={() => navigate(getLocalizedNavPath("/profile"))}
                   >
-                    <LayoutDashboard className="mr-2 h-4 w-4" />
+                    <IdCard className="mr-2 h-4 w-4" />
                     {t.nav.profile}
                   </DropdownMenuItem>
                   <DropdownMenuItem

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useMemo, useState } from "react";
+import { User as SupabaseUser } from "@supabase/supabase-js";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { supabase } from "@/integrations/supabase/client";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/use-toast";
+import { Loader2, ShieldCheck } from "lucide-react";
+
+interface TeacherProfile {
+  firstName: string;
+  lastName: string;
+  school: string;
+  subject: string;
+  phoneNumber: string;
+  email: string;
+  avatarUrl?: string;
+}
+
+const Profile = () => {
+  const { t } = useLanguage();
+  const [user, setUser] = useState<SupabaseUser | null>(null);
+  const [isResettingPassword, setIsResettingPassword] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      setUser(data.user ?? null);
+    };
+
+    fetchUser();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const teacherProfile = useMemo<TeacherProfile>(() => {
+    const metadata = user?.user_metadata ?? {};
+
+    return {
+      firstName: metadata.firstName || metadata.first_name || t.profilePage.fallback.notProvided,
+      lastName: metadata.lastName || metadata.last_name || t.profilePage.fallback.notProvided,
+      school: metadata.school || t.profilePage.fallback.notProvided,
+      subject: metadata.subject || t.profilePage.fallback.notProvided,
+      phoneNumber: metadata.phoneNumber || metadata.phone_number || t.profilePage.fallback.notProvided,
+      email: user?.email ?? t.profilePage.fallback.notProvided,
+      avatarUrl: metadata.avatarUrl || metadata.avatar_url,
+    };
+  }, [t.profilePage.fallback.notProvided, user?.email, user?.user_metadata]);
+
+  const handlePasswordReset = async () => {
+    if (!user?.email) {
+      toast({
+        title: t.profilePage.security.resetError,
+        description: t.profilePage.security.noEmail,
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      setIsResettingPassword(true);
+      const { error } = await supabase.auth.resetPasswordForEmail(user.email, {
+        redirectTo: `${window.location.origin}/auth`,
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      toast({
+        title: t.profilePage.security.resetSent,
+        description: t.profilePage.security.resetDescription,
+      });
+    } catch (error) {
+      toast({
+        title: t.profilePage.security.resetError,
+        description: error instanceof Error ? error.message : String(error),
+        variant: "destructive",
+      });
+    } finally {
+      setIsResettingPassword(false);
+    }
+  };
+
+  const initials = useMemo(() => {
+    const firstInitial = teacherProfile.firstName?.[0] ?? "";
+    const lastInitial = teacherProfile.lastName?.[0] ?? "";
+    return `${firstInitial}${lastInitial}`.toUpperCase() || "ST";
+  }, [teacherProfile.firstName, teacherProfile.lastName]);
+
+  return (
+    <div className="container py-10">
+      <div className="mb-10 max-w-2xl">
+        <h1 className="text-3xl font-bold tracking-tight">
+          {t.profilePage.title}
+        </h1>
+        <p className="mt-2 text-muted-foreground">
+          {t.profilePage.subtitle}
+        </p>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <Card>
+          <CardHeader className="flex flex-row items-center gap-4">
+            <Avatar className="h-16 w-16">
+              {teacherProfile.avatarUrl ? (
+                <AvatarImage src={teacherProfile.avatarUrl} alt={teacherProfile.firstName} />
+              ) : null}
+              <AvatarFallback>{initials}</AvatarFallback>
+            </Avatar>
+            <div>
+              <CardTitle>{t.profilePage.info.title}</CardTitle>
+              <CardDescription>{t.profilePage.info.description}</CardDescription>
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-6">
+            <div className="grid gap-2">
+              <Label>{t.profilePage.info.firstName}</Label>
+              <Input value={teacherProfile.firstName} readOnly />
+            </div>
+            <div className="grid gap-2">
+              <Label>{t.profilePage.info.lastName}</Label>
+              <Input value={teacherProfile.lastName} readOnly />
+            </div>
+            <div className="grid gap-2">
+              <Label>{t.profilePage.info.school}</Label>
+              <Input value={teacherProfile.school} readOnly />
+            </div>
+            <div className="grid gap-2">
+              <Label>{t.profilePage.info.subject}</Label>
+              <Input value={teacherProfile.subject} readOnly />
+            </div>
+            <div className="grid gap-2">
+              <Label>{t.profilePage.info.phone}</Label>
+              <Input value={teacherProfile.phoneNumber} readOnly />
+            </div>
+            <div className="grid gap-2">
+              <Label>{t.profilePage.info.email}</Label>
+              <Input value={teacherProfile.email} readOnly />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-primary" />
+              {t.profilePage.security.title}
+            </CardTitle>
+            <CardDescription>{t.profilePage.security.description}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              {t.profilePage.security.instructions}
+            </p>
+            <Button onClick={handlePasswordReset} disabled={isResettingPassword} className="w-full">
+              {isResettingPassword ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              {t.profilePage.security.resetButton}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Profile;

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -17,7 +17,35 @@ export const en = {
     signIn: "Sign In",
     signUp: "Sign Up",
     signOut: "Sign Out",
-    profile: "My Dashboard"
+    profile: "My Profile"
+  },
+  profilePage: {
+    title: "My Profile",
+    subtitle: "Manage your teacher information and security preferences.",
+    info: {
+      title: "Teacher Information",
+      description: "Review the personal details connected to your SchoolTech Hub account.",
+      firstName: "First name",
+      lastName: "Last name",
+      school: "School",
+      subject: "Subject",
+      phone: "Phone number",
+      email: "Email",
+    },
+    security: {
+      title: "Security",
+      description: "Keep your account secure by updating your password when needed.",
+      instructions:
+        "Send a password reset link to your email address. Follow the instructions in the email to choose a new password.",
+      resetButton: "Send password reset email",
+      resetSent: "Password reset sent",
+      resetDescription: "Check your inbox for the password reset email and follow the link provided.",
+      resetError: "Unable to send reset email",
+      noEmail: "We could not find an email associated with your account.",
+    },
+    fallback: {
+      notProvided: "Not provided",
+    },
   },
   hero: {
     title: "Empowering Education Through Innovation",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -17,7 +17,35 @@ export const sq = {
     signIn: "Hyr",
     signUp: "Regjistrohu",
     signOut: "Dil",
-    profile: "Pulti Im"
+    profile: "Profili Im"
+  },
+  profilePage: {
+    title: "Profili im",
+    subtitle: "Menaxho informacionet e mësuesit dhe cilësimet e sigurisë.",
+    info: {
+      title: "Informacioni i mësuesit",
+      description: "Shiko të dhënat personale të lidhura me llogarinë tënde SchoolTech Hub.",
+      firstName: "Emri",
+      lastName: "Mbiemri",
+      school: "Shkolla",
+      subject: "Lënda",
+      phone: "Numri i telefonit",
+      email: "Email",
+    },
+    security: {
+      title: "Siguria",
+      description: "Mbaj llogarinë tënde të sigurt duke përditësuar fjalëkalimin kur është e nevojshme.",
+      instructions:
+        "Dërgo një lidhje për rinisjen e fjalëkalimit në emailin tënd dhe ndiq udhëzimet për të vendosur një fjalëkalim të ri.",
+      resetButton: "Dërgo email për rinisjen e fjalëkalimit",
+      resetSent: "Emaili për rinisjen u dërgua",
+      resetDescription: "Kontrollo kutinë postare dhe ndiq lidhjen për të përfunduar procesin.",
+      resetError: "Nuk mund të dërgohet emaili",
+      noEmail: "Nuk u gjet një email i lidhur me këtë llogari.",
+    },
+    fallback: {
+      notProvided: "E paplotësuar",
+    },
   },
   hero: {
     title: "Fuqizimi i Arsimit përmes Inovacionit",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -17,7 +17,35 @@ export const vi = {
     signIn: "Đăng nhập",
     signUp: "Đăng ký",
     signOut: "Đăng xuất",
-    profile: "Bảng điều khiển của tôi"
+    profile: "Hồ sơ của tôi"
+  },
+  profilePage: {
+    title: "Hồ sơ của tôi",
+    subtitle: "Quản lý thông tin giáo viên và cài đặt bảo mật của bạn.",
+    info: {
+      title: "Thông tin giáo viên",
+      description: "Xem lại các thông tin cá nhân được liên kết với tài khoản SchoolTech Hub của bạn.",
+      firstName: "Tên",
+      lastName: "Họ",
+      school: "Trường",
+      subject: "Môn giảng dạy",
+      phone: "Số điện thoại",
+      email: "Email",
+    },
+    security: {
+      title: "Bảo mật",
+      description: "Giữ an toàn cho tài khoản bằng cách cập nhật mật khẩu khi cần thiết.",
+      instructions:
+        "Gửi liên kết đặt lại mật khẩu đến email của bạn và làm theo hướng dẫn để tạo mật khẩu mới.",
+      resetButton: "Gửi email đặt lại mật khẩu",
+      resetSent: "Đã gửi email đặt lại",
+      resetDescription: "Kiểm tra hộp thư và làm theo liên kết để hoàn tất việc đặt lại mật khẩu.",
+      resetError: "Không thể gửi email đặt lại",
+      noEmail: "Không tìm thấy email liên kết với tài khoản của bạn.",
+    },
+    fallback: {
+      notProvided: "Chưa cung cấp",
+    },
   },
   hero: {
     title: "Trao quyền cho giáo dục thông qua đổi mới",


### PR DESCRIPTION
## Summary
- add a dedicated My Profile route and replace the old dashboard link in the navigation menu
- create a teacher profile page that surfaces personal information and a password reset action
- expand translation files with strings for the new profile experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0e183333083319c486610ef2fc94f