### PR TITLE
Enhance authentication page with role-based previews

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -9,7 +9,15 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
 import { SEO } from "@/components/SEO";
-import { Chrome } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  Chrome,
+  GraduationCap,
+  Users2,
+  LayoutDashboard,
+  CheckCircle2,
+} from "lucide-react";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 
@@ -114,139 +122,259 @@ const Auth = () => {
     setGoogleLoading(false);
   };
 
+  const roleIconMap = {
+    student: GraduationCap,
+    parent: Users2,
+    teacher: LayoutDashboard,
+  } as const;
+
+  type RoleKey = keyof typeof roleIconMap;
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/5 to-primary/10 px-4">
+    <div className="min-h-screen bg-gradient-to-br from-primary/5 via-background to-primary/10 px-4 py-16">
       <SEO
         title={t.auth.seo.title}
         description={t.auth.seo.description}
         canonicalUrl={t.auth.seo.canonical}
       />
 
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <CardTitle className="text-2xl">{t.auth.card.title}</CardTitle>
-          <CardDescription>{t.auth.card.description}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Tabs defaultValue="signin" className="w-full">
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="signin">{t.auth.tabs.signIn}</TabsTrigger>
-              <TabsTrigger value="signup">{t.auth.tabs.signUp}</TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="signin">
-              <form onSubmit={handleSignIn} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="signin-email">{t.auth.email}</Label>
-                  <Input
-                    id="signin-email"
-                    type="email"
-                    placeholder={t.auth.emailPlaceholder}
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="signin-password">{t.auth.password}</Label>
-                  <Input
-                    id="signin-password"
-                    type="password"
-                    placeholder={t.auth.passwordPlaceholder}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    required
-                  />
-                </div>
-                <Button type="submit" className="w-full" disabled={loading}>
-                  {loading ? t.auth.signingIn : t.auth.signIn}
-                </Button>
-              </form>
-            </TabsContent>
-
-            <TabsContent value="signup">
-              <form onSubmit={handleSignUp} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="signup-name">{t.auth.name}</Label>
-                  <Input
-                    id="signup-name"
-                    type="text"
-                    placeholder={t.auth.namePlaceholder}
-                    value={fullName}
-                    onChange={(e) => setFullName(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="signup-email">{t.auth.email}</Label>
-                  <Input
-                    id="signup-email"
-                    type="email"
-                    placeholder={t.auth.emailPlaceholder}
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="signup-password">{t.auth.password}</Label>
-                  <Input
-                    id="signup-password"
-                    type="password"
-                    placeholder={t.auth.passwordCreatePlaceholder}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="role">{t.auth.role}</Label>
-                  <Select value={role} onValueChange={setRole}>
-                    <SelectTrigger id="role">
-                      <SelectValue placeholder={t.auth.selectRole} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="Teacher">{t.auth.roles.teacher}</SelectItem>
-                      <SelectItem value="Admin">{t.auth.roles.admin}</SelectItem>
-                      <SelectItem value="Parent">{t.auth.roles.parent}</SelectItem>
-                      <SelectItem value="Student">{t.auth.roles.student}</SelectItem>
-                      <SelectItem value="Other">{t.auth.roles.other}</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <Button type="submit" className="w-full" disabled={loading}>
-                  {loading ? t.auth.signingUp : t.auth.signUp}
-                </Button>
-              </form>
-            </TabsContent>
-          </Tabs>
-
-          <div className="relative my-6">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
+      <div className="container mx-auto grid max-w-6xl gap-12 lg:grid-cols-[minmax(0,420px)_1fr]">
+        <Card className="w-full self-start shadow-lg lg:sticky lg:top-10">
+          <CardHeader className="space-y-3 text-center">
+            <div className="flex justify-center">
+              <Badge variant="outline" className="px-3 py-1 text-xs font-medium uppercase tracking-wide">
+                {t.auth.roleShowcase.badge}
+              </Badge>
             </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-background px-2 text-muted-foreground">{t.auth.orContinueWith}</span>
+            <div className="space-y-1">
+              <CardTitle className="text-2xl">{t.auth.card.title}</CardTitle>
+              <CardDescription>{t.auth.card.description}</CardDescription>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Tabs defaultValue="signin" className="w-full">
+              <TabsList className="grid w-full grid-cols-2">
+                <TabsTrigger value="signin">{t.auth.tabs.signIn}</TabsTrigger>
+                <TabsTrigger value="signup">{t.auth.tabs.signUp}</TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="signin">
+                <form onSubmit={handleSignIn} className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="signin-email">{t.auth.email}</Label>
+                    <Input
+                      id="signin-email"
+                      type="email"
+                      placeholder={t.auth.emailPlaceholder}
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="signin-password">{t.auth.password}</Label>
+                    <Input
+                      id="signin-password"
+                      type="password"
+                      placeholder={t.auth.passwordPlaceholder}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <Button type="submit" className="w-full" disabled={loading}>
+                    {loading ? t.auth.signingIn : t.auth.signIn}
+                  </Button>
+                </form>
+              </TabsContent>
+
+              <TabsContent value="signup">
+                <form onSubmit={handleSignUp} className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="signup-name">{t.auth.name}</Label>
+                    <Input
+                      id="signup-name"
+                      type="text"
+                      placeholder={t.auth.namePlaceholder}
+                      value={fullName}
+                      onChange={(e) => setFullName(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="signup-email">{t.auth.email}</Label>
+                    <Input
+                      id="signup-email"
+                      type="email"
+                      placeholder={t.auth.emailPlaceholder}
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="signup-password">{t.auth.password}</Label>
+                    <Input
+                      id="signup-password"
+                      type="password"
+                      placeholder={t.auth.passwordCreatePlaceholder}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="role">{t.auth.role}</Label>
+                    <Select value={role} onValueChange={setRole}>
+                      <SelectTrigger id="role">
+                        <SelectValue placeholder={t.auth.selectRole} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Teacher">{t.auth.roles.teacher}</SelectItem>
+                        <SelectItem value="Admin">{t.auth.roles.admin}</SelectItem>
+                        <SelectItem value="Parent">{t.auth.roles.parent}</SelectItem>
+                        <SelectItem value="Student">{t.auth.roles.student}</SelectItem>
+                        <SelectItem value="Other">{t.auth.roles.other}</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Button type="submit" className="w-full" disabled={loading}>
+                    {loading ? t.auth.signingUp : t.auth.signUp}
+                  </Button>
+                </form>
+              </TabsContent>
+            </Tabs>
+
+            <div className="relative my-6">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t" />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-background px-2 text-muted-foreground">{t.auth.orContinueWith}</span>
+              </div>
+            </div>
+
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleGoogleSignIn}
+              disabled={loading}
+            >
+              <Chrome className="mr-2 h-4 w-4" />
+              {googleLoading ? t.auth.googleSigningIn : t.auth.googleSignIn}
+            </Button>
+
+            <div className="mt-4 text-center text-sm">
+              <Link to={getLocalizedPath("/", language)} className="text-primary hover:underline">
+                {t.auth.backToHome}
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-10">
+          <div className="space-y-3">
+            <Badge variant="secondary" className="w-fit px-3 py-1 text-xs font-medium uppercase tracking-wide">
+              {t.auth.roleShowcase.badge}
+            </Badge>
+            <h1 className="text-3xl font-semibold sm:text-4xl">
+              {t.auth.roleShowcase.title}
+            </h1>
+            <p className="max-w-2xl text-base text-muted-foreground">
+              {t.auth.roleShowcase.subtitle}
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {(Object.keys(roleIconMap) as RoleKey[]).map((key) => {
+              const roleContent = t.auth.roleShowcase.roles[key];
+              const Icon = roleIconMap[key];
+
+              return (
+                <Card key={key} className="flex h-full flex-col justify-between border-primary/10 bg-background/60 shadow-sm">
+                  <CardHeader className="space-y-4">
+                    <div className="flex items-start gap-3">
+                      <div className="rounded-full bg-primary/10 p-2 text-primary">
+                        <Icon className="h-5 w-5" />
+                      </div>
+                      <div>
+                        <CardTitle className="text-lg">{roleContent.title}</CardTitle>
+                        <CardDescription>{roleContent.description}</CardDescription>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <ul className="space-y-2 text-sm text-muted-foreground">
+                      {roleContent.highlights.map((item) => (
+                        <li key={item} className="flex items-start gap-2">
+                          <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" />
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                    <div className="rounded-lg border border-dashed border-primary/20 bg-primary/5 p-4">
+                      <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-primary">
+                        {roleContent.preview.title}
+                      </p>
+                      <div className="space-y-2 text-sm">
+                        {roleContent.preview.items.map((item) => (
+                          <div key={item.label} className="rounded-md bg-background/80 px-3 py-2 shadow-sm">
+                            <p className="text-xs font-medium text-muted-foreground">{item.label}</p>
+                            <p className="font-medium text-foreground">{item.value}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          <div className="space-y-6 rounded-2xl border border-primary/20 bg-background/70 p-6 shadow-sm">
+            <div className="space-y-2">
+              <h2 className="text-2xl font-semibold">{t.auth.roleShowcase.teacherFlow.title}</h2>
+              <p className="max-w-3xl text-sm text-muted-foreground">
+                {t.auth.roleShowcase.teacherFlow.description}
+              </p>
+            </div>
+            <div className="space-y-4">
+              {t.auth.roleShowcase.teacherFlow.steps.map((step, index) => (
+                <div
+                  key={step.title}
+                  className="rounded-xl border border-dashed border-primary/30 bg-primary/5 p-4"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+                        {t.auth.roleShowcase.teacherFlow.stepLabel} {index + 1}
+                      </p>
+                      <h3 className="text-base font-semibold text-foreground">{step.title}</h3>
+                    </div>
+                  </div>
+                  <p className="mt-2 text-sm text-muted-foreground">{step.description}</p>
+                </div>
+              ))}
             </div>
           </div>
 
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={handleGoogleSignIn}
-            disabled={loading}
-          >
-            <Chrome className="mr-2 h-4 w-4" />
-            {googleLoading ? t.auth.googleSigningIn : t.auth.googleSignIn}
-          </Button>
-
-          <div className="mt-4 text-center text-sm">
-            <Link to={getLocalizedPath("/", language)} className="text-primary hover:underline">
-              {t.auth.backToHome}
-            </Link>
+          <div className="space-y-4 rounded-2xl border border-muted bg-background/70 p-6 shadow-sm">
+            <div className="space-y-1">
+              <h2 className="text-xl font-semibold">{t.auth.roleShowcase.connection.title}</h2>
+              <p className="text-sm text-muted-foreground">{t.auth.roleShowcase.connection.subtitle}</p>
+            </div>
+            <Separator />
+            <div className="grid gap-4 md:grid-cols-3">
+              {t.auth.roleShowcase.connection.items.map((item) => (
+                <div key={item.title} className="rounded-lg border border-muted/60 bg-muted/30 p-4">
+                  <h3 className="text-sm font-semibold text-foreground">{item.title}</h3>
+                  <p className="mt-2 text-sm text-muted-foreground">{item.description}</p>
+                </div>
+              ))}
+            </div>
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1173,7 +1173,108 @@ export const en = {
     checkEmail: "Please check your email to confirm your account",
     successSignUp: "Account created successfully!",
     errorSignIn: "Invalid email or password",
-    errorSignUp: "Failed to create account"
+    errorSignUp: "Failed to create account",
+    roleShowcase: {
+      badge: "Tailored access",
+      title: "One login, three connected experiences",
+      subtitle:
+        "Whether you're teaching, learning, or supporting at home, SchoolTechHub gives every role the insights they need while keeping families threaded together.",
+      roles: {
+        student: {
+          title: "Student Dashboard",
+          description: "Stay organised with a personal view of assignments, scores, and nightly homework.",
+          highlights: [
+            "See every assignment with due dates, status, and teacher notes.",
+            "Review quiz and project scores as soon as they're posted.",
+            "Know exactly which homework tasks are due tonight.",
+          ],
+          preview: {
+            title: "This week's snapshot",
+            items: [
+              { label: "Assignments", value: "Solar System Lab — due Fri • Status: In progress" },
+              { label: "Score Snapshot", value: "Algebra Quiz — 92% (+5% growth)" },
+              { label: "Tonight's Homework", value: "Read Chapter 3 & upload reflection" },
+            ],
+          },
+        },
+        parent: {
+          title: "Parent Portal",
+          description: "Follow each child's results and conversations with their teachers in one place.",
+          highlights: [
+            "Review every child's latest results, attendance, and growth trends.",
+            "Track homework completion and teacher feedback in real time.",
+            "Send quick messages when you need more classroom context.",
+          ],
+          preview: {
+            title: "Family overview",
+            items: [
+              { label: "Child Overview", value: "Ava (Grade 6) • Attendance 98% • Growth +7%" },
+              { label: "Latest Results", value: "Science Project — 95% (Teacher: Mr. Patel)" },
+              { label: "Homework Status", value: "Math Practice Set — Submitted" },
+            ],
+          },
+        },
+        teacher: {
+          title: "Teacher Workspace",
+          description: "Plan curriculum-connected lessons, assign homework, and monitor mastery in minutes.",
+          highlights: [
+            "Start with curriculum-aligned class plans and adapt instantly.",
+            "Link skills, resources, and assessments for every roster.",
+            "Assign homework and monitor completion from one screen.",
+          ],
+          preview: {
+            title: "Today's focus",
+            items: [
+              { label: "Classes", value: "Grade 6 Science • Grade 6 Math" },
+              { label: "Skill Tracker", value: "Scientific Inquiry — 78% mastery" },
+              { label: "Homework Queue", value: "Digital Lab Journal • Due Tomorrow" },
+            ],
+          },
+        },
+      },
+      teacherFlow: {
+        title: "From class setup to homework in four threaded steps",
+        description:
+          "Teachers orchestrate the learning journey while students and parents receive the updates instantly—no extra tools required.",
+        stepLabel: "Step",
+        steps: [
+          {
+            title: "Class overview",
+            description: "Start with rosters, pacing guides, and attendance insights in one dashboard.",
+          },
+          {
+            title: "Curriculum to skills",
+            description: "Map standards to daily objectives and monitor mastery for every learner.",
+          },
+          {
+            title: "Lesson builder",
+            description: "Drag in activities, resources, and AI suggestions to craft engaging lessons fast.",
+          },
+          {
+            title: "Homework & feedback",
+            description: "Assign differentiated practice, review submissions, and share feedback instantly.",
+          },
+        ],
+      },
+      connection: {
+        title: "Threaded together for every login",
+        subtitle: "Updates flow automatically so students, parents, and teachers always start conversations with the same information.",
+        items: [
+          {
+            title: "Real-time sync",
+            description: "Homework assigned by teachers appears in the student dashboard and the parent portal within seconds.",
+          },
+          {
+            title: "Shared progress language",
+            description: "Scores, skills, and comments use the same labels everywhere, making school-home dialogue effortless.",
+          },
+          {
+            title: "Supportive nudges",
+            description: "Parents receive gentle reminders when assignments are missing so they can help students stay on track.",
+          },
+        ],
+      },
+    },
   },
   events: {
     title: "Upcoming Events & Webinars",


### PR DESCRIPTION
## Summary
- restructure the authentication page layout to pair the login form with rich role-based previews
- showcase student, parent, and teacher experiences with example data and a connected family narrative
- add supporting translation strings for role highlights, previews, and teacher workflow steps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e202c021908331923c2c7b3cbe33f2