### PR TITLE
Remove Quick tip block from blog search card

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -799,10 +799,6 @@ const Blog = () => {
                     aria-label={t.blog.searchPlaceholder}
                   />
                 </div>
-                <div className="rounded-2xl border border-white/15 bg-white/5 p-4 text-sm text-white/70">
-                  <p className="font-medium text-white">Quick tip</p>
-                  <p className="mt-1">Combine filters below to surface stories that match your subject, grade, and goals.</p>
-                </div>
               </CardContent>
             </Card>
           </div>


### PR DESCRIPTION
## Summary
- remove the "Quick tip" helper text from the blog search card so the card only contains the search input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24a3caad083319ff6e35482fe1112