### PR TITLE
Remove blog hero headline copy

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -671,12 +671,6 @@ const Blog = () => {
               <Badge variant="secondary" className="w-fit rounded-full bg-primary/10 text-primary">
                 {t.blog.hero.title}
               </Badge>
-              <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl">
-                {t.blog.title}
-              </h1>
-              <p className="text-lg text-muted-foreground">
-                {t.blog.subtitle}
-              </p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- remove the blog hero heading so the page no longer shows the previous "Latest Insights & Updates" copy

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e10f3308e48331bfc436cebf09ea44