### PR TITLE
Enable editable dashboard example data

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useToast } from "@/hooks/use-toast";
 import { useOptionalUser } from "@/hooks/useOptionalUser";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -28,6 +29,7 @@ import {
   fetchCurriculumItems,
   fetchMyClasses,
   fetchMyProfile,
+  seedExampleDashboardData,
 } from "@/features/dashboard/api";
 import {
   DASHBOARD_EXAMPLE_CLASS,
@@ -162,6 +164,21 @@ export default function DashboardPage() {
     },
   });
 
+  const seedExampleDataMutation = useMutation({
+    mutationFn: () => seedExampleDashboardData({ ownerId: user!.id }),
+    onSuccess: result => {
+      toast({ description: t.dashboard.toasts.exampleDataCreated });
+      setActiveCurriculumId(result.curriculum.id);
+      queryClient.setQueryData(["dashboard-curriculum-items", result.curriculum.id], result.items);
+      void queryClient.invalidateQueries({ queryKey: ["dashboard-classes", user?.id] });
+      void queryClient.invalidateQueries({ queryKey: ["dashboard-curricula", user?.id] });
+      void queryClient.invalidateQueries({ queryKey: ["dashboard-curriculum-items"], exact: false });
+    },
+    onError: () => {
+      toast({ description: t.dashboard.toasts.error, variant: "destructive" });
+    },
+  });
+
   const handleQuickAction = (action: DashboardQuickAction) => {
     switch (action) {
       case "ask-question":
@@ -194,6 +211,13 @@ export default function DashboardPage() {
     }
     return [DASHBOARD_EXAMPLE_CURRICULUM];
   }, [curriculaQuery.data]);
+
+  const showingExampleData = useMemo(() => {
+    if (classesQuery.isLoading || curriculaQuery.isLoading) {
+      return false;
+    }
+    return classes.some(item => item.isExample) || curricula.some(item => item.isExample);
+  }, [classes, curricula, classesQuery.isLoading, curriculaQuery.isLoading]);
 
   const fallbackCurriculumId = curricula[0]?.id ?? null;
   const effectiveCurriculumId = activeCurriculumId ?? fallbackCurriculumId;
@@ -239,6 +263,21 @@ export default function DashboardPage() {
   return (
     <main className="container space-y-8 py-10">
       <SEO title="My Dashboard" description="Teacher workspace dashboard" />
+      {showingExampleData ? (
+        <Alert>
+          <AlertTitle>{t.dashboard.common.exampleActionsTitle}</AlertTitle>
+          <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <span>{t.dashboard.common.exampleActionsDescription}</span>
+            <Button
+              onClick={() => seedExampleDataMutation.mutate()}
+              disabled={seedExampleDataMutation.isPending}
+              aria-label={t.dashboard.common.exampleActionsCta}
+            >
+              {seedExampleDataMutation.isPending ? t.common.loading : t.dashboard.common.exampleActionsCta}
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
       <DashboardHeader
         profile={profileQuery.data ?? null}
         avatarUrl={profileQuery.data?.avatar_url ?? null}

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -73,13 +73,19 @@ export const en = {
       signInPrompt: "Sign in to manage your dashboard.",
       exampleTag: "Example",
       exampleDescription: "Preview data to show how your workspace will look.",
-      exampleActionsDisabled: "Actions are disabled for example items.",
+      exampleActionsDisabled:
+        "Actions are disabled for example items. Add them to your workspace to enable full functionality.",
+      exampleActionsTitle: "Make the example data editable",
+      exampleActionsDescription:
+        "We'll copy the example class and curriculum into your account so you can try every action without starting from scratch.",
+      exampleActionsCta: "Add example data to my workspace",
     },
     toasts: {
       classCreated: "Class created",
       curriculumCreated: "Curriculum created",
       lessonPlanCreated: "Lesson plan created",
       exportUnavailable: "CSV export will be available soon.",
+      exampleDataCreated: "Example data added to your workspace.",
       error: "Something went wrong. Please try again.",
     },
     classes: {


### PR DESCRIPTION
## Summary
- add an API helper to copy the dashboard example class, curriculum, and items into a signed-in account
- surface an in-app alert so teachers can import the sample data and enable all dashboard actions
- refresh dashboard copy to direct users to add the examples to their workspace

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e10bd4391083319d20bc86836c2e61