### PR TITLE
Wrap hero intro in beveled workflow board

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -261,14 +261,26 @@ const Index = () => {
           <div className="grid gap-16 md:grid-cols-[minmax(0,1fr)_0.9fr]">
             <div>
               <Reveal>
-                <h1 className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-4xl font-bold tracking-tight text-transparent animate-gradient md:text-6xl">
-                  Power every lesson with organised workflows and luminous insights
-                </h1>
-              </Reveal>
-              <Reveal delay={120}>
-                <p className="mt-6 max-w-2xl text-lg text-white/80 md:text-xl">
-                  SchoolTech Hub helps teachers orchestrate their workflow, collaborate with colleagues, and weave technology into every learning moment. Plan lessons, track progress, and publish AI-guided reports without leaving your digital staffroom.
-                </p>
+                <Card
+                  className={cn(
+                    neonCardClass,
+                    "relative isolate rounded-[2rem] bg-gradient-to-br from-primary/30 via-background/85 to-background/95 p-8 shadow-[0_28px_60px_-20px_rgba(54,20,130,0.65)] transition-shadow duration-500 hover:shadow-[0_36px_72px_-18px_rgba(76,32,176,0.7)] md:p-10",
+                    "before:absolute before:inset-[1.5px] before:rounded-[1.92rem] before:bg-[linear-gradient(150deg,rgba(255,255,255,0.22),rgba(15,15,35,0.65))] before:opacity-80 before:content-[''] before:z-0",
+                    "after:absolute after:inset-0 after:rounded-[2rem] after:border after:border-white/12 after:shadow-[inset_0_2px_3px_rgba(255,255,255,0.45),inset_0_-6px_12px_rgba(12,11,30,0.85)] after:content-[''] after:pointer-events-none after:z-20",
+                  )}
+                >
+                  <div className="relative z-10">
+                    <div className="text-sm uppercase tracking-[0.28em] text-white/60">Workflow brilliance</div>
+                    <h2 className="mt-5 text-4xl font-semibold text-white md:text-5xl">
+                      Power every lesson with organised workflows and luminous insights
+                    </h2>
+                    <p className="mt-6 max-w-xl text-base text-white/80 md:text-lg">
+                      SchoolTech Hub helps teachers orchestrate their workflow, collaborate with colleagues, and weave technology into every learning moment. Plan lessons, track progress, and publish AI-guided reports without leaving your digital staffroom.
+                    </p>
+                  </div>
+                  <div className="pointer-events-none absolute -left-20 top-1/2 h-56 w-56 -translate-y-1/2 rounded-full bg-primary/25 blur-3xl" />
+                  <div className="pointer-events-none absolute -right-16 -top-12 h-48 w-48 rounded-full bg-secondary/20 blur-3xl" />
+                </Card>
               </Reveal>
             </div>
             <div className="relative hidden md:flex">


### PR DESCRIPTION
## Summary
- replace the hero headline with a beveled workflow board card that matches the dashboard styling
- add layered gradients and glow accents to deliver a luminous 3D bevel effect around the new board

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2348f68c48331ac9e371ec59ff68c