### PR TITLE
Remove focus highlight from buttons and tabs

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,14 +5,14 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border-2 border-primary/60 bg-background/90 text-primary transition-shadow hover:border-[hsl(24_100%_50%)] hover:bg-[hsl(24_100%_50%/0.15)] hover:text-primary active:border-[hsl(24_100%_50%)] active:bg-[hsl(24_100%_50%/0.25)] active:text-primary data-[state=open]:border-[hsl(24_100%_50%)] data-[state=open]:bg-[hsl(24_100%_50%/0.15)] shadow-[0_0_12px_hsl(var(--glow-primary)/0.15)]",
+          "border-2 border-primary/60 bg-background/90 text-primary transition-shadow hover:border-primary hover:bg-primary/10 hover:text-primary active:border-primary active:bg-primary/15 active:text-primary data-[state=open]:border-primary data-[state=open]:bg-primary/10 shadow-[0_0_12px_hsl(var(--glow-primary)/0.15)]",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-lg border-2 border-transparent px-4 py-2 text-sm font-semibold text-muted-foreground ring-offset-background transition-all hover:border-primary/40 hover:bg-primary/10 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-primary data-[state=active]:bg-primary/15 data-[state=active]:text-primary data-[state=active]:shadow-[0_0_18px_hsl(var(--glow-primary)/0.25)]",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-lg border-2 border-transparent px-4 py-2 text-sm font-semibold text-muted-foreground ring-offset-background transition-all hover:border-primary/40 hover:bg-primary/10 hover:text-primary disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-primary data-[state=active]:bg-primary/15 data-[state=active]:text-primary data-[state=active]:shadow-[0_0_18px_hsl(var(--glow-primary)/0.25)]",
       className,
     )}
     {...props}
@@ -42,7 +42,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "mt-2 ring-offset-background",
       className,
     )}
     {...props}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-lg border-2 border-transparent bg-transparent text-sm font-semibold text-muted-foreground ring-offset-background transition-all hover:border-primary/40 hover:bg-primary/10 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:border-primary data-[state=on]:bg-primary/15 data-[state=on]:text-primary data-[state=on]:shadow-[0_0_15px_hsl(var(--glow-primary)/0.25)]",
+  "inline-flex items-center justify-center rounded-lg border-2 border-transparent bg-transparent text-sm font-semibold text-muted-foreground ring-offset-background transition-all hover:border-primary/40 hover:bg-primary/10 hover:text-primary disabled:pointer-events-none disabled:opacity-50 data-[state=on]:border-primary data-[state=on]:bg-primary/15 data-[state=on]:text-primary data-[state=on]:shadow-[0_0_15px_hsl(var(--glow-primary)/0.25)]",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- remove focus ring styling from shared button, tabs, and toggle components
- align outline button hover and active states with the primary palette instead of orange accents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27ea264108331936cb7e1c12ca6a4