### PR TITLE
Remove creation quick actions from teacher dashboard header

### DIFF
--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,19 +1,10 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useLanguage } from "@/contexts/LanguageContext";
 
 export type DashboardQuickAction =
   | "ask-question"
-  | "post-blog"
-  | "new-lesson-plan"
-  | "new-curriculum"
-  | "new-class";
+  | "post-blog";
 
 export interface DashboardHeaderNameParts {
   honorific?: string | null;
@@ -25,7 +16,6 @@ interface DashboardHeaderProps {
   nameParts: DashboardHeaderNameParts;
   displayName?: string | null;
   avatarUrl?: string | null;
-  hasCurriculumContext: boolean;
   onQuickAction: (action: DashboardQuickAction) => void;
 }
 
@@ -33,7 +23,6 @@ export function DashboardHeader({
   nameParts,
   displayName,
   avatarUrl,
-  hasCurriculumContext,
   onQuickAction,
 }: DashboardHeaderProps) {
   const { t } = useLanguage();
@@ -72,60 +61,24 @@ export function DashboardHeader({
             </p>
           </div>
         </div>
-        <TooltipProvider>
-          <div className="grid w-full gap-2 sm:w-auto sm:grid-cols-2 lg:grid-cols-5">
-            <Button
-              onClick={() => onQuickAction("ask-question")}
-              variant="outline"
-              className="w-full justify-center"
-              aria-label={t.dashboard.quickActions.askQuestion}
-            >
-              {t.dashboard.quickActions.askQuestion}
-            </Button>
-            <Button
-              onClick={() => onQuickAction("post-blog")}
-              variant="outline"
-              className="w-full justify-center"
-              aria-label={t.dashboard.quickActions.postBlog}
-            >
-              {t.dashboard.quickActions.postBlog}
-            </Button>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="w-full">
-                  <Button
-                    onClick={() => onQuickAction("new-lesson-plan")}
-                    className="w-full justify-center"
-                    aria-label={t.dashboard.quickActions.newLessonPlan}
-                    disabled={!hasCurriculumContext}
-                  >
-                    {t.dashboard.quickActions.newLessonPlan}
-                  </Button>
-                </span>
-              </TooltipTrigger>
-              {!hasCurriculumContext ? (
-                <TooltipContent side="bottom">
-                  {t.dashboard.quickActions.newLessonPlanTooltip}
-                </TooltipContent>
-              ) : null}
-            </Tooltip>
-            <Button
-              onClick={() => onQuickAction("new-curriculum")}
-              className="w-full justify-center"
-              aria-label={t.dashboard.quickActions.newCurriculum}
-            >
-              {t.dashboard.quickActions.newCurriculum}
-            </Button>
-            <Button
-              onClick={() => onQuickAction("new-class")}
-              className="w-full justify-center"
-              variant="secondary"
-              aria-label={t.dashboard.quickActions.newClass}
-            >
-              {t.dashboard.quickActions.newClass}
-            </Button>
-          </div>
-        </TooltipProvider>
+        <div className="grid w-full gap-2 sm:w-auto sm:grid-cols-2 lg:grid-cols-2">
+          <Button
+            onClick={() => onQuickAction("ask-question")}
+            variant="outline"
+            className="w-full justify-center"
+            aria-label={t.dashboard.quickActions.askQuestion}
+          >
+            {t.dashboard.quickActions.askQuestion}
+          </Button>
+          <Button
+            onClick={() => onQuickAction("post-blog")}
+            variant="outline"
+            className="w-full justify-center"
+            aria-label={t.dashboard.quickActions.postBlog}
+          >
+            {t.dashboard.quickActions.postBlog}
+          </Button>
+        </div>
       </div>
     </header>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -385,15 +385,6 @@ export default function DashboardPage() {
       case "post-blog":
         navigate("/blog/new");
         return;
-      case "new-lesson-plan":
-        setLessonBuilderContext(null);
-        return;
-      case "new-curriculum":
-        setCurriculumDialogOpen(true);
-        return;
-      case "new-class":
-        setClassDialogOpen(true);
-        return;
       default:
         return;
     }
@@ -593,7 +584,6 @@ export default function DashboardPage() {
         nameParts={derivedNameParts}
         displayName={normalizeName(displayName) ?? normalizeName(fullName)}
         avatarUrl={avatarUrl}
-        hasCurriculumContext={hasCurriculumContext}
         onQuickAction={handleQuickAction}
       />
       <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">


### PR DESCRIPTION
## Summary
- remove the new lesson plan, new curriculum, and new class quick action buttons from the teacher dashboard header
- simplify the dashboard quick action handler now that only ask-question and post-blog remain

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2145df92c8331b2dd9624eac9e599