### PR TITLE
Adjust blog filters sidebar width

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -800,7 +800,7 @@ const Blog = () => {
           </div>
         </section>
 
-        <section className="grid gap-8 lg:grid-cols-[280px,1fr]">
+        <section className="grid gap-8 lg:grid-cols-[240px,1fr]">
           <aside className="space-y-6">
             <Card className="border-white/15 bg-white/10 text-white shadow-[0_20px_60px_-30px_rgba(15,23,42,0.9)] backdrop-blur-2xl">
               <CardHeader className="space-y-2">


### PR DESCRIPTION
## Summary
- narrow the blog filters sidebar track from 280px to 240px for a slimmer filters board on the posts page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e260df4404833184ba2759b15a5c4b