### PR TITLE
Rename profile navigation label in menu

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -46,7 +46,6 @@ const Navigation = () => {
 
   const navItems = useMemo(() => {
     const items = [
-      { name: t.nav.dashboard ?? t.nav.profile, path: "/profile" },
       { name: t.nav.home, path: "/" },
       { name: t.nav.blog, path: "/blog" },
       { name: t.nav.events, path: "/events" },
@@ -58,10 +57,8 @@ const Navigation = () => {
   }, [
     t.nav.about,
     t.nav.blog,
-    t.nav.dashboard,
     t.nav.events,
     t.nav.home,
-    t.nav.profile,
     t.nav.services,
   ]);
   
@@ -164,7 +161,7 @@ const Navigation = () => {
                     onClick={() => navigate(getLocalizedNavPath("/profile"))}
                   >
                     <IdCard className="mr-2 h-4 w-4" />
-                    {t.nav.dashboard ?? t.nav.profile}
+                    {t.nav.profile ?? t.nav.dashboard}
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={() => navigate(getLocalizedNavPath("/account?tab=classes"))}
@@ -251,7 +248,7 @@ const Navigation = () => {
                       onClick={() => setIsOpen(false)}
                     >
                       <Button className="w-full" variant="secondary">
-                        {t.nav.dashboard ?? t.nav.profile}
+                        {t.nav.profile ?? t.nav.dashboard}
                       </Button>
                     </Link>
                     <Link

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -20,7 +20,7 @@ type DynamicLink = RouteLink & {
 type TranslationDictionary = typeof en;
 
 const createStaticRoutes = (dictionary: TranslationDictionary): RouteLink[] => [
-  { title: dictionary.nav.dashboard, url: "/" },
+  { title: dictionary.nav.profile ?? dictionary.nav.dashboard, url: "/profile" },
   { title: dictionary.nav.home, url: "/home" },
   { title: dictionary.nav.about, url: "/about" },
   { title: dictionary.nav.services, url: "/services" },

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,6 +1,6 @@
 export const en = {
   nav: {
-    dashboard: "My Dashboard",
+    dashboard: "My profile",
     home: "Home",
     about: "About",
     services: "Services",
@@ -17,7 +17,7 @@ export const en = {
     signIn: "Sign In",
     signUp: "Sign Up",
     signOut: "Sign Out",
-    profile: "My Dashboard"
+    profile: "My profile"
   },
   profilePage: {
     title: "My Profile",

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -1,6 +1,6 @@
 export const sq = {
   nav: {
-    dashboard: "Pulti im",
+    dashboard: "Profili im",
     home: "Ballina",
     about: "Rreth Nesh",
     services: "Shërbimet",
@@ -17,7 +17,7 @@ export const sq = {
     signIn: "Hyr",
     signUp: "Regjistrohu",
     signOut: "Dil",
-    profile: "Pulti Im"
+    profile: "Profili im"
   },
   profilePage: {
     title: "Profili im",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -1,6 +1,6 @@
 export const vi = {
   nav: {
-    dashboard: "Bảng điều khiển của tôi",
+    dashboard: "Hồ sơ của tôi",
     home: "Trang chủ",
     about: "Về chúng tôi",
     services: "Dịch vụ",
@@ -17,7 +17,7 @@ export const vi = {
     signIn: "Đăng nhập",
     signUp: "Đăng ký",
     signOut: "Đăng xuất",
-    profile: "Bảng điều khiển của tôi"
+    profile: "Hồ sơ của tôi"
   },
   profilePage: {
     title: "Hồ sơ của tôi",


### PR DESCRIPTION
## Summary
- rename the dashboard navigation label to "My profile" across supported locales
- remove the profile link from the primary navigation menu while keeping it in the account dropdown
- point the sitemap profile entry to the /profile route with the updated label

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0f2b0082483319bd4b7be83a9bec7