### PR TITLE
Fix initialization order for student example state

### DIFF
--- a/src/features/students/api.ts
+++ b/src/features/students/api.ts
@@ -6,6 +6,13 @@ import type { SkillDefinition, StudentRecord, StudentSkillProgress, StudentSkill
 
 const EXAMPLE_FLAG = (import.meta.env.VITE_ENABLE_STUDENT_EXAMPLES ?? "true").toString().toLowerCase();
 
+const cloneDeep = <T>(value: T): T => {
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
 const exampleState = {
   students: cloneDeep(DASHBOARD_EXAMPLE_STUDENTS),
   skills: cloneDeep(DASHBOARD_EXAMPLE_SKILLS),
@@ -57,13 +64,6 @@ type SupabaseStudentSkillScoreRow = {
 const getCurrentMonth = () => {
   const now = new Date();
   return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
-};
-
-const cloneDeep = <T>(value: T): T => {
-  if (typeof structuredClone === "function") {
-    return structuredClone(value);
-  }
-  return JSON.parse(JSON.stringify(value)) as T;
 };
 
 const toMonthDisplay = (value: string | null | undefined): string => {


### PR DESCRIPTION
## Summary
- define the local cloneDeep helper before using it to build the mock student state
- avoid the cloneDeep temporal dead zone error that blocked the dashboard from rendering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1ec0cbf688331840e41ebee4d0eb1