### PR TITLE
Make convex panel bezels thinner

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -182,7 +182,7 @@ All colors MUST be HSL.
   .convex-panel-sheen::after {
     content: "";
     position: absolute;
-    inset: clamp(0.45rem, 1.6vw, 0.95rem);
+    inset: clamp(0.3rem, 1.2vw, 0.75rem);
     border-radius: inherit;
     border: 1px solid hsla(0 0% 100% / 0.05);
     background: linear-gradient(135deg, hsla(0 0% 100% / 0.1), hsla(222 47% 12% / 0));
@@ -202,7 +202,7 @@ All colors MUST be HSL.
   }
 
   .convex-panel-sheen--compact::after {
-    inset: clamp(0.28rem, 1.05vw, 0.6rem);
+    inset: clamp(0.18rem, 0.85vw, 0.45rem);
     border: 1px solid hsla(0 0% 100% / 0.08);
     opacity: 0.8;
   }


### PR DESCRIPTION
## Summary
- reduce the pseudo-element inset on convex panel sheens so the bezel appears thinner
- apply the thinner treatment to both standard and compact convex panels for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e25ebdee7c8331a91330622396e786