### PR TITLE
Update teacher dashboard quick action button text

### DIFF
--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -57,8 +57,8 @@ export const en = {
       subtitle: "Review your classes, build curricula, and start new lesson plans.",
     },
     quickActions: {
-      askQuestion: "Ask the Community",
-      postBlog: "Write a Blog Post",
+      askQuestion: "Ask",
+      postBlog: "Write",
       newLessonPlan: "New Lesson Plan",
       newLessonPlanTooltip: "Create a curriculum first to unlock lesson planning.",
       newCurriculum: "New Curriculum",


### PR DESCRIPTION
## Summary
- shorten the teacher dashboard quick action labels to "Ask" and "Write"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e211aecf6c8331b31d868e43ce2944