### PR TITLE
Add skip link and centralize main layout region

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -35,7 +35,9 @@ import StudentDashboardPage from '@/pages/StudentDashboard';
 const RouteWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <>
     <Navigation />
-    {children}
+    <main id="main-content" tabIndex={-1} className="flex-1 focus:outline-none">
+      {children}
+    </main>
     <Footer />
   </>
 );

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -82,6 +82,12 @@ const Navigation = () => {
 
   return (
     <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
+      >
+        Skip to main content
+      </a>
       <div className="container flex h-16 items-center gap-4">
         <Link to={getLocalizedNavPath("/")} className="flex items-center gap-2 flex-shrink-0">
           <div className="flex items-center gap-2">

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -659,7 +659,7 @@ const Blog = () => {
 
       {structuredData ? <StructuredData data={structuredData} /> : null}
 
-      <main className="flex-1">
+      <div className="flex-1">
         <section className="border-b border-border/50 bg-background/60 backdrop-blur">
           <div className="container py-8">
             <div className="mx-auto max-w-2xl">
@@ -890,7 +890,7 @@ const Blog = () => {
                 )}
           </div>
         </section>
-      </main>
+      </div>
     </div>
   );
 };

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -562,17 +562,17 @@ export default function DashboardPage() {
 
   if (!user) {
     return (
-      <main className="container space-y-8 py-10">
+      <div className="container space-y-8 py-10">
         <SEO title="My Dashboard" description="Teacher workspace dashboard" />
         <div className="rounded-xl border bg-muted/10 p-10 text-center text-muted-foreground">
           {t.dashboard.common.signInPrompt}
         </div>
-      </main>
+      </div>
     );
   }
 
   return (
-    <main className="container space-y-8 py-10">
+    <div className="container space-y-8 py-10">
       <SEO title="My Dashboard" description="Teacher workspace dashboard" />
       {showingExampleData ? (
         <Alert>
@@ -798,6 +798,6 @@ export default function DashboardPage() {
           </form>
         </DialogContent>
       </Dialog>
-    </main>
+    </div>
   );
 }

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -138,7 +138,7 @@ const Events = () => {
         canonicalUrl="https://schooltechhub.com/events"
       />
 
-      <main className="flex-1">
+      <div className="flex-1">
         <div className="container py-12">
           <div className="mb-8">
             <h1 className="text-4xl font-bold mb-2 flex items-center gap-3">
@@ -364,7 +364,7 @@ const Events = () => {
             </div>
           </div>
         </div>
-      </main>
+      </div>
     </div>
   );
 };

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -74,7 +74,7 @@ const FAQ = () => {
           }}
         />
       )}
-      <main className="flex-1">
+      <div className="flex-1">
         <div className="container py-12">
           <div className="max-w-4xl mx-auto">
             <div className="text-center mb-12">
@@ -137,7 +137,7 @@ const FAQ = () => {
             </Card>
           </div>
         </div>
-      </main>
+      </div>
 
     </div>
   );

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -112,7 +112,7 @@ const Sitemap = () => {
         description={t.sitemap.description}
         keywords="sitemap, navigation, school tech hub pages"
       />
-      <main className="flex-1">
+      <div className="flex-1">
         <div className="container py-12">
           <h1 className="text-4xl font-bold mb-2">{t.sitemap.title}</h1>
           <p className="text-muted-foreground mb-8">
@@ -196,7 +196,7 @@ const Sitemap = () => {
             </CardContent>
           </Card>
         </div>
-      </main>
+      </div>
 
     </div>
   );

--- a/src/pages/StudentDashboard.tsx
+++ b/src/pages/StudentDashboard.tsx
@@ -119,12 +119,12 @@ export default function StudentDashboardPage() {
 
   if (!user) {
     return (
-      <main className="container space-y-8 py-10">
+      <div className="container space-y-8 py-10">
         <SEO title="Student Dashboard" description="Student progress" />
         <div className="rounded-xl border bg-muted/10 p-10 text-center text-muted-foreground">
           {t.dashboard.common.signInPrompt}
         </div>
-      </main>
+      </div>
     );
   }
 
@@ -176,7 +176,7 @@ export default function StudentDashboardPage() {
   };
 
   return (
-    <main className="container space-y-8 py-10">
+    <div className="container space-y-8 py-10">
       <SEO title={`${student.fullName} • ${t.studentDashboard.title}`} description="Student progress overview" />
       <Button
         variant="ghost"
@@ -291,6 +291,6 @@ export default function StudentDashboardPage() {
           </div>
         )}
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/pages/account/ClassDashboard.tsx
+++ b/src/pages/account/ClassDashboard.tsx
@@ -78,7 +78,7 @@ export function ClassDashboard() {
         description={t.account.classes.dashboard.seoDescription}
         canonicalUrl="https://schooltechhub.com/account/classes"
       />
-      <main className="container mx-auto space-y-8 px-4">
+      <div className="container mx-auto space-y-8 px-4">
         <div className="flex items-center justify-between gap-4">
           <Button variant="ghost" asChild>
             <Link to={getLocalizedPath("/account", language)} className="inline-flex items-center gap-2">
@@ -220,7 +220,7 @@ export function ClassDashboard() {
             </div>
           </div>
         )}
-      </main>
+      </div>
     </div>
   );
 }

