### PR TITLE
Make blog filter sections collapsed by default

### DIFF
--- a/src/components/filters/FilterSection.tsx
+++ b/src/components/filters/FilterSection.tsx
@@ -5,10 +5,12 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { cn } from "@/lib/utils";
 
 interface FilterSectionProps {
-  title: string;
+  title: ReactNode;
   children: ReactNode;
   defaultOpen?: boolean;
   className?: string;
+  triggerClassName?: string;
+  titleWrapperClassName?: string;
   contentClassName?: string;
 }
 
@@ -17,6 +19,8 @@ export function FilterSection({
   children,
   defaultOpen = true,
   className,
+  triggerClassName,
+  titleWrapperClassName,
   contentClassName,
 }: FilterSectionProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
@@ -30,10 +34,13 @@ export function FilterSection({
       <CollapsibleTrigger asChild>
         <button
           type="button"
-          className="flex w-full items-center justify-between gap-2 text-left text-sm font-semibold"
+          className={cn(
+            "flex w-full items-center justify-between gap-2 text-left text-sm font-semibold",
+            triggerClassName,
+          )}
           aria-expanded={isOpen}
         >
-          <span>{title}</span>
+          <span className={cn("flex items-center gap-2", titleWrapperClassName)}>{title}</span>
           <ChevronDown
             className={cn(
               "h-4 w-4 shrink-0 transition-transform duration-200",

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -32,6 +32,7 @@ import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
 import { SEO } from "@/components/SEO";
 import { StructuredData } from "@/components/StructuredData";
+import { FilterSection } from "@/components/filters/FilterSection";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
@@ -974,29 +975,33 @@ const Blog = () => {
 
                       const Icon = filterSectionIcons[key];
                       return (
-                        <div key={key} className="space-y-3">
-                          <div className="flex items-center gap-2 text-sm font-semibold">
-                            <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
-                            <span>{t.blog.filters[key]}</span>
-                          </div>
-                          <div className="flex flex-wrap gap-2">
-                            {options.map(([value, label]) => {
-                              const isActive = filters[key].includes(value);
-                              return (
-                                <Button
-                                  key={value}
-                                  type="button"
-                                  size="sm"
-                                  variant={isActive ? "default" : "outline"}
-                                  className="rounded-full"
-                                  onClick={() => handleFilterToggle(key, value)}
-                                >
-                                  {label}
-                                </Button>
-                              );
-                            })}
-                          </div>
-                        </div>
+                        <FilterSection
+                          key={key}
+                          title={
+                            <>
+                              <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+                              <span>{t.blog.filters[key]}</span>
+                            </>
+                          }
+                          defaultOpen={false}
+                          contentClassName="flex flex-wrap gap-2"
+                        >
+                          {options.map(([value, label]) => {
+                            const isActive = filters[key].includes(value);
+                            return (
+                              <Button
+                                key={value}
+                                type="button"
+                                size="sm"
+                                variant={isActive ? "default" : "outline"}
+                                className="rounded-full"
+                                onClick={() => handleFilterToggle(key, value)}
+                              >
+                                {label}
+                              </Button>
+                            );
+                          })}
+                        </FilterSection>
                       );
                     })}
                 </CardContent>


### PR DESCRIPTION
## Summary
- extend the reusable filter section component to support custom trigger layouts
- update the blog sidebar filters to use collapsible sections that start closed

## Testing
- npm run lint *(fails: pre-existing lint errors around prefer-as-const and explicit any)*

------
https://chatgpt.com/codex/tasks/task_e_68e20c8f0c188331baea0b24c02d4840