### PR TITLE
Remove logo icon from top navigation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -80,12 +80,7 @@ const Navigation = () => {
       </a>
       <div className="container flex h-16 items-center gap-4">
         <Link to={getLocalizedNavPath("/")} className="flex items-center gap-2 flex-shrink-0">
-          <div className="flex items-center gap-2">
-            <div className="h-10 w-10 rounded-lg border border-white bg-muted flex items-center justify-center">
-              <BookOpen className="h-6 w-6 text-primary" />
-            </div>
-            <span className="text-xl font-bold">SchoolTech</span>
-          </div>
+          <span className="text-xl font-bold">SchoolTech</span>
         </Link>
 
         <div className="flex flex-1 items-center justify-end gap-3">


### PR DESCRIPTION
## Summary
- remove the book icon container from the top navigation link so only the text label remains

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e28cf436a08331a903b8b9288db762