### PR TITLE
Adjust hero spacing on home page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -172,7 +172,7 @@ const Index = () => {
       />
       <StructuredData type="Organization" data={structuredData} />
 
-      <section className="relative overflow-hidden py-28">
+      <section className="relative overflow-hidden pt-20 pb-28 md:pt-24">
         <MouseGlowEffect />
         <SparklesBackground />
         <div className="absolute inset-0">


### PR DESCRIPTION
## Summary
- reduce the top padding on the home page hero section so the headline and live dashboard preview sit higher on the screen

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e203f80d5c8331affa53a2e6db94b6