### PR TITLE
Remove dashboard resources tab

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -204,9 +204,6 @@ export default function DashboardPage() {
           <TabsTrigger value="lessonPlans" disabled>
             {t.dashboard.tabs.lessonPlans}
           </TabsTrigger>
-          <TabsTrigger value="resources" disabled>
-            {t.dashboard.tabs.resources}
-          </TabsTrigger>
           <TabsTrigger value="activity" disabled>
             {t.dashboard.tabs.activity}
           </TabsTrigger>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -66,7 +66,6 @@ export const en = {
       curriculum: "Curriculum",
       classes: "My Classes",
       lessonPlans: "Lesson Plans",
-      resources: "Resources",
       activity: "Activity",
     },
     common: {

--- a/src/translations/sq.ts
+++ b/src/translations/sq.ts
@@ -64,7 +64,6 @@ export const sq = {
       curriculum: "Kurrikul",
       classes: "Klasat e mia",
       lessonPlans: "Planet mësimore",
-      resources: "Burimet",
       activity: "Aktiviteti",
     },
     common: {

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -64,7 +64,6 @@ export const vi = {
       curriculum: "Chương trình",
       classes: "Lớp học của tôi",
       lessonPlans: "Kế hoạch",
-      resources: "Tài nguyên",
       activity: "Hoạt động",
     },
     common: {


### PR DESCRIPTION
## Summary
- remove the unused Resources tab from the dashboard navigation
- align English, Albanian, and Vietnamese translations with the updated tab set

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e1026030748331b5809df0b0ed699e