### PR TITLE
Add My account label to navigation user menu

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -159,8 +159,12 @@ const Navigation = () => {
             {user ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon">
+                  <Button
+                    variant="ghost"
+                    className="flex items-center gap-2"
+                  >
                     <User className="h-5 w-5" />
+                    <span className="text-sm font-medium">My account</span>
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-56">


### PR DESCRIPTION
## Summary
- display a "My account" label next to the user icon in the navigation bar for signed-in users

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e214181db48331bdbe1c66dca093f2