### PR TITLE
Adjust nav hover to glassmorphism

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -110,8 +110,8 @@ const Navigation = () => {
                   to={localizedPath}
                   aria-current={isActive ? "page" : undefined}
                   className={cn(
-                    "rounded-full px-4 py-2 text-sm font-semibold transition-colors whitespace-nowrap",
-                    "border border-transparent hover:border-primary/40 hover:bg-primary/5 hover:text-primary",
+                    "rounded-full px-4 py-2 text-sm font-semibold transition-all whitespace-nowrap",
+                    "border border-transparent hover:border-white/40 hover:bg-white/20 hover:text-foreground hover:backdrop-blur-sm",
                     isActive
                       ? "border-primary bg-primary/10 text-primary"
                       : "text-muted-foreground"


### PR DESCRIPTION
## Summary
- update desktop navigation link hover styling to use a white glassmorphic effect instead of the previous blue highlight

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e24a78f1188331a55ed3b9d8802c2c