### PR TITLE
Adjust lesson plan metadata table background

### DIFF
--- a/src/pages/lesson-builder/LessonBuilderPage.tsx
+++ b/src/pages/lesson-builder/LessonBuilderPage.tsx
@@ -90,7 +90,7 @@ const createLessonDocTemplate = (meta: LessonPlanMetaDraft, fallbackTeacher: str
           <th style="text-align:left;padding:0.5rem;border:1px solid #d8dee6;background:#f1f5f9;font-weight:600;">${escapeHtml(
             row.label,
           )}</th>
-          <td style="padding:0.5rem;border:1px solid #d8dee6;">${value}</td>
+          <td style="padding:0.5rem;border:1px solid #d8dee6;background:#f1f5f9;">${value}</td>
         </tr>
       `;
     })


### PR DESCRIPTION
## Summary
- update the generated lesson plan document template so metadata table cells share the same background colour as their labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2122ae2e08331aeaa44b2e5ab56ec