### PR TITLE
Rename dashboard routes to teacher page

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -51,6 +51,14 @@ const LegacyBuilderRedirect: React.FC = () => {
   return <Navigate to={destination} replace />;
 };
 
+const LegacyStudentDashboardRedirect: React.FC = () => {
+  const params = useParams<{ id?: string }>();
+  const destination = params.id
+    ? `/teacher/students/${params.id}`
+    : `/teacher?tab=students`;
+  return <Navigate to={destination} replace />;
+};
+
 export const LocalizedRoutes = () => {
   return (
     <Routes>
@@ -76,9 +84,11 @@ export const LocalizedRoutes = () => {
       <Route path="/faq" element={<RouteWrapper><FAQ /></RouteWrapper>} />
       <Route path="/auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
       <Route path="/account" element={<RouteWrapper><Account /></RouteWrapper>} />
-      <Route path="/dashboard" element={<RouteWrapper><DashboardPage /></RouteWrapper>} />
+      <Route path="/teacher" element={<RouteWrapper><DashboardPage /></RouteWrapper>} />
+      <Route path="/dashboard" element={<Navigate to="/teacher" replace />} />
       <Route path="/student" element={<RouteWrapper><StudentPage /></RouteWrapper>} />
-      <Route path="/dashboard/students/:id" element={<RouteWrapper><StudentDashboardPage /></RouteWrapper>} />
+      <Route path="/teacher/students/:id" element={<RouteWrapper><StudentDashboardPage /></RouteWrapper>} />
+      <Route path="/dashboard/students/:id" element={<LegacyStudentDashboardRedirect />} />
       <Route path="/my-profile" element={<RouteWrapper><Profile /></RouteWrapper>} />
       <Route path="/profile" element={<Navigate to="/my-profile" replace />} />
       <Route path="/account/classes/:id" element={<RouteWrapper><ClassDashboard /></RouteWrapper>} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -44,7 +44,7 @@ const Navigation = () => {
   const navItems = useMemo(() => {
     const items = [
       { name: t.nav.home, path: "/" },
-      { name: t.nav.dashboard, path: "/dashboard" },
+      { name: t.nav.dashboard, path: "/teacher" },
       { name: t.nav.student, path: "/student" },
       { name: t.nav.blog, path: "/blog" },
       { name: t.nav.events, path: "/events" },

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -678,7 +678,7 @@ export default function DashboardPage() {
             <TabsContent value="students" className="space-y-6">
               <StudentsSection
                 classes={classes}
-                onOpenStudent={studentId => navigate(`/dashboard/students/${studentId}`)}
+                onOpenStudent={studentId => navigate(`/teacher/students/${studentId}`)}
               />
             </TabsContent>
             <TabsContent value="skills" className="space-y-6">

--- a/src/pages/StudentDashboard.tsx
+++ b/src/pages/StudentDashboard.tsx
@@ -77,7 +77,7 @@ export default function StudentDashboardPage() {
   useEffect(() => {
     if (!studentsQuery.isLoading && !student && id) {
       toast({ description: t.studentDashboard.toasts.notFound, variant: "destructive" });
-      navigate("/dashboard?tab=students", { replace: true });
+      navigate("/teacher?tab=students", { replace: true });
     }
   }, [id, navigate, student, studentsQuery.isLoading, t.studentDashboard.toasts.notFound, toast]);
 
@@ -180,7 +180,7 @@ export default function StudentDashboardPage() {
       <SEO title={`${student.fullName} • ${t.studentDashboard.title}`} description="Student progress overview" />
       <Button
         variant="ghost"
-        onClick={() => navigate("/dashboard?tab=students")}
+        onClick={() => navigate("/teacher?tab=students")}
         className="-ml-2 w-fit"
       >
         ← {t.studentDashboard.actions.back}


### PR DESCRIPTION
## Summary
- update localized routing to serve the teacher workspace at `/teacher` and redirect legacy dashboard URLs
- point the global navigation to the new teacher path and adjust student dashboard navigation targets

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e2429948688331bdc210267b563c1c