### PR TITLE
Add workflow feature boards beneath hero card

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -330,6 +330,35 @@ const Index = () => {
                 </Card>
               </Reveal>
             </div>
+            <div className="mt-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              {workflowTools.map(({ title, description, icon: Icon }, index) => (
+                <Reveal key={title} delay={index * 120}>
+                  <Card
+                    className={cn(
+                      "h-full",
+                      compactCardBaseClass,
+                      compactCardGradients[index % compactCardGradients.length],
+                    )}
+                  >
+                    <span className={cn(convexOverlayClass, "convex-panel-sheen--compact")} aria-hidden />
+                    <div className="relative z-10 flex h-full flex-col gap-4 text-left">
+                      <div
+                        className={cn(
+                          "flex h-10 w-10 items-center justify-center rounded-xl",
+                          iconColorClasses[index % iconColorClasses.length],
+                        )}
+                      >
+                        <Icon className="h-5 w-5" />
+                      </div>
+                      <div className="space-y-2">
+                        <h3 className="text-xl font-semibold text-primary">{title}</h3>
+                        <p className="text-sm text-white/70">{description}</p>
+                      </div>
+                    </div>
+                  </Card>
+                </Reveal>
+              ))}
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- surface the four workflow boards directly beneath the hero spotlight card on the index page
- reuse existing feature metadata and styling so the Lesson Builder Platform and related highlights appear immediately in the hero section

## Testing
- npm run lint *(fails: existing lint rule violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2606fda008331bc7580956e8fcb2e