### PR TITLE
Reorder navigation to show Dashboard first

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -47,6 +47,7 @@ const Navigation = () => {
 
   const navItems = useMemo(() => {
     const items = [
+      { name: t.dashboard.header.title, path: "/dashboard" },
       { name: t.nav.home, path: "/" },
       { name: t.nav.blog, path: "/blog" },
       { name: t.nav.events, path: "/events" },
@@ -56,6 +57,7 @@ const Navigation = () => {
 
     return items;
   }, [
+    t.dashboard.header.title,
     t.nav.about,
     t.nav.blog,
     t.nav.events,


### PR DESCRIPTION
## Summary
- add the dashboard route as the first entry in the primary navigation menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0fdb555988331b74811a1981ed09a