### PR TITLE
Remove blog hero header text

### DIFF
--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -663,8 +663,8 @@ export const en = {
     }
   },
   blog: {
-    title: "Latest Insights & Updates",
-    subtitle: "Stay informed about the latest trends in educational technology",
+    title: "",
+    subtitle: "",
     searchPlaceholder: "Search posts...",
     readMore: "Read More",
     minRead: "min read",


### PR DESCRIPTION
## Summary
- clear the blog section title and subtitle translations so the header text no longer displays

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e20caefeec8331a00f0c538eccbb2c