### PR TITLE
Make Home the primary navigation tab

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -47,8 +47,8 @@ const Navigation = () => {
 
   const navItems = useMemo(() => {
     const items = [
-      { name: t.nav.dashboard, path: "/dashboard" },
       { name: t.nav.home, path: "/" },
+      { name: t.nav.dashboard, path: "/dashboard" },
       { name: t.nav.blog, path: "/blog" },
       { name: t.nav.events, path: "/events" },
       { name: t.nav.services, path: "/services" },


### PR DESCRIPTION
## Summary
- reorder the main navigation items so the Home tab is the first entry and links to the landing page at /

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2019f852883319fbb00a6b1d6cdf9