### PR TITLE
Add convex bevel styling and bolt accents to home workflow cards

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -157,6 +157,74 @@ All colors MUST be HSL.
     width: clamp(16rem, 28vw, 24rem);
     height: clamp(16rem, 28vw, 24rem);
   }
+
+  .convex-panel-sheen {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background:
+      radial-gradient(circle at 28% 18%, hsla(0 0% 100% / 0.18), transparent 60%),
+      radial-gradient(circle at 75% 78%, hsla(222 47% 18% / 0.55), transparent 68%),
+      linear-gradient(150deg, hsla(0 0% 100% / 0.12), hsla(222 47% 14% / 0.92));
+    box-shadow:
+      inset 14px 14px 32px hsla(222 67% 6% / 0.75),
+      inset -14px -14px 32px hsla(0 0% 100% / 0.08);
+    opacity: 0.92;
+    pointer-events: none;
+    z-index: 0;
+    transition: opacity 0.4s ease;
+  }
+
+  .group:hover .convex-panel-sheen {
+    opacity: 1;
+  }
+
+  .convex-panel-sheen::after {
+    content: "";
+    position: absolute;
+    inset: clamp(0.85rem, 2.5vw, 1.6rem);
+    border-radius: inherit;
+    border: 1px solid hsla(0 0% 100% / 0.06);
+    background: linear-gradient(135deg, hsla(0 0% 100% / 0.12), hsla(222 47% 12% / 0));
+    mix-blend-mode: screen;
+    opacity: 0.75;
+  }
+
+  .bolt-fastener {
+    position: absolute;
+    display: inline-flex;
+    height: 1.4rem;
+    width: 1.4rem;
+    border-radius: 9999px;
+    background: radial-gradient(circle at 30% 30%, hsla(0 0% 100% / 0.75), hsla(222 47% 24% / 0.7));
+    border: 1px solid hsla(0 0% 100% / 0.2);
+    box-shadow:
+      inset 2px 2px 4px hsla(0 0% 100% / 0.5),
+      inset -2px -2px 4px hsla(222 47% 8% / 0.65),
+      0 8px 16px hsla(222 47% 6% / 0.55);
+    pointer-events: none;
+  }
+
+  .bolt-fastener::before {
+    content: "";
+    position: absolute;
+    inset: 3px;
+    border-radius: inherit;
+    background: radial-gradient(circle, hsla(222 47% 14% / 0.85), hsla(222 47% 22% / 0.3));
+    box-shadow: inset 1px 1px 2px hsla(0 0% 100% / 0.25);
+  }
+
+  .bolt-fastener::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background:
+      linear-gradient(0deg, transparent calc(50% - 1px), hsla(0 0% 100% / 0.38) calc(50% - 1px), hsla(0 0% 100% / 0.38) calc(50% + 1px), transparent calc(50% + 1px)),
+      linear-gradient(90deg, transparent calc(50% - 1px), hsla(0 0% 100% / 0.25) calc(50% - 1px), hsla(0 0% 100% / 0.25) calc(50% + 1px), transparent calc(50% + 1px));
+    opacity: 0.55;
+    mix-blend-mode: screen;
+  }
 }
 
 /* Custom glow effects */

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -199,6 +199,8 @@ const neonCardGradients = [
   "bg-gradient-to-br from-accent/25 via-background/75 to-background/95",
 ];
 
+const convexOverlayClass = "convex-panel-sheen";
+
 const classroomTechnologyBackgrounds = {
   featureShowcase:
     "https://images.unsplash.com/photo-1523580846011-d3a5bc25702b?auto=format&fit=crop&w=2100&q=80",
@@ -360,6 +362,9 @@ const Index = () => {
                     "before:absolute before:inset-[1.5px] before:rounded-[1.92rem] before:bg-[linear-gradient(150deg,rgba(255,255,255,0.22),rgba(15,15,35,0.65))] before:opacity-80 before:content-[''] before:z-0",
                   )}
                 >
+                  <span className={convexOverlayClass} aria-hidden />
+                  <span className="bolt-fastener absolute left-8 top-6 z-20 md:left-12 md:top-8" aria-hidden />
+                  <span className="bolt-fastener absolute right-8 top-6 z-20 md:right-12 md:top-8" aria-hidden />
                   <div className="relative z-10">
                     <div className="text-sm uppercase tracking-[0.28em] text-white/60">Workflow brilliance</div>
                     <h2 className="mt-5 text-4xl font-semibold text-white md:text-5xl">
@@ -379,11 +384,16 @@ const Index = () => {
                 <Reveal>
                   <Card className={cn(neonCardClass, "rounded-[1.75rem] bg-gradient-to-br from-primary/15 via-background/60 to-background")}
                   >
-                    <div className="text-sm uppercase tracking-[0.3em] text-white/60">Live dashboards</div>
-                    <h3 className="mt-4 text-2xl font-semibold text-white">Class and student insights synchronised in real time</h3>
-                    <p className="mt-3 text-white/70">
-                      Monitor attendance, mastery, and wellbeing signals in one luminous workspace designed for teaching teams.
-                    </p>
+                    <span className={convexOverlayClass} aria-hidden />
+                    <span className="bolt-fastener absolute left-6 top-5 z-20 md:left-8 md:top-7" aria-hidden />
+                    <span className="bolt-fastener absolute right-6 top-5 z-20 md:right-8 md:top-7" aria-hidden />
+                    <div className="relative z-10">
+                      <div className="text-sm uppercase tracking-[0.3em] text-white/60">Live dashboards</div>
+                      <h3 className="mt-4 text-2xl font-semibold text-white">Class and student insights synchronised in real time</h3>
+                      <p className="mt-3 text-white/70">
+                        Monitor attendance, mastery, and wellbeing signals in one luminous workspace designed for teaching teams.
+                      </p>
+                    </div>
                   </Card>
                 </Reveal>
                 <div className="grid gap-6 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- add reusable convex panel overlay helper for featured workflow cards
- style workflow brilliance and live dashboards cards with bolt fasteners to suggest mounted panels

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files such as src/features/students/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e24fcd42b08331a42f628533a9fb90