### PR TITLE
Refine blog page filters and layout

### DIFF
--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -693,6 +693,7 @@ export const en = {
       helper: "Refine posts by topic, stage, subject, and format.",
       clear: "Clear filters",
       all: "All",
+      more: "More",
       category: "Category",
       stage: "Stage",
       subject: "Subject",


### PR DESCRIPTION
## Summary
- add a left sidebar filter card with checkbox controls and a clear action for blog filters
- reposition the search input alongside category tabs and introduce a "More" dropdown for overflow categories
- add a translation entry for the new dropdown label

## Testing
- npm run build *(fails: Rollup could not resolve `@dnd-kit/core`)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e9224da4833194edb330b5723cc6