### PR TITLE
Rename dashboard to Teacher

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -563,7 +563,7 @@ export default function DashboardPage() {
   if (!user) {
     return (
       <div className="container space-y-8 py-10">
-        <SEO title="My Dashboard" description="Teacher workspace dashboard" />
+        <SEO title="Teacher" description="Teacher workspace dashboard" />
         <div className="rounded-xl border bg-muted/10 p-10 text-center text-muted-foreground">
           {t.dashboard.common.signInPrompt}
         </div>
@@ -573,7 +573,7 @@ export default function DashboardPage() {
 
   return (
     <div className="container space-y-8 py-10">
-      <SEO title="My Dashboard" description="Teacher workspace dashboard" />
+      <SEO title="Teacher" description="Teacher workspace dashboard" />
       {showingExampleData ? (
         <Alert>
           <AlertTitle>{t.dashboard.common.exampleActionsTitle}</AlertTitle>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,6 +1,6 @@
 export const en = {
   nav: {
-    dashboard: "My Dashboard",
+    dashboard: "Teacher",
     home: "Home",
     about: "About",
     services: "Services",
@@ -52,7 +52,7 @@ export const en = {
   dashboard: {
     fallbackDisplayName: "Teacher",
     header: {
-      title: "My Dashboard",
+      title: "Teacher",
       greeting: "Welcome {name}",
       subtitle: "Review your classes, build curricula, and start new lesson plans.",
     },
@@ -1735,7 +1735,7 @@ export const en = {
       research: "Research"
     },
     overview: {
-      title: "My Dashboard",
+      title: "Teacher",
       subtitle: "Here’s a personalized snapshot of your SchoolTech Hub activity and upcoming lessons.",
       ctas: {
         postBlog: "Post a blog",


### PR DESCRIPTION
## Summary
- update the dashboard SEO title to "Teacher"
- change navigation and header translations from "My Dashboard" to "Teacher"
- align the account overview title to the new "Teacher" label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e20bca6a4483319d7ceeb0c43ab6e5