### PR TITLE
Add My Profile route and enrich teacher profile form

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -79,7 +79,8 @@ export const LocalizedRoutes = () => {
       <Route path="/dashboard" element={<RouteWrapper><DashboardPage /></RouteWrapper>} />
       <Route path="/student" element={<RouteWrapper><StudentPage /></RouteWrapper>} />
       <Route path="/dashboard/students/:id" element={<RouteWrapper><StudentDashboardPage /></RouteWrapper>} />
-      <Route path="/profile" element={<RouteWrapper><Profile /></RouteWrapper>} />
+      <Route path="/my-profile" element={<RouteWrapper><Profile /></RouteWrapper>} />
+      <Route path="/profile" element={<Navigate to="/my-profile" replace />} />
       <Route path="/account/classes/:id" element={<RouteWrapper><ClassDashboard /></RouteWrapper>} />
       <Route path="/account/resources" element={<RouteWrapper><AccountResources /></RouteWrapper>} />
       <Route path="/account/resources/new" element={<RouteWrapper><AccountResourceNew /></RouteWrapper>} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -172,7 +172,7 @@ const Navigation = () => {
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
-                    onClick={() => navigate(getLocalizedNavPath("/account"))}
+                    onClick={() => navigate(getLocalizedNavPath("/my-profile"))}
                   >
                     <IdCard className="mr-2 h-4 w-4" />
                     {t.nav.my_profile}
@@ -258,7 +258,7 @@ const Navigation = () => {
                   <div className="border-t pt-4 space-y-3">
                     <p className="px-2 text-sm text-muted-foreground">{user.email}</p>
                     <Link
-                      to={getLocalizedNavPath("/account")}
+                      to={getLocalizedNavPath("/my-profile")}
                       onClick={() => setIsOpen(false)}
                     >
                       <Button className="w-full" variant="secondary">

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -22,7 +22,7 @@ type TranslationDictionary = typeof en;
 const createStaticRoutes = (dictionary: TranslationDictionary): RouteLink[] => [
   {
     title: dictionary.nav.my_profile ?? dictionary.nav.profile ?? dictionary.nav.dashboard,
-    url: "/account"
+    url: "/my-profile"
   },
   { title: dictionary.nav.home, url: "/home" },
   { title: dictionary.nav.about, url: "/about" },

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -27,6 +27,7 @@ export const en = {
     info: {
       title: "Teacher Information",
       description: "Review the personal details connected to your SchoolTech Hub account.",
+      salutation: "Title",
       firstName: "First name",
       lastName: "Last name",
       school: "School",
@@ -1712,6 +1713,15 @@ export const en = {
     personal: {
       title: "Personal information",
       description: "Update the details that appear on your profile.",
+      salutationLabel: "Title",
+      salutationPlaceholder: "Select a title",
+      salutationNone: "No title",
+      salutationOptions: {
+        Mr: "Mr",
+        Ms: "Ms",
+        Mx: "Mx",
+      },
+      emailLabel: "Email address",
       firstNameLabel: "First name",
       firstNamePlaceholder: "e.g. Jordan",
       lastNameLabel: "Last name",


### PR DESCRIPTION
## Summary
- add a dedicated `/my-profile` route and update navigation/sitemap links to point at it
- surface stored honorifics on the My Profile page so greetings can show titles alongside names
- extend the account settings form to capture salutation details, display the user email, and persist the data with new translations

## Testing
- `npm run lint` *(fails: existing @typescript-eslint/prefer-as-const errors in src/features/students/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e231a6e5a88331aced531374936620