### PR TITLE
Refine blog filters layout

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -13,6 +13,15 @@ import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 import { cn } from "@/lib/utils";
@@ -689,10 +698,10 @@ const Blog = () => {
           </div>
         </section>
 
-        <section className="border-b border-border/60 bg-background/40">
-          <div className="container py-10">
-            <div className="flex flex-col gap-6">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <section className="container py-12">
+          <div className="flex flex-col gap-10 lg:flex-row">
+            <aside className="space-y-8 rounded-3xl border border-border/40 bg-background/40 p-6 backdrop-blur lg:w-80 lg:flex-shrink-0">
+              <div className="space-y-3">
                 <div>
                   <h2 className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
                     {t.blog.filters.title}
@@ -702,242 +711,276 @@ const Blog = () => {
                   </p>
                 </div>
                 {hasActiveFilters ? (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={clearFilters}
-                    className="w-full sm:w-auto"
-                  >
+                  <Button variant="outline" size="sm" onClick={clearFilters} className="w-full">
                     {t.blog.filters.clear}
                   </Button>
                 ) : null}
               </div>
 
-              <div className="grid gap-8 lg:grid-cols-2 xl:grid-cols-3">
-                {BLOG_FILTER_KEYS.map(key => {
-                  const options = optionEntries[key] ?? [];
-                  if (!options.length) {
-                    return null;
-                  }
+              <div className="space-y-6">
+                <div className="space-y-2">
+                  <Label htmlFor="blog-category-filter" className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                    {t.blog.filters.category}
+                  </Label>
+                  <Select
+                    value={filters.category[0] ?? undefined}
+                    onValueChange={(value) => {
+                      setFilters(prev => ({ ...prev, category: value ? [value] : [] }));
+                    }}
+                  >
+                    <SelectTrigger
+                      id="blog-category-filter"
+                      className="h-11 w-full rounded-full border-border/50 bg-background/80 text-left"
+                    >
+                      <SelectValue placeholder={t.blog.filters.category} />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-64">
+                      {optionEntries.category?.map(([value, label]) => (
+                        <SelectItem key={`category-${value}`} value={value}>
+                          {label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {filters.category.length > 0 ? (
+                    <Button
+                      variant="link"
+                      size="sm"
+                      className="h-auto px-0 text-xs text-muted-foreground"
+                      onClick={() => setFilters(prev => ({ ...prev, category: [] }))}
+                    >
+                      {t.blog.filters.clear}
+                    </Button>
+                  ) : null}
+                </div>
 
-                  const sectionLabel = {
-                    category: t.blog.filters.category,
-                    stage: t.blog.filters.stage,
-                    subject: t.blog.filters.subject,
-                    delivery: t.blog.filters.delivery,
-                    payment: t.blog.filters.payment,
-                    platform: t.blog.filters.platform,
-                  }[key];
+                <Accordion type="multiple" className="space-y-1">
+                  {BLOG_FILTER_KEYS.filter((key): key is Exclude<BlogFilterKey, "category"> => key !== "category").map(key => {
+                    const options = optionEntries[key] ?? [];
+                    if (!options.length) {
+                      return null;
+                    }
 
-                  return (
-                    <div key={key} className="space-y-3">
-                      <div className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                        {sectionLabel}
+                    const sectionLabel = {
+                      stage: t.blog.filters.stage,
+                      subject: t.blog.filters.subject,
+                      delivery: t.blog.filters.delivery,
+                      payment: t.blog.filters.payment,
+                      platform: t.blog.filters.platform,
+                    }[key];
+
+                    return (
+                      <AccordionItem key={key} value={key} className="border-border/40">
+                        <AccordionTrigger className="text-sm font-semibold text-left">
+                          {sectionLabel}
+                        </AccordionTrigger>
+                        <AccordionContent>
+                          <div className="flex flex-wrap gap-2 pt-2">
+                            {options.map(([value, label]) => (
+                              <FilterChip
+                                key={`${key}-${value}`}
+                                label={label}
+                                active={filters[key].includes(value)}
+                                onToggle={() => toggleFilter(key, value)}
+                              />
+                            ))}
+                          </div>
+                        </AccordionContent>
+                      </AccordionItem>
+                    );
+                  })}
+                </Accordion>
+              </div>
+            </aside>
+
+            <div className="flex-1 space-y-8">
+              {error ? (
+                <Alert variant="destructive">
+                  <AlertTitle>Something went wrong</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              ) : null}
+
+              {loading ? (
+                <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                  {Array.from({ length: 6 }).map((_, index) => (
+                    <Card key={index} className="overflow-hidden border-border/40">
+                      <Skeleton className="h-48 w-full" />
+                      <CardHeader className="space-y-3">
+                        <Skeleton className="h-5 w-24" />
+                        <Skeleton className="h-6 w-3/4" />
+                        <Skeleton className="h-4 w-full" />
+                        <Skeleton className="h-4 w-2/3" />
+                      </CardHeader>
+                      <CardFooter className="flex items-center justify-between">
+                        <Skeleton className="h-4 w-24" />
+                        <Skeleton className="h-9 w-28" />
+                      </CardFooter>
+                    </Card>
+                  ))}
+                </div>
+              ) : filteredPosts.length === 0 ? (
+                <Card className="border-dashed border-border/60 bg-background/40">
+                  <CardContent className="py-16 text-center">
+                    <h2 className="text-2xl font-semibold">{t.blog.states.empty}</h2>
+                    <p className="mt-2 text-muted-foreground">
+                      {t.blog.subtitle}
+                    </p>
+                  </CardContent>
+                </Card>
+              ) : (
+                <div className="space-y-12">
+                  {featuredPosts.length > 0 ? (
+                    <div className="space-y-6">
+                      <div className="flex items-center gap-3">
+                        <div className="h-1 w-12 rounded-full bg-primary" />
+                        <span className="text-sm font-semibold uppercase tracking-widest text-primary">
+                          {t.blog.badges.featured}
+                        </span>
                       </div>
-                      <div className="flex flex-wrap gap-2">
-                        {options.map(([value, label]) => (
-                          <FilterChip
-                            key={`${key}-${value}`}
-                            label={label}
-                            active={filters[key].includes(value)}
-                            onToggle={() => toggleFilter(key, value)}
-                          />
+                      <div className="grid gap-6 md:grid-cols-2">
+                        {featuredPosts.map(post => (
+                          <Card key={post.id} className="group overflow-hidden border-primary/30 bg-background/80 shadow-[0_10px_40px_rgba(33,150,243,0.08)]">
+                            {post.featured_image ? (
+                              <div className="relative h-56 overflow-hidden">
+                                <img
+                                  src={post.featured_image}
+                                  alt={post.title}
+                                  className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                                  loading="lazy"
+                                />
+                              </div>
+                            ) : null}
+                            <CardHeader className="space-y-3">
+                              <div className="flex flex-wrap items-center gap-2">
+                                {post.category ? (
+                                  <Badge variant="outline" className="rounded-full border-primary/60 text-primary">
+                                    {getCategoryLabel(post.category)}
+                                  </Badge>
+                                ) : null}
+                                {Array.isArray(post.tags)
+                                  ? post.tags.slice(0, 2).map(tag => (
+                                      <Badge key={tag} variant="secondary" className="rounded-full bg-primary/10 text-primary">
+                                        <Tag className="mr-1 h-3.5 w-3.5" />
+                                        {tag}
+                                      </Badge>
+                                    ))
+                                  : null}
+                              </div>
+                              <h2 className="text-2xl font-semibold leading-tight text-white transition-colors group-hover:text-primary">
+                                {post.title}
+                              </h2>
+                              {post.subtitle ? (
+                                <p className="text-base text-muted-foreground">{post.subtitle}</p>
+                              ) : null}
+                              <p className="text-sm text-muted-foreground/90">
+                                {post.excerpt}
+                              </p>
+                            </CardHeader>
+                            <CardFooter className="flex flex-col gap-4 border-t border-border/40 bg-background/60 p-6 sm:flex-row sm:items-center sm:justify-between">
+                              <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
+                                <span className="flex items-center gap-1.5">
+                                  <User className="h-4 w-4 text-primary" />
+                                  {t.blog.postedBy} {getAuthorName(post)}
+                                </span>
+                                {formatPublishedDate(post.published_at ?? post.created_at) ? (
+                                  <span className="flex items-center gap-1.5">
+                                    <Calendar className="h-4 w-4 text-primary" />
+                                    {formatPublishedDate(post.published_at ?? post.created_at)}
+                                  </span>
+                                ) : null}
+                                {getReadTimeLabel(post) ? (
+                                  <span className="flex items-center gap-1.5">
+                                    <Clock className="h-4 w-4 text-primary" />
+                                    {getReadTimeLabel(post)}
+                                  </span>
+                                ) : null}
+                              </div>
+                              <Button asChild size="lg" className="rounded-full">
+                                <Link to={getLocalizedPath(`/blog/${post.slug}`, language)}>
+                                  {t.blog.readMore}
+                                </Link>
+                              </Button>
+                            </CardFooter>
+                          </Card>
                         ))}
                       </div>
                     </div>
-                  );
-                })}
-              </div>
+                  ) : null}
+
+                  {regularPosts.length > 0 ? (
+                    <div className="space-y-6">
+                      <div className="flex items-center justify-between">
+                        <h2 className="text-2xl font-semibold">{t.blog.title}</h2>
+                        <span className="text-sm text-muted-foreground">
+                          {regularPosts.length} {regularPosts.length === 1 ? "post" : "posts"}
+                        </span>
+                      </div>
+                      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                        {regularPosts.map(post => (
+                          <Card key={post.id} className="group flex h-full flex-col overflow-hidden border-border/40 bg-background/70">
+                            {post.featured_image ? (
+                              <div className="relative h-44 overflow-hidden">
+                                <img
+                                  src={post.featured_image}
+                                  alt={post.title}
+                                  className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                                  loading="lazy"
+                                />
+                              </div>
+                            ) : null}
+                            <CardHeader className="space-y-3">
+                              <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+                                {post.category ? (
+                                  <Badge variant="outline" className="rounded-full border-muted-foreground/40 text-muted-foreground">
+                                    {getCategoryLabel(post.category)}
+                                  </Badge>
+                                ) : null}
+                                {getReadTimeLabel(post) ? (
+                                  <span className="flex items-center gap-1">
+                                    <Clock className="h-3.5 w-3.5" />
+                                    {getReadTimeLabel(post)}
+                                  </span>
+                                ) : null}
+                              </div>
+                              <h3 className="text-xl font-semibold leading-tight text-white transition-colors group-hover:text-primary">
+                                {post.title}
+                              </h3>
+                              {post.subtitle ? (
+                                <p className="text-sm text-muted-foreground">{post.subtitle}</p>
+                              ) : null}
+                              <p className="text-sm text-muted-foreground/90 line-clamp-3">
+                                {post.excerpt}
+                              </p>
+                            </CardHeader>
+                            <CardFooter className="mt-auto flex items-center justify-between border-t border-border/40 bg-background/50 p-6">
+                              <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+                                <span className="flex items-center gap-1.5">
+                                  <User className="h-3.5 w-3.5" />
+                                  {getAuthorName(post)}
+                                </span>
+                                {formatPublishedDate(post.published_at ?? post.created_at) ? (
+                                  <span className="flex items-center gap-1.5">
+                                    <Calendar className="h-3.5 w-3.5" />
+                                    {formatPublishedDate(post.published_at ?? post.created_at)}
+                                  </span>
+                                ) : null}
+                              </div>
+                              <Button asChild variant="secondary" size="sm" className="rounded-full">
+                                <Link to={getLocalizedPath(`/blog/${post.slug}`, language)}>
+                                  {t.blog.readMore}
+                                </Link>
+                              </Button>
+                            </CardFooter>
+                          </Card>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                  </div>
+                )}
             </div>
           </div>
-        </section>
-
-        <section className="container py-12">
-          {error ? (
-            <Alert variant="destructive" className="mb-8">
-              <AlertTitle>Something went wrong</AlertTitle>
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          ) : null}
-
-          {loading ? (
-            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {Array.from({ length: 6 }).map((_, index) => (
-                <Card key={index} className="overflow-hidden border-border/40">
-                  <Skeleton className="h-48 w-full" />
-                  <CardHeader className="space-y-3">
-                    <Skeleton className="h-5 w-24" />
-                    <Skeleton className="h-6 w-3/4" />
-                    <Skeleton className="h-4 w-full" />
-                    <Skeleton className="h-4 w-2/3" />
-                  </CardHeader>
-                  <CardFooter className="flex items-center justify-between">
-                    <Skeleton className="h-4 w-24" />
-                    <Skeleton className="h-9 w-28" />
-                  </CardFooter>
-                </Card>
-              ))}
-            </div>
-          ) : filteredPosts.length === 0 ? (
-            <Card className="border-dashed border-border/60 bg-background/40">
-              <CardContent className="py-16 text-center">
-                <h2 className="text-2xl font-semibold">{t.blog.states.empty}</h2>
-                <p className="mt-2 text-muted-foreground">
-                  {t.blog.subtitle}
-                </p>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="space-y-12">
-              {featuredPosts.length > 0 ? (
-                <div className="space-y-6">
-                  <div className="flex items-center gap-3">
-                    <div className="h-1 w-12 rounded-full bg-primary" />
-                    <span className="text-sm font-semibold uppercase tracking-widest text-primary">
-                      {t.blog.badges.featured}
-                    </span>
-                  </div>
-                  <div className="grid gap-6 md:grid-cols-2">
-                    {featuredPosts.map(post => (
-                      <Card key={post.id} className="group overflow-hidden border-primary/30 bg-background/80 shadow-[0_10px_40px_rgba(33,150,243,0.08)]">
-                        {post.featured_image ? (
-                          <div className="relative h-56 overflow-hidden">
-                            <img
-                              src={post.featured_image}
-                              alt={post.title}
-                              className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                              loading="lazy"
-                            />
-                          </div>
-                        ) : null}
-                        <CardHeader className="space-y-3">
-                          <div className="flex flex-wrap items-center gap-2">
-                            {post.category ? (
-                              <Badge variant="outline" className="rounded-full border-primary/60 text-primary">
-                                {getCategoryLabel(post.category)}
-                              </Badge>
-                            ) : null}
-                            {Array.isArray(post.tags)
-                              ? post.tags.slice(0, 2).map(tag => (
-                                <Badge key={tag} variant="secondary" className="rounded-full bg-primary/10 text-primary">
-                                  <Tag className="mr-1 h-3.5 w-3.5" />
-                                  {tag}
-                                </Badge>
-                              ))
-                              : null}
-                          </div>
-                          <h2 className="text-2xl font-semibold leading-tight text-white transition-colors group-hover:text-primary">
-                            {post.title}
-                          </h2>
-                          {post.subtitle ? (
-                            <p className="text-base text-muted-foreground">{post.subtitle}</p>
-                          ) : null}
-                          <p className="text-sm text-muted-foreground/90">
-                            {post.excerpt}
-                          </p>
-                        </CardHeader>
-                        <CardFooter className="flex flex-col gap-4 border-t border-border/40 bg-background/60 p-6 sm:flex-row sm:items-center sm:justify-between">
-                          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
-                            <span className="flex items-center gap-1.5">
-                              <User className="h-4 w-4 text-primary" />
-                              {t.blog.postedBy} {getAuthorName(post)}
-                            </span>
-                            {formatPublishedDate(post.published_at ?? post.created_at) ? (
-                              <span className="flex items-center gap-1.5">
-                                <Calendar className="h-4 w-4 text-primary" />
-                                {formatPublishedDate(post.published_at ?? post.created_at)}
-                              </span>
-                            ) : null}
-                            {getReadTimeLabel(post) ? (
-                              <span className="flex items-center gap-1.5">
-                                <Clock className="h-4 w-4 text-primary" />
-                                {getReadTimeLabel(post)}
-                              </span>
-                            ) : null}
-                          </div>
-                          <Button asChild size="lg" className="rounded-full">
-                            <Link to={getLocalizedPath(`/blog/${post.slug}`, language)}>
-                              {t.blog.readMore}
-                            </Link>
-                          </Button>
-                        </CardFooter>
-                      </Card>
-                    ))}
-                  </div>
-                </div>
-              ) : null}
-
-              {regularPosts.length > 0 ? (
-                <div className="space-y-6">
-                  <div className="flex items-center justify-between">
-                    <h2 className="text-2xl font-semibold">{t.blog.title}</h2>
-                    <span className="text-sm text-muted-foreground">
-                      {regularPosts.length} {regularPosts.length === 1 ? "post" : "posts"}
-                    </span>
-                  </div>
-                  <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-                    {regularPosts.map(post => (
-                      <Card key={post.id} className="group flex h-full flex-col overflow-hidden border-border/40 bg-background/70">
-                        {post.featured_image ? (
-                          <div className="relative h-44 overflow-hidden">
-                            <img
-                              src={post.featured_image}
-                              alt={post.title}
-                              className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                              loading="lazy"
-                            />
-                          </div>
-                        ) : null}
-                        <CardHeader className="space-y-3">
-                          <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-                            {post.category ? (
-                              <Badge variant="outline" className="rounded-full border-muted-foreground/40 text-muted-foreground">
-                                {getCategoryLabel(post.category)}
-                              </Badge>
-                            ) : null}
-                            {getReadTimeLabel(post) ? (
-                              <span className="flex items-center gap-1">
-                                <Clock className="h-3.5 w-3.5" />
-                                {getReadTimeLabel(post)}
-                              </span>
-                            ) : null}
-                          </div>
-                          <h3 className="text-xl font-semibold leading-tight text-white transition-colors group-hover:text-primary">
-                            {post.title}
-                          </h3>
-                          {post.subtitle ? (
-                            <p className="text-sm text-muted-foreground">{post.subtitle}</p>
-                          ) : null}
-                          <p className="text-sm text-muted-foreground/90 line-clamp-3">
-                            {post.excerpt}
-                          </p>
-                        </CardHeader>
-                        <CardFooter className="mt-auto flex items-center justify-between border-t border-border/40 bg-background/50 p-6">
-                          <div className="flex flex-col gap-1 text-xs text-muted-foreground">
-                            <span className="flex items-center gap-1.5">
-                              <User className="h-3.5 w-3.5" />
-                              {getAuthorName(post)}
-                            </span>
-                            {formatPublishedDate(post.published_at ?? post.created_at) ? (
-                              <span className="flex items-center gap-1.5">
-                                <Calendar className="h-3.5 w-3.5" />
-                                {formatPublishedDate(post.published_at ?? post.created_at)}
-                              </span>
-                            ) : null}
-                          </div>
-                          <Button asChild variant="secondary" size="sm" className="rounded-full">
-                            <Link to={getLocalizedPath(`/blog/${post.slug}`, language)}>
-                              {t.blog.readMore}
-                            </Link>
-                          </Button>
-                        </CardFooter>
-                      </Card>
-                    ))}
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          )}
         </section>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- move blog filters into a sidebar layout with a dedicated category select dropdown
- collapse secondary filters into an accordion for easier browsing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1029fa7108331b52a0e1bba18fcc1