### PR TITLE
Remove Teacher shortcut from account dropdown

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -10,7 +10,6 @@ import {
   BookOpen,
   IdCard,
   GraduationCap,
-  LayoutDashboard,
 } from "lucide-react";
 import { useState, useEffect, useMemo } from "react";
 import { cn } from "@/lib/utils";
@@ -172,12 +171,6 @@ const Navigation = () => {
                     {user.email}
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() => navigate(getLocalizedNavPath("/dashboard"))}
-                  >
-                    <LayoutDashboard className="mr-2 h-4 w-4" />
-                    {t.nav.dashboard}
-                  </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={() => navigate(getLocalizedNavPath("/account"))}
                   >


### PR DESCRIPTION
## Summary
- remove the Teacher navigation shortcut from the authenticated account dropdown
- clean up the unused LayoutDashboard icon import after removing the shortcut

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e215c85aa88331b085f2ef78efa0e1