### PR TITLE
Add lesson builder tab to dashboard

### DIFF
--- a/src/components/dashboard/CurriculumEditor.tsx
+++ b/src/components/dashboard/CurriculumEditor.tsx
@@ -8,7 +8,7 @@ import { format } from "date-fns";
 interface CurriculumEditorProps {
   items: Array<CurriculumItem & { isExample?: boolean }>;
   loading?: boolean;
-  onCreateLessonPlan: (curriculumItemId: string) => void;
+  onPlanLesson: (item: CurriculumItem & { isExample?: boolean }) => void;
 }
 
 const formatDate = (value?: string | null) => {
@@ -20,7 +20,7 @@ const formatDate = (value?: string | null) => {
   }
 };
 
-export function CurriculumEditor({ items, loading, onCreateLessonPlan }: CurriculumEditorProps) {
+export function CurriculumEditor({ items, loading, onPlanLesson }: CurriculumEditorProps) {
   const { t } = useLanguage();
 
   return (
@@ -78,7 +78,7 @@ export function CurriculumEditor({ items, loading, onCreateLessonPlan }: Curricu
                     variant="outline"
                     size="sm"
                     disabled={!item.id || item.isExample}
-                    onClick={() => onCreateLessonPlan(item.id)}
+                    onClick={() => onPlanLesson(item)}
                     aria-label={t.dashboard.curriculumView.actions.createLessonPlan}
                   >
                     {t.dashboard.curriculumView.actions.createLessonPlan}

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -67,6 +67,7 @@ export const en = {
     tabs: {
       curriculum: "Curriculum",
       classes: "My Classes",
+      lessonBuilder: "Lesson Builder",
       students: "My Students",
       skills: "Skills",
       lessonPlans: "Lesson Plans",
@@ -174,6 +175,23 @@ export const en = {
       },
       toasts: {
         created: "Skill created",
+      },
+    },
+    lessonBuilder: {
+      contextTitle: "Planning details",
+      fallback: "—",
+      labels: {
+        lesson: "Lesson",
+        class: "Class",
+        stage: "Stage",
+        date: "Scheduled date",
+        sequence: "Sequence",
+      },
+      intercept: {
+        title: "Choose a lesson to start planning",
+        description:
+          "Select a lesson from your curriculum tab to prefill the builder. We'll load the workspace here once you've chosen one.",
+        cta: "Browse curriculum",
       },
     },
     curriculum: {


### PR DESCRIPTION
## Summary
- drive the dashboard tab state from URL search params and capture lesson context for the builder
- add a lesson builder tab with an intercept view plus embedded builder prefilled from the captured context
- update curriculum editor actions and translations to support the new planning workflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1d432d5148331af3d92450c8fd283