### PR TITLE
Reduce homepage convex bezel thickness

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -182,7 +182,7 @@ All colors MUST be HSL.
   .convex-panel-sheen::after {
     content: "";
     position: absolute;
-    inset: clamp(1rem, 2.8vw, 1.8rem);
+    inset: clamp(0.65rem, 2.1vw, 1.2rem);
     border-radius: inherit;
     border: 1px solid hsla(0 0% 100% / 0.05);
     background: linear-gradient(135deg, hsla(0 0% 100% / 0.1), hsla(222 47% 12% / 0));
@@ -202,7 +202,7 @@ All colors MUST be HSL.
   }
 
   .convex-panel-sheen--compact::after {
-    inset: clamp(0.55rem, 1.8vw, 1.05rem);
+    inset: clamp(0.38rem, 1.35vw, 0.75rem);
     border: 1px solid hsla(0 0% 100% / 0.08);
     opacity: 0.8;
   }


### PR DESCRIPTION
## Summary
- decrease the inset spacing on the convex bezel overlays so the bevel frames appear slimmer on homepage boards
- adjust both standard and compact variants to keep proportions consistent across card sizes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e25a2ee82083318d186686e5618d79