### PR TITLE
Add slide-up landing animation to homepage reveals

### DIFF
--- a/src/components/animations/Reveal.tsx
+++ b/src/components/animations/Reveal.tsx
@@ -12,21 +12,30 @@ type RevealProps = PropsWithChildren<{
 export const Reveal = ({ children, className, delay = 0, direction = "up" }: RevealProps) => {
   const { ref, isInView } = useInView<HTMLDivElement>({ threshold: 0.2 });
 
-  const initialTransform =
-    direction === "up" ? "translate-y-8" : direction === "left" ? "-translate-x-8" : "translate-x-8";
-  const inViewTransform = direction === "up" ? "translate-y-0" : "translate-x-0";
+  const baseTransformClass =
+    direction === "left" ? "-translate-x-8" : direction === "right" ? "translate-x-8" : "translate-y-8";
+  const activeTransformClass = direction === "left" || direction === "right" ? "translate-x-0" : "translate-y-0";
+  const isVerticalReveal = direction === "up";
 
   return (
     <div
       ref={ref}
       className={cn(
-        "opacity-0 transition-transform transition-opacity duration-700 ease-out will-change-transform",
-        initialTransform,
-        isInView && "opacity-100",
-        isInView && inViewTransform,
+        "will-change-transform",
+        isVerticalReveal
+          ? "reveal-landing"
+          : "opacity-0 transition-transform transition-opacity duration-700 ease-out",
+        !isVerticalReveal && baseTransformClass,
+        isInView &&
+          (isVerticalReveal
+            ? "reveal-landing-visible"
+            : cn("opacity-100", activeTransformClass)),
         className,
       )}
-      style={{ transitionDelay: `${delay}ms` }}
+      style={{
+        transitionDelay: !isVerticalReveal ? `${delay}ms` : undefined,
+        animationDelay: isVerticalReveal ? `${delay}ms` : undefined,
+      }}
     >
       {children}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -151,6 +151,15 @@ All colors MUST be HSL.
       0 0 25px hsl(var(--glow-primary) / 0.35),
       0 0 55px hsl(var(--glow-primary) / 0.25);
   }
+
+  .reveal-landing {
+    opacity: 0;
+    transform: translate3d(0, 48px, 0);
+  }
+
+  .reveal-landing-visible {
+    animation: reveal-slide-up-lock 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  }
 }
 
 /* Fix for blog post images overlapping text */
@@ -211,6 +220,38 @@ All colors MUST be HSL.
   100% {
     opacity: 0;
     transform: translate3d(var(--spark-x, 0px), -140px, 0) scale(1.1);
+  }
+}
+
+@keyframes reveal-slide-up-lock {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 48px, 0);
+  }
+
+  60% {
+    opacity: 1;
+    transform: translate3d(0, -8px, 0);
+  }
+
+  78% {
+    transform: translate3d(0, 4px, 0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-landing {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .reveal-landing-visible {
+    animation: none !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a lock-in slide-up animation to vertically revealed content for the homepage hero and cards
- introduce reusable CSS keyframes and reduced-motion safeguards for the new reveal effect

## Testing
- npm run lint *(fails: pre-existing lint errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e2355e27e48331a633ca0efbfc7522