### PR TITLE
Add profile management page and improve class creation fallback

### DIFF
--- a/src/lib/data/classes.ts
+++ b/src/lib/data/classes.ts
@@ -185,13 +185,26 @@ function buildClassPayload(
 }
 
 function isUndefinedColumnError(error: unknown): boolean {
-  return Boolean(
-    error &&
-      typeof error === "object" &&
-      "code" in error &&
-      typeof (error as { code?: unknown }).code === "string" &&
-      (error as { code: string }).code === "42703",
-  );
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === "string" && code === "42703") {
+    return true;
+  }
+
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === "string" && /column .* does not exist/i.test(message)) {
+    return true;
+  }
+
+  const details = (error as { details?: unknown }).details;
+  if (typeof details === "string" && /column .* does not exist/i.test(details)) {
+    return true;
+  }
+
+  return false;
 }
 
 async function insertClassRecord(

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,7 +1,269 @@
-import AccountDashboard from "@/pages/account";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { Loader2, Mail, School, User as UserIcon } from "lucide-react";
+
+import { SEO } from "@/components/SEO";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { useOptionalUser } from "@/hooks/useOptionalUser";
+import { useToast } from "@/hooks/use-toast";
+import { useMyProfile } from "@/hooks/useMyProfile";
+import { supabase } from "@/integrations/supabase/client";
+import { createProfileImageSignedUrl, resolveAvatarReference } from "@/lib/avatar";
+import { SettingsPanel } from "@/pages/account/components/SettingsPanel";
+
+const extractMetadataValue = (metadata: Record<string, unknown>, key: string): string | null => {
+  const value = metadata[key];
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
 
 const Profile = () => {
-  return <AccountDashboard />;
+  const { t } = useLanguage();
+  const { toast } = useToast();
+  const { user, loading } = useOptionalUser();
+  const { fullName, schoolName } = useMyProfile();
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [isSendingReset, setIsSendingReset] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadAvatar = async () => {
+      if (!user) {
+        if (isMounted) {
+          setAvatarUrl(null);
+        }
+        return;
+      }
+
+      const metadata = (user.user_metadata ?? {}) as Record<string, unknown>;
+      const { reference, url } = resolveAvatarReference(metadata);
+
+      if (url) {
+        if (isMounted) {
+          setAvatarUrl(url);
+        }
+        return;
+      }
+
+      if (!reference) {
+        if (isMounted) {
+          setAvatarUrl(null);
+        }
+        return;
+      }
+
+      try {
+        const signedUrl = await createProfileImageSignedUrl(reference);
+        if (isMounted) {
+          setAvatarUrl(signedUrl);
+        }
+      } catch (error) {
+        console.error("Failed to resolve avatar", error);
+        if (isMounted) {
+          setAvatarUrl(null);
+        }
+      }
+    };
+
+    void loadAvatar();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [user]);
+
+  const metadata = (user?.user_metadata ?? {}) as Record<string, unknown>;
+  const firstName = extractMetadataValue(metadata, "first_name");
+  const lastName = extractMetadataValue(metadata, "last_name");
+  const subject = extractMetadataValue(metadata, "subject");
+  const phoneNumber = extractMetadataValue(metadata, "phone");
+
+  const fallbackValue = t.profilePage.fallback.notProvided;
+  const displayFullName = useMemo(() => {
+    if (fullName && fullName.trim().length > 0) {
+      return fullName.trim();
+    }
+    if (firstName || lastName) {
+      return [firstName, lastName].filter(Boolean).join(" ");
+    }
+    return fallbackValue;
+  }, [fallbackValue, firstName, fullName, lastName]);
+
+  const avatarFallback = useMemo(() => {
+    const source = displayFullName !== fallbackValue ? displayFullName : user?.email ?? "";
+    return source ? source.charAt(0).toUpperCase() : "?";
+  }, [displayFullName, fallbackValue, user?.email]);
+
+  const handleSendPasswordReset = async () => {
+    if (!user?.email) {
+      toast({
+        title: t.profilePage.security.resetError,
+        description: t.profilePage.security.noEmail,
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSendingReset(true);
+    try {
+      const redirectTo = typeof window !== "undefined" ? `${window.location.origin}/auth` : undefined;
+      const { error } = await supabase.auth.resetPasswordForEmail(user.email, {
+        redirectTo,
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      toast({
+        title: t.profilePage.security.resetSent,
+        description: t.profilePage.security.resetDescription,
+      });
+    } catch (error) {
+      console.error("Failed to send password reset email", error);
+      toast({
+        title: t.profilePage.security.resetError,
+        description: t.common.tryAgain,
+        variant: "destructive",
+      });
+    } finally {
+      setIsSendingReset(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-muted/10">
+        <SEO title={t.profilePage.title} description={t.profilePage.subtitle} />
+        <div className="container flex min-h-[60vh] items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen bg-muted/10">
+        <SEO title={t.profilePage.title} description={t.profilePage.subtitle} />
+        <div className="container flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+          <Card className="max-w-lg">
+            <CardHeader>
+              <CardTitle>{t.profilePage.title}</CardTitle>
+              <CardDescription>{t.profilePage.subtitle}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-muted-foreground">{t.profilePage.fallback.signInRequired}</p>
+              <Button asChild>
+                <Link to="/auth">{t.nav.signIn}</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  const detailItems = [
+    {
+      label: t.profilePage.info.email,
+      value: user.email ?? fallbackValue,
+      icon: <Mail className="h-4 w-4" />,
+    },
+    {
+      label: t.profilePage.info.firstName,
+      value: firstName ?? fallbackValue,
+      icon: <UserIcon className="h-4 w-4" />,
+    },
+    {
+      label: t.profilePage.info.lastName,
+      value: lastName ?? fallbackValue,
+      icon: <UserIcon className="h-4 w-4" />,
+    },
+    {
+      label: t.profilePage.info.school,
+      value: schoolName ?? extractMetadataValue(metadata, "school_name") ?? fallbackValue,
+      icon: <School className="h-4 w-4" />,
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-muted/10 pb-16">
+      <SEO title={t.profilePage.title} description={t.profilePage.subtitle} />
+      <div className="container space-y-8 py-10">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">{t.profilePage.title}</h1>
+          <p className="mt-2 max-w-2xl text-muted-foreground">{t.profilePage.subtitle}</p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[360px,1fr]">
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>{t.profilePage.info.title}</CardTitle>
+                <CardDescription>{t.profilePage.info.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="flex items-center gap-4">
+                  <Avatar className="h-20 w-20">
+                    {avatarUrl ? <AvatarImage src={avatarUrl} alt="" /> : null}
+                    <AvatarFallback>{avatarFallback}</AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="text-lg font-semibold text-foreground">{displayFullName}</p>
+                    <p className="text-sm text-muted-foreground">{subject ?? fallbackValue}</p>
+                    <p className="text-sm text-muted-foreground">{phoneNumber ?? fallbackValue}</p>
+                  </div>
+                </div>
+                <dl className="space-y-4">
+                  {detailItems.map(item => (
+                    <div key={item.label} className="flex items-start gap-3 rounded-lg border border-border/60 bg-background/80 p-3">
+                      <div className="mt-0.5 text-muted-foreground">{item.icon}</div>
+                      <div className="space-y-1">
+                        <dt className="text-xs uppercase tracking-wide text-muted-foreground">{item.label}</dt>
+                        <dd className="text-sm font-medium text-foreground">{item.value}</dd>
+                      </div>
+                    </div>
+                  ))}
+                </dl>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>{t.profilePage.security.title}</CardTitle>
+                <CardDescription>{t.profilePage.security.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-sm text-muted-foreground">{t.profilePage.security.instructions}</p>
+                <Button onClick={handleSendPasswordReset} disabled={isSendingReset}>
+                  {isSendingReset ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      {t.common.loading}
+                    </>
+                  ) : (
+                    t.profilePage.security.resetButton
+                  )}
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div>
+            <SettingsPanel user={user} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default Profile;

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -253,14 +253,6 @@ const AccountDashboard = () => {
     return emailName ? `Mr ${emailName}` : defaultSalutation;
   }, [fullName, user, defaultSalutation]);
 
-  const accountDisplayName = useMemo(() => {
-    const trimmed = fullName?.trim();
-    if (trimmed && trimmed.length > 0) {
-      return trimmed;
-    }
-    return user?.email ?? defaultSalutation;
-  }, [fullName, user, defaultSalutation]);
-
   const classesQuery = useQuery({
     queryKey: ["dashboard-classes"],
     queryFn: () => listMyClassesWithPlanCount(),
@@ -592,9 +584,6 @@ const AccountDashboard = () => {
                   <CardDescription>
                     Everything you need to run your classroom in one place.
                   </CardDescription>
-                  {accountDisplayName ? (
-                    <p className="text-sm text-muted-foreground">Signed in as {accountDisplayName}</p>
-                  ) : null}
                 </div>
               </div>
               <div className="flex flex-wrap gap-2">
@@ -651,7 +640,7 @@ const AccountDashboard = () => {
                   Ask a question
                 </Button>
               )}
-              <Button onClick={() => handleOpenLessonBuilder(null, null)}>
+              <Button onClick={() => handleTabChange("curriculum")}>
                 <NotebookPen className="mr-2 h-4 w-4" /> Plan a lesson
               </Button>
             </div>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -45,6 +45,7 @@ export const en = {
     },
     fallback: {
       notProvided: "Not provided",
+      signInRequired: "Sign in to view your profile details.",
     },
   },
   hero: {


### PR DESCRIPTION
## Summary
- add a dedicated My Profile page that surfaces teacher details, reset-password controls, and the existing settings editor
- adjust the dashboard lesson planner shortcut and copy, and extend translations for the new profile view
- make the Supabase class creation fallback detect additional undefined-column errors so inserts succeed on legacy schemas

## Testing
- npm run test -- src/pages/account/__tests__/AccountDashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0eeeb5ed08331ad0553f2842182b7