--- a/src/pages/admin/AdminLayout.tsx
+++ b/src/pages/admin/AdminLayout.tsx
@@ -71,9 +71,9 @@ export default function AdminLayout() {
           </div>
         </header>
 
-        <main className="flex-1 overflow-y-auto px-4 py-6 md:px-8">
+        <div className="flex-1 overflow-y-auto px-4 py-6 md:px-8">
           <Outlet context={{ meta }} />
-        </main>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/lesson-builder/LessonBuilderPage.tsx
+++ b/src/pages/lesson-builder/LessonBuilderPage.tsx
@@ -726,7 +726,7 @@ const LessonBuilderPage = ({
           description="Plan lesson logistics and craft each instructional step from a single workspace."
         />
       ) : null}
-      <main className={mainClasses}>
+      <div className={mainClasses}>
         <header className="mx-auto max-w-3xl space-y-3 text-center">
           <h1 className="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">Lesson Builder</h1>
           <div className="flex justify-center text-sm text-muted-foreground">
@@ -923,7 +923,7 @@ const LessonBuilderPage = ({
             </p>
           </div>
         </section>
-      </main>
+      </div>
 
       <ResourceSearchModal
         open={isResourceSearchOpen}

--- a/src/pages/lesson-builder/LessonBuilderWorkspace.tsx
+++ b/src/pages/lesson-builder/LessonBuilderWorkspace.tsx
@@ -314,39 +314,39 @@ export default function LessonBuilderWorkspace() {
 
   if (!user) {
     return (
-      <main className="container py-10">
+      <div className="container py-10">
         <SEO title="Lesson Builder" description="Lesson Builder" />
         <div className="rounded-lg border bg-muted/20 p-10 text-center text-muted-foreground">
           {t.dashboard.common.signInPrompt}
         </div>
-      </main>
+      </div>
     );
   }
 
   if (planQuery.isError) {
     return (
-      <main className="container py-10">
+      <div className="container py-10">
         <SEO title="Lesson Builder" description="Lesson Builder" />
         <div className="rounded-lg border bg-destructive/10 p-10 text-center text-destructive">
           {t.lessonBuilder.editor.loadError}
         </div>
-      </main>
+      </div>
     );
   }
 
   if (!planQuery.data) {
     return (
-      <main className="container py-10">
+      <div className="container py-10">
         <SEO title="Lesson Builder" description="Lesson Builder" />
         <div className="rounded-lg border bg-muted/20 p-10 text-center text-muted-foreground">
           {t.lessonBuilder.editor.loading}
         </div>
-      </main>
+      </div>
     );
   }
 
   return (
-    <main className="container h-[calc(100vh-8rem)] py-6">
+    <div className="container h-[calc(100vh-8rem)] py-6">
       <SEO title={t.lessonBuilder.editor.pageTitle.replace("{title}", planQuery.data.title)} description={t.lessonBuilder.editor.pageDescription} />
       <LessonBuilder
         metadata={metadata}
@@ -367,6 +367,6 @@ export default function LessonBuilderWorkspace() {
         autosaveState={autosaveState}
         lastSavedAt={lastSavedAt}
       />
-    </main>
+    </div>
   );
 }

--- a/src/pages/resources/index.tsx
+++ b/src/pages/resources/index.tsx
@@ -556,7 +556,7 @@ const ResourcesPage = () => {
         canonicalUrl={`https://schooltechhub.com${getLocalizedPath("/resources", language)}`}
         lang={language}
       />
-      <main className="container py-12">
+      <div className="container py-12">
         <div className="flex flex-col gap-12 lg:grid lg:grid-cols-[280px_1fr]">
           <aside className="flex flex-col gap-6">
             <div className="space-y-3">
@@ -803,7 +803,7 @@ const ResourcesPage = () => {
             </div>
           </section>
         </div>
-      </main>
+      </div>
 
       <UploadResourceDialog
         open={uploadDialogOpen}


### PR DESCRIPTION
## Summary
- add a focusable "Skip to main content" link in the global navigation for improved keyboard access
- wrap routed pages with a shared `<main id="main-content">` region so the skip link has a consistent target
- update individual pages to rely on the shared `<main>` wrapper and avoid nested main elements or duplicate IDs

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f170627c8331a50f8b965e95ae7f