### PR TITLE
Remove curriculum link from navigation bar

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -49,7 +49,6 @@ const Navigation = () => {
       { name: t.nav.dashboard ?? t.nav.profile, path: "/profile" },
       { name: t.nav.home, path: "/" },
       { name: t.nav.blog, path: "/blog" },
-      { name: t.nav.curriculum ?? "Curriculum", path: "/account?tab=curriculum" },
       { name: t.nav.events, path: "/events" },
       { name: t.nav.services, path: "/services" },
       { name: t.nav.about, path: "/about" },
@@ -59,7 +58,6 @@ const Navigation = () => {
   }, [
     t.nav.about,
     t.nav.blog,
-    t.nav.curriculum,
     t.nav.dashboard,
     t.nav.events,
     t.nav.home,


### PR DESCRIPTION
## Summary
- remove the curriculum navigation item so it no longer appears in the main menu

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0f01fd1b4833189ef3913f1cc22d4