### PR TITLE
Add gradient backgrounds to homepage cards

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -153,6 +153,13 @@ const neonIconClass =
 const neonIconSecondaryClass =
   "relative mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full border border-secondary/30 bg-secondary/10 text-secondary shadow-[0_0_18px_hsl(var(--glow-secondary)/0.25)] before:absolute before:-inset-3 before:rounded-full before:bg-secondary/10 before:blur-lg before:content-['']";
 
+const gradientVariants = [
+  "bg-gradient-to-b from-primary/18 via-background/70 to-background",
+  "bg-gradient-to-b from-secondary/20 via-background/70 to-background",
+  "bg-gradient-to-b from-accent/18 via-background/70 to-background",
+  "bg-gradient-to-b from-primary/24 via-background/70 to-background",
+];
+
 const Index = () => {
   const { language } = useLanguage();
 
@@ -267,8 +274,11 @@ const Index = () => {
             </p>
           </div>
           <div className="grid gap-8 md:grid-cols-2">
-            {workflowTools.map(({ title, description, icon: Icon }) => (
-              <Card key={title} className={cn("h-full", neonCardClass)}>
+            {workflowTools.map(({ title, description, icon: Icon }, index) => (
+              <Card
+                key={title}
+                className={cn("h-full", neonCardClass, gradientVariants[index % gradientVariants.length])}
+              >
                 <div className="flex flex-col items-center text-center">
                   <div className={neonIconClass}>
                     <Icon className="relative h-8 w-8 drop-shadow-[0_0_10px_hsl(var(--glow-primary)/0.35)]" />
@@ -312,8 +322,15 @@ const Index = () => {
               </div>
             </div>
             <div className="grid w-full max-w-2xl gap-6 md:grid-cols-2">
-              {schoolSolutions.map(({ title, description, icon: Icon }) => (
-                <Card key={title} className={cn("h-full", neonCardClass)}>
+              {schoolSolutions.map(({ title, description, icon: Icon }, index) => (
+                <Card
+                  key={title}
+                  className={cn(
+                    "h-full",
+                    neonCardClass,
+                    gradientVariants[index % gradientVariants.length],
+                  )}
+                >
                   <div className="flex flex-col items-center text-center">
                     <div className={neonIconSecondaryClass}>
                       <Icon className="relative h-8 w-8 drop-shadow-[0_0_10px_hsl(var(--glow-secondary)/0.35)]" />
@@ -334,8 +351,15 @@ const Index = () => {
         <div className="absolute inset-0 -z-10 bg-gradient-to-r from-primary/15 via-background to-secondary/15" />
         <div className="container mx-auto px-4">
           <div className="grid gap-8 text-center md:grid-cols-4">
-            {stats.map((stat) => (
-              <Card key={stat.label} className={cn("p-8", neonCardClass)}>
+            {stats.map((stat, index) => (
+              <Card
+                key={stat.label}
+                className={cn(
+                  "p-8",
+                  neonCardClass,
+                  gradientVariants[index % gradientVariants.length],
+                )}
+              >
                 <p className="text-4xl font-bold text-primary text-glow">{stat.number}</p>
                 <p className="mt-3 text-sm uppercase tracking-wide text-white/65">{stat.label}</p>
               </Card>
@@ -355,8 +379,15 @@ const Index = () => {
             </p>
           </div>
           <div className="grid gap-8 md:grid-cols-3">
-            {testimonials.map(({ quote, name, role }) => (
-              <Card key={name} className={cn("p-8 text-center", neonCardClass)}>
+            {testimonials.map(({ quote, name, role }, index) => (
+              <Card
+                key={name}
+                className={cn(
+                  "p-8 text-center",
+                  neonCardClass,
+                  gradientVariants[index % gradientVariants.length],
+                )}
+              >
                 <p className="mb-6 text-white/90 italic">“{quote}”</p>
                 <div className="space-y-1">
                   <p className="text-lg font-semibold text-white">{name}</p>


### PR DESCRIPTION
## Summary
- introduce shared gradient variants for neon cards on the homepage
- apply the gradient styling to workflow, solutions, stats, and testimonial cards for consistent visuals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e206d259248331887a28aa1b9653bc