### PR TITLE
Update dashboard quick actions labels and hide example alert

### DIFF
--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -78,7 +78,9 @@ export function DashboardHeader({
               onClick={() => onQuickAction("ask-question")}
               variant="outline"
               className="w-full justify-center"
-              aria-label={t.dashboard.quickActions.askQuestion}
+              aria-label={
+                t.dashboard.quickActions.askQuestionLabel ?? t.dashboard.quickActions.askQuestion
+              }
             >
               {t.dashboard.quickActions.askQuestion}
             </Button>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -14,7 +14,6 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useToast } from "@/hooks/use-toast";
 import { useOptionalUser } from "@/hooks/useOptionalUser";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -33,7 +32,6 @@ import {
   fetchCurriculumItems,
   fetchMyClasses,
   reorderCurriculumItems,
-  seedExampleDashboardData,
 } from "@/features/dashboard/api";
 import {
   DASHBOARD_EXAMPLE_CLASS,
@@ -362,21 +360,6 @@ export default function DashboardPage() {
     },
   });
 
-  const seedExampleDataMutation = useMutation({
-    mutationFn: () => seedExampleDashboardData({ ownerId: user!.id }),
-    onSuccess: result => {
-      toast({ description: t.dashboard.toasts.exampleDataCreated });
-      setActiveCurriculumId(result.curriculum.id);
-      queryClient.setQueryData(["dashboard-curriculum-items", result.curriculum.id], result.items);
-      void queryClient.invalidateQueries({ queryKey: ["dashboard-classes", user?.id] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard-curricula", user?.id] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard-curriculum-items"], exact: false });
-    },
-    onError: () => {
-      toast({ description: t.dashboard.toasts.error, variant: "destructive" });
-    },
-  });
-
   const handleQuickAction = (action: DashboardQuickAction) => {
     switch (action) {
       case "ask-question":
@@ -412,13 +395,6 @@ export default function DashboardPage() {
     }
     return [DASHBOARD_EXAMPLE_CURRICULUM];
   }, [curriculaQuery.data]);
-
-  const showingExampleData = useMemo(() => {
-    if (classesQuery.isLoading || curriculaQuery.isLoading) {
-      return false;
-    }
-    return classes.some(item => item.isExample) || curricula.some(item => item.isExample);
-  }, [classes, curricula, classesQuery.isLoading, curriculaQuery.isLoading]);
 
   const hasCurriculumContext = useMemo(() => {
     if (!curriculaQuery.data || curriculaQuery.data.length === 0) {
@@ -574,21 +550,6 @@ export default function DashboardPage() {
   return (
     <main className="container space-y-8 py-10">
       <SEO title="My Dashboard" description="Teacher workspace dashboard" />
-      {showingExampleData ? (
-        <Alert>
-          <AlertTitle>{t.dashboard.common.exampleActionsTitle}</AlertTitle>
-          <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <span>{t.dashboard.common.exampleActionsDescription}</span>
-            <Button
-              onClick={() => seedExampleDataMutation.mutate()}
-              disabled={seedExampleDataMutation.isPending}
-              aria-label={t.dashboard.common.exampleActionsCta}
-            >
-              {seedExampleDataMutation.isPending ? t.common.loading : t.dashboard.common.exampleActionsCta}
-            </Button>
-          </AlertDescription>
-        </Alert>
-      ) : null}
       <DashboardHeader
         nameParts={derivedNameParts}
         displayName={normalizeName(displayName) ?? normalizeName(fullName)}

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -57,8 +57,9 @@ export const en = {
       subtitle: "Review your classes, build curricula, and start new lesson plans.",
     },
     quickActions: {
-      askQuestion: "Ask the Community",
-      postBlog: "Write a Blog Post",
+      askQuestion: "Ask",
+      askQuestionLabel: "Ask the Community",
+      postBlog: "Write a Blog",
       newLessonPlan: "New Lesson Plan",
       newLessonPlanTooltip: "Create a curriculum first to unlock lesson planning.",
       newCurriculum: "New Curriculum",


### PR DESCRIPTION
## Summary
- shorten the dashboard quick action labels so the Ask button reads "Ask" and the blog option reads "Write a Blog"
- keep accessibility by providing a dedicated aria label for the Ask button
- remove the example data alert panel from the top of the dashboard for a cleaner layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1e974186c83319aa62795ed11f668