### PR TITLE
Adjust navigation logo colors

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -81,8 +81,8 @@ const Navigation = () => {
       <div className="container flex h-16 items-center gap-4">
         <Link to={getLocalizedNavPath("/")} className="flex items-center gap-2 flex-shrink-0">
           <div className="flex items-center gap-2">
-            <div className="h-10 w-10 rounded-lg bg-primary flex items-center justify-center">
-              <BookOpen className="h-6 w-6 text-primary-foreground" />
+            <div className="h-10 w-10 rounded-lg border border-primary bg-white flex items-center justify-center">
+              <BookOpen className="h-6 w-6 text-primary" />
             </div>
             <span className="text-xl font-bold">SchoolTech</span>
           </div>


### PR DESCRIPTION
## Summary
- update the navigation logo icon to use a white background with a primary-colored outline and icon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24ab6a1b483318d5b56be2bb4777b