### PR TITLE
Add editable personal details to profile settings

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { Loader2, Mail, School, User as UserIcon } from "lucide-react";
+import { BookOpen, Loader2, Mail, Phone, School, User as UserIcon } from "lucide-react";
 
 import { SEO } from "@/components/SEO";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -186,6 +186,16 @@ const Profile = () => {
       label: t.profilePage.info.lastName,
       value: lastName ?? fallbackValue,
       icon: <UserIcon className="h-4 w-4" />,
+    },
+    {
+      label: t.profilePage.info.subject,
+      value: subject ?? fallbackValue,
+      icon: <BookOpen className="h-4 w-4" />,
+    },
+    {
+      label: t.profilePage.info.phone,
+      value: phoneNumber ?? fallbackValue,
+      icon: <Phone className="h-4 w-4" />,
     },
     {
       label: t.profilePage.info.school,

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1586,6 +1586,19 @@ export const en = {
       changeButton: "Change avatar",
       uploadButton: "Save new avatar"
     },
+    personal: {
+      title: "Personal information",
+      description: "Update the details that appear on your profile.",
+      firstNameLabel: "First name",
+      firstNamePlaceholder: "e.g. Jordan",
+      lastNameLabel: "Last name",
+      lastNamePlaceholder: "e.g. Rivera",
+      subjectLabel: "Subject focus",
+      subjectPlaceholder: "e.g. Mathematics",
+      phoneLabel: "Phone number",
+      phonePlaceholder: "e.g. +1 555 123 4567",
+      saveButton: "Save personal info"
+    },
     school: {
       title: "School information",
       description: "Share your school's details to personalise lesson previews and exports.",


### PR DESCRIPTION
## Summary
- add a personal information form to the account settings panel so names, subject focus, and phone number can be updated
- persist changes to Supabase auth metadata/profile records and refresh the displayed details, including subject and phone on the profile page
- localize copy for the new personal information controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e10b95b9ac8331a465351526133f0b