### PR TITLE
Add edit link from profile overview to settings

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -198,9 +198,14 @@ const Profile = () => {
     <div className="min-h-screen bg-muted/10 pb-16">
       <SEO title={t.profilePage.title} description={t.profilePage.subtitle} />
       <div className="container space-y-8 py-10">
-        <div>
-          <h1 className="text-3xl font-bold text-foreground">{t.profilePage.title}</h1>
-          <p className="mt-2 max-w-2xl text-muted-foreground">{t.profilePage.subtitle}</p>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-foreground">{t.profilePage.title}</h1>
+            <p className="mt-2 max-w-2xl text-muted-foreground">{t.profilePage.subtitle}</p>
+          </div>
+          <Button asChild className="sm:shrink-0" variant="outline">
+            <a href="#profile-settings">{t.profilePage.editButton}</a>
+          </Button>
         </div>
 
         <div className="grid gap-6 lg:grid-cols-[360px,1fr]">
@@ -257,7 +262,7 @@ const Profile = () => {
             </Card>
           </div>
 
-          <div>
+          <div id="profile-settings">
             <SettingsPanel user={user} />
           </div>
         </div>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -22,6 +22,7 @@ export const en = {
   profilePage: {
     title: "My Profile",
     subtitle: "Manage your teacher information and security preferences.",
+    editButton: "Edit profile",
     info: {
       title: "Teacher Information",
       description: "Review the personal details connected to your SchoolTech Hub account.",


### PR DESCRIPTION
## Summary
- add an edit profile button that anchors to the settings panel on the profile page
- expose translation copy for the new edit profile button label

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0f87c65608331a7c2d4573c5286ed