### PR TITLE
Remove blog hero search card header text

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -776,10 +776,6 @@ const Blog = () => {
             </div>
 
             <Card className="border-white/20 bg-white/10 text-white shadow-[0_20px_70px_-25px_rgba(15,23,42,0.85)] backdrop-blur-xl md:-mt-6 md:self-start lg:-mt-8">
-              <CardHeader className="space-y-2">
-                <h2 className="text-2xl font-semibold">Search the library</h2>
-                <p className="text-sm text-white/70">Find strategies, reflections, and toolkits tailored to your classroom.</p>
-              </CardHeader>
               <CardContent className="space-y-4">
                 <label htmlFor="blog-search" className="sr-only">
                   {t.blog.searchPlaceholder}


### PR DESCRIPTION
## Summary
- remove the heading and helper copy from the blog hero search card so the panel only contains the search input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27f7ae06c8331be6dbacf8a6f5806