### PR TITLE
Enhance homepage hero background with layered imagery

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -111,9 +111,51 @@ All colors MUST be HSL.
   body {
     @apply bg-background text-foreground font-space;
   }
-  
+
   h1, h2, h3, h4, h5, h6 {
     @apply font-orbitron;
+  }
+}
+
+@layer components {
+  .hero-floating-cluster {
+    @apply absolute inset-0 pointer-events-none;
+  }
+
+  .hero-floating-card {
+    @apply absolute overflow-hidden rounded-[2.5rem] border border-white/10 bg-white/5 shadow-[0_45px_90px_-40px_rgba(10,12,45,0.85)];
+    width: clamp(14rem, 22vw, 20rem);
+    height: clamp(14rem, 22vw, 20rem);
+    backdrop-filter: blur(18px);
+    will-change: transform;
+  }
+
+  .hero-floating-card img {
+    @apply h-full w-full object-cover opacity-80 transition-opacity duration-700;
+  }
+
+  .hero-floating-card:hover img {
+    @apply opacity-100;
+  }
+
+  .hero-floating-card__glow {
+    @apply pointer-events-none absolute inset-0 mix-blend-screen opacity-75;
+    background: radial-gradient(circle at 25% 20%, hsla(var(--glow-primary) / 0.45), transparent 62%),
+      radial-gradient(circle at 80% 70%, hsla(var(--glow-secondary) / 0.25), transparent 55%);
+  }
+
+  .hero-floating-card--primary {
+    top: clamp(12%, 16vw, 18%);
+    left: clamp(1.5rem, 8vw, 6rem);
+    animation: hero-float 22s ease-in-out infinite;
+  }
+
+  .hero-floating-card--secondary {
+    bottom: clamp(-10rem, -6vw, -3rem);
+    right: clamp(-12rem, -8vw, -4rem);
+    animation: hero-float-alt 26s ease-in-out infinite;
+    width: clamp(16rem, 28vw, 24rem);
+    height: clamp(16rem, 28vw, 24rem);
   }
 }
 
@@ -267,6 +309,34 @@ All colors MUST be HSL.
     box-shadow:
       0 0 28px hsl(var(--glow-primary) / 0.45),
       0 0 65px hsl(var(--glow-secondary) / 0.35);
+  }
+}
+
+@keyframes hero-float {
+  0% {
+    transform: translate3d(-4px, 0, 0) rotate(-2deg) scale(0.98);
+  }
+
+  50% {
+    transform: translate3d(6px, -18px, 0) rotate(2deg) scale(1.02);
+  }
+
+  100% {
+    transform: translate3d(-4px, 0, 0) rotate(-2deg) scale(0.98);
+  }
+}
+
+@keyframes hero-float-alt {
+  0% {
+    transform: translate3d(6px, 0, 0) rotate(2deg) scale(1);
+  }
+
+  50% {
+    transform: translate3d(-10px, 22px, 0) rotate(-3deg) scale(1.04);
+  }
+
+  100% {
+    transform: translate3d(6px, 0, 0) rotate(2deg) scale(1);
   }
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -29,7 +29,9 @@ import { useCountUp } from "@/hooks/useCountUp";
 import { useInView } from "@/hooks/useInView";
 import { cn } from "@/lib/utils";
 
-import heroImage from "@/assets/futuristic-classroom-hero.jpg";
+import aiCollaborationImage from "@/assets/ai-collaboration.jpg";
+import futuristicHeroImage from "@/assets/futuristic-classroom-hero.jpg";
+import holographicTeachingImage from "@/assets/holographic-teaching.jpg";
 
 type Feature = {
   title: string;
@@ -247,13 +249,37 @@ const Index = () => {
       <section className="relative overflow-hidden pt-20 pb-28 md:pt-24">
         <MouseGlowEffect />
         <SparklesBackground />
-        <div className="absolute inset-0">
-          <img
-            src={heroImage}
-            alt="Futuristic classroom with holographic interfaces"
-            className="h-full w-full object-cover object-center opacity-45"
-            loading="lazy"
-          />
+        <div className="absolute inset-0 overflow-hidden" aria-hidden="true">
+          <div className="absolute inset-0">
+            <img
+              src={futuristicHeroImage}
+              alt="Futuristic classroom with holographic interfaces"
+              className="h-full w-full object-cover object-center opacity-45"
+              loading="lazy"
+            />
+          </div>
+
+          <div className="hero-floating-cluster">
+            <div className="hero-floating-card hero-floating-card--primary hidden lg:block">
+              <img
+                src={aiCollaborationImage}
+                alt=""
+                loading="lazy"
+                className="h-full w-full object-cover"
+              />
+              <div className="hero-floating-card__glow" />
+            </div>
+            <div className="hero-floating-card hero-floating-card--secondary hidden xl:block">
+              <img
+                src={holographicTeachingImage}
+                alt=""
+                loading="lazy"
+                className="h-full w-full object-cover"
+              />
+              <div className="hero-floating-card__glow" />
+            </div>
+          </div>
+
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,hsla(var(--glow-primary)/0.22),transparent_60%)]" />
           <div className="absolute inset-0 bg-gradient-to-b from-background/60 via-background/85 to-background" />
         </div>


### PR DESCRIPTION
## Summary
- add layered hero background cards that surface additional classroom imagery on the homepage
- style the floating imagery with reusable component classes and subtle animated glow effects
- introduce gentle float animations to complement the existing hero gradients while keeping content accessible

## Testing
- npm run lint *(fails: existing lint warnings/errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e246bc5b548331879905ea94e87eea