### PR TITLE
style: refresh profile page with glassmorphism

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useMyProfile } from "@/hooks/useMyProfile";
 import { supabase } from "@/integrations/supabase/client";
 import { createProfileImageSignedUrl, resolveAvatarReference } from "@/lib/avatar";
+import { cn } from "@/lib/utils";
 import { SettingsPanel } from "@/pages/account/components/SettingsPanel";
 
 const extractMetadataValue = (metadata: Record<string, unknown>, key: string): string | null => {
@@ -22,6 +23,15 @@ const extractMetadataValue = (metadata: Record<string, unknown>, key: string): s
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
 };
+
+const BackgroundOrnaments = () => (
+  <div className="pointer-events-none absolute inset-0 -z-10">
+    <div className="absolute -top-48 left-1/3 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-sky-500/25 blur-3xl" />
+    <div className="absolute bottom-[-14rem] right-[-8rem] h-[34rem] w-[34rem] rounded-full bg-purple-500/20 blur-3xl" />
+    <div className="absolute top-1/3 right-1/5 h-[22rem] w-[22rem] rounded-full bg-emerald-500/20 blur-3xl" />
+    <div className="absolute left-[-10rem] top-1/2 h-[18rem] w-[18rem] rounded-full bg-blue-500/20 blur-3xl" />
+  </div>
+);
 
 const Profile = () => {
   const { t } = useLanguage();
@@ -155,12 +165,16 @@ const Profile = () => {
     }
   };
 
+  const gradientBackgroundClass =
+    "relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-black text-white";
+
   if (loading) {
     return (
-      <div className="min-h-screen bg-muted/10">
+      <div className={gradientBackgroundClass}>
         <SEO title={t.profilePage.title} description={t.profilePage.subtitle} />
-        <div className="container flex min-h-[60vh] items-center justify-center">
-          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <BackgroundOrnaments />
+        <div className="relative flex min-h-[60vh] items-center justify-center px-4 py-20">
+          <Loader2 className="h-10 w-10 animate-spin text-white/80" />
         </div>
       </div>
     );
@@ -168,19 +182,31 @@ const Profile = () => {
 
   if (!user) {
     return (
-      <div className="min-h-screen bg-muted/10">
+      <div className={gradientBackgroundClass}>
         <SEO title={t.profilePage.title} description={t.profilePage.subtitle} />
-        <div className="container flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
-          <Card className="max-w-lg">
-            <CardHeader>
-              <CardTitle>{t.profilePage.title}</CardTitle>
-              <CardDescription>{t.profilePage.subtitle}</CardDescription>
+        <BackgroundOrnaments />
+        <div className="relative mx-auto flex min-h-[70vh] w-full max-w-4xl flex-col items-center justify-center px-4 py-16 text-center">
+          <Card
+            className={cn(
+              "w-full rounded-[2rem] border border-white/15 bg-white/10 p-8 text-white shadow-[0_20px_70px_-30px_rgba(15,23,42,0.85)] backdrop-blur-2xl",
+            )}
+          >
+            <CardHeader className="space-y-4">
+              <CardTitle className="text-3xl font-semibold text-white">{t.profilePage.title}</CardTitle>
+              <CardDescription className="text-white/70">
+                {t.profilePage.subtitle}
+              </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-4">
-              <p className="text-muted-foreground">{t.profilePage.fallback.signInRequired}</p>
-              <Button asChild>
-                <Link to="/auth">{t.nav.signIn}</Link>
-              </Button>
+            <CardContent className="space-y-6">
+              <p className="text-white/70">{t.profilePage.fallback.signInRequired}</p>
+              <div className="flex justify-center">
+                <Button
+                  asChild
+                  className="rounded-full border border-white/20 bg-white/10 px-6 py-2 text-white hover:bg-white/20"
+                >
+                  <Link to="/auth">{t.nav.signIn}</Link>
+                </Button>
+              </div>
             </CardContent>
           </Card>
         </div>
@@ -226,46 +252,67 @@ const Profile = () => {
     },
   ];
 
-  return (
-    <div className="min-h-screen bg-muted/10 pb-16">
-      <SEO title={t.profilePage.title} description={t.profilePage.subtitle} />
-      <div className="container space-y-8 py-10">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-3xl font-bold text-foreground">{t.profilePage.title}</h1>
-            <p className="mt-2 max-w-2xl text-muted-foreground">{t.profilePage.subtitle}</p>
-          </div>
-          <Button asChild className="sm:shrink-0" variant="outline">
-            <a href="#profile-settings">{t.profilePage.editButton}</a>
-          </Button>
-        </div>
+  const heroCardClass =
+    "relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-white/10 p-8 shadow-[0_25px_80px_-20px_rgba(15,23,42,0.65)] backdrop-blur-2xl sm:p-12";
+  const glassCardClass =
+    "rounded-[2rem] border border-white/15 bg-white/10 text-white shadow-[0_20px_70px_-30px_rgba(15,23,42,0.85)] backdrop-blur-2xl";
+  const detailItemClass =
+    "flex items-start gap-3 rounded-2xl border border-white/20 bg-white/10 p-4 shadow-[0_10px_40px_-20px_rgba(15,23,42,0.85)]";
+  const subtleTextClass = "text-white/70";
+  const actionButtonClass =
+    "rounded-full border border-white/20 bg-white/10 px-6 py-3 text-white hover:bg-white/20";
 
-        <div className="grid gap-6 lg:grid-cols-[360px,1fr]">
+  return (
+    <div className={cn(gradientBackgroundClass, "pb-20")}>
+      <SEO title={t.profilePage.title} description={t.profilePage.subtitle} />
+      <BackgroundOrnaments />
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-16 md:px-8">
+        <section className={heroCardClass}>
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.35)_0%,_rgba(15,23,42,0)_70%)] opacity-80" />
+          <div className="relative z-10 flex flex-col gap-8 md:flex-row md:items-end md:justify-between">
+            <div className="space-y-4 text-center md:max-w-2xl md:text-left">
+              <p className="text-sm font-medium uppercase tracking-[0.35em] text-white/60">Account</p>
+              <h1 className="text-4xl font-semibold tracking-tight md:text-5xl">{t.profilePage.title}</h1>
+              <p className={cn("mx-auto max-w-2xl text-lg", subtleTextClass)}>{t.profilePage.subtitle}</p>
+            </div>
+            <div className="flex justify-center md:justify-end">
+              <Button asChild className={cn(actionButtonClass)}>
+                <a href="#profile-settings">{t.profilePage.editButton}</a>
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        <div className="grid gap-8 lg:grid-cols-[360px,1fr]">
           <div className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>{t.profilePage.info.title}</CardTitle>
-                <CardDescription>{t.profilePage.info.description}</CardDescription>
+            <Card className={cn(glassCardClass, "p-6 sm:p-8")}>
+              <CardHeader className="space-y-4 border-none p-0">
+                <CardTitle className="text-2xl font-semibold text-white">
+                  {t.profilePage.info.title}
+                </CardTitle>
+                <CardDescription className={cn(subtleTextClass)}>
+                  {t.profilePage.info.description}
+                </CardDescription>
               </CardHeader>
-              <CardContent className="space-y-6">
-                <div className="flex items-center gap-4">
-                  <Avatar className="h-20 w-20">
+              <CardContent className="space-y-6 p-0 pt-6">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                  <Avatar className="h-20 w-20 border border-white/30 bg-white/10 text-white">
                     {avatarUrl ? <AvatarImage src={avatarUrl} alt="" /> : null}
                     <AvatarFallback>{avatarFallback}</AvatarFallback>
                   </Avatar>
-                  <div>
-                    <p className="text-lg font-semibold text-foreground">{displayFullName}</p>
-                    <p className="text-sm text-muted-foreground">{subject ?? fallbackValue}</p>
-                    <p className="text-sm text-muted-foreground">{phoneNumber ?? fallbackValue}</p>
+                  <div className="space-y-1 text-center sm:text-left">
+                    <p className="text-xl font-semibold text-white">{displayFullName}</p>
+                    <p className={cn("text-sm", subtleTextClass)}>{subject ?? fallbackValue}</p>
+                    <p className={cn("text-sm", subtleTextClass)}>{phoneNumber ?? fallbackValue}</p>
                   </div>
                 </div>
                 <dl className="space-y-4">
                   {detailItems.map(item => (
-                    <div key={item.label} className="flex items-start gap-3 rounded-lg border border-border/60 bg-background/80 p-3">
-                      <div className="mt-0.5 text-muted-foreground">{item.icon}</div>
+                    <div key={item.label} className={detailItemClass}>
+                      <div className="mt-0.5 text-white/70">{item.icon}</div>
                       <div className="space-y-1">
-                        <dt className="text-xs uppercase tracking-wide text-muted-foreground">{item.label}</dt>
-                        <dd className="text-sm font-medium text-foreground">{item.value}</dd>
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-white/60">{item.label}</dt>
+                        <dd className="text-sm font-medium text-white">{item.value}</dd>
                       </div>
                     </div>
                   ))}
@@ -273,14 +320,22 @@ const Profile = () => {
               </CardContent>
             </Card>
 
-            <Card>
-              <CardHeader>
-                <CardTitle>{t.profilePage.security.title}</CardTitle>
-                <CardDescription>{t.profilePage.security.description}</CardDescription>
+            <Card className={cn(glassCardClass, "p-6 sm:p-8")}>
+              <CardHeader className="space-y-4 border-none p-0">
+                <CardTitle className="text-2xl font-semibold text-white">
+                  {t.profilePage.security.title}
+                </CardTitle>
+                <CardDescription className={cn(subtleTextClass)}>
+                  {t.profilePage.security.description}
+                </CardDescription>
               </CardHeader>
-              <CardContent className="space-y-4">
-                <p className="text-sm text-muted-foreground">{t.profilePage.security.instructions}</p>
-                <Button onClick={handleSendPasswordReset} disabled={isSendingReset}>
+              <CardContent className="space-y-4 p-0 pt-6">
+                <p className={cn("text-sm", subtleTextClass)}>{t.profilePage.security.instructions}</p>
+                <Button
+                  onClick={handleSendPasswordReset}
+                  disabled={isSendingReset}
+                  className={cn(actionButtonClass, "w-full justify-center")}
+                >
                   {isSendingReset ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -294,8 +349,8 @@ const Profile = () => {
             </Card>
           </div>
 
-          <div id="profile-settings">
-            <SettingsPanel user={user} />
+          <div id="profile-settings" className="space-y-6">
+            <SettingsPanel user={user} variant="glass" className="space-y-6" />
           </div>
         </div>
       </div>

--- a/src/pages/account/components/SettingsPanel.tsx
+++ b/src/pages/account/components/SettingsPanel.tsx
@@ -32,11 +32,14 @@ import {
   isHttpUrl,
 } from "@/lib/avatar";
 import { createFileIdentifier } from "@/lib/files";
+import { cn } from "@/lib/utils";
 import type { Salutation } from "@/types/supabase-tables";
 
 type ThemePreference = "system" | "light" | "dark";
 type SettingsPanelProps = {
   user: User;
+  className?: string;
+  variant?: "default" | "glass";
 };
 
 const isThemePreference = (value: unknown): value is ThemePreference =>
@@ -67,7 +70,7 @@ const getMetadataSalutation = (metadata: Record<string, unknown> | undefined): S
   return isSalutationValue(rawValue) ? (rawValue as Salutation) : "none";
 };
 
-export const SettingsPanel = ({ user }: SettingsPanelProps) => {
+export const SettingsPanel = ({ user, className, variant = "default" }: SettingsPanelProps) => {
   const { toast } = useToast();
   const { t } = useLanguage();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -133,6 +136,35 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
   const [isSavingPreferences, setIsSavingPreferences] = useState(false);
   const [passwordForm, setPasswordForm] = useState({ newPassword: "", confirmPassword: "" });
   const [isUpdatingPassword, setIsUpdatingPassword] = useState(false);
+
+  const isGlass = variant === "glass";
+  const cardClassName = isGlass
+    ? "border border-white/15 bg-white/10 text-white shadow-[0_20px_70px_-30px_rgba(15,23,42,0.85)] backdrop-blur-2xl"
+    : undefined;
+  const inputClassName = isGlass
+    ? "border-white/20 bg-white/10 text-white placeholder:text-white/60 focus-visible:ring-white/50"
+    : undefined;
+  const helperTextClassName = isGlass ? "text-white/60" : "text-muted-foreground";
+  const subtleTextClassName = isGlass ? "text-white/70" : "text-muted-foreground";
+  const labelClassName = isGlass ? "text-white" : undefined;
+  const containerClassName = cn("space-y-6", className, isGlass && "text-white");
+  const primaryButtonClassName = isGlass
+    ? "border border-white/20 bg-white/10 text-white hover:bg-white/20 hover:text-white"
+    : undefined;
+  const outlineButtonClassName = isGlass
+    ? "border-white/30 bg-white/10 text-white hover:bg-white/20"
+    : undefined;
+  const ghostButtonClassName = isGlass ? "text-white hover:bg-white/10" : undefined;
+  const avatarContainerClassName = isGlass
+    ? "border-white/20 bg-white/10"
+    : "border-border/70 bg-muted/40";
+  const selectTriggerClassName = isGlass
+    ? "border-white/20 bg-white/10 text-white focus:ring-white/50"
+    : undefined;
+  const selectContentClassName = isGlass
+    ? "border border-white/20 bg-slate-900/90 text-white backdrop-blur-xl"
+    : undefined;
+  const selectItemClassName = isGlass ? "focus:bg-white/20 focus:text-white" : undefined;
 
   useEffect(() => {
     const metadata = user.user_metadata as Record<string, unknown> | undefined;
@@ -612,11 +644,13 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
   };
 
   return (
-    <div className="space-y-6">
-      <Card>
+    <div className={containerClassName}>
+      <Card className={cn(cardClassName)}>
         <CardHeader>
           <CardTitle>{t.account.image.title}</CardTitle>
-          <CardDescription>{t.account.image.description}</CardDescription>
+          <CardDescription className={cn(subtleTextClassName)}>
+            {t.account.image.description}
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -626,13 +660,9 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
                 <AvatarFallback>{avatarFallback}</AvatarFallback>
               </Avatar>
               <div className="space-y-1">
-                {user.email ? (
-                  <p className="text-sm font-medium">{user.email}</p>
-                ) : null}
+                {user.email ? <p className="text-sm font-medium">{user.email}</p> : null}
                 {currentAvatarUrl ? (
-                  <p className="text-xs text-muted-foreground">
-                    {t.account.image.description}
-                  </p>
+                  <p className={cn("text-xs", subtleTextClassName)}>{t.account.image.description}</p>
                 ) : null}
               </div>
             </div>
@@ -649,6 +679,7 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
                 variant="outline"
                 onClick={() => fileInputRef.current?.click()}
                 disabled={isUploadingAvatar}
+                className={cn(outlineButtonClassName)}
               >
                 {t.account.image.changeButton}
               </Button>
@@ -656,6 +687,7 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
                 type="button"
                 onClick={handleAvatarUpload}
                 disabled={!avatarFile || isUploadingAvatar}
+                className={cn(primaryButtonClassName)}
               >
                 {isUploadingAvatar ? (
                   <>
@@ -671,27 +703,34 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card className={cn(cardClassName)}>
         <form onSubmit={handlePersonalInfoSubmit} className="space-y-0">
           <CardHeader>
             <CardTitle>{t.account.personal.title}</CardTitle>
-            <CardDescription>{t.account.personal.description}</CardDescription>
+            <CardDescription className={cn(subtleTextClassName)}>
+              {t.account.personal.description}
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="grid gap-2">
-                <Label htmlFor="salutation">{t.account.personal.salutationLabel}</Label>
-                <Select
-                  value={salutation}
-                  onValueChange={value => setSalutation(value as SalutationOption)}
-                >
-                  <SelectTrigger id="salutation" disabled={isSavingPersonalInfo}>
+                <Label htmlFor="salutation" className={cn(labelClassName)}>
+                  {t.account.personal.salutationLabel}
+                </Label>
+                <Select value={salutation} onValueChange={value => setSalutation(value as SalutationOption)}>
+                  <SelectTrigger
+                    id="salutation"
+                    disabled={isSavingPersonalInfo}
+                    className={cn(selectTriggerClassName)}
+                  >
                     <SelectValue placeholder={t.account.personal.salutationPlaceholder} />
                   </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">{t.account.personal.salutationNone}</SelectItem>
+                  <SelectContent className={cn(selectContentClassName)}>
+                    <SelectItem value="none" className={cn(selectItemClassName)}>
+                      {t.account.personal.salutationNone}
+                    </SelectItem>
                     {SALUTATION_OPTIONS.map(option => (
-                      <SelectItem key={option} value={option}>
+                      <SelectItem key={option} value={option} className={cn(selectItemClassName)}>
                         {t.account.personal.salutationOptions[option]}
                       </SelectItem>
                     ))}
@@ -699,55 +738,69 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
                 </Select>
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="email">{t.account.personal.emailLabel}</Label>
-                <Input id="email" value={user.email ?? ""} disabled />
+                <Label htmlFor="email" className={cn(labelClassName)}>
+                  {t.account.personal.emailLabel}
+                </Label>
+                <Input id="email" value={user.email ?? ""} disabled className={cn(inputClassName)} />
               </div>
             </div>
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="grid gap-2">
-                <Label htmlFor="first-name">{t.account.personal.firstNameLabel}</Label>
+                <Label htmlFor="first-name" className={cn(labelClassName)}>
+                  {t.account.personal.firstNameLabel}
+                </Label>
                 <Input
                   id="first-name"
                   value={firstName}
                   onChange={event => setFirstName(event.target.value)}
                   placeholder={t.account.personal.firstNamePlaceholder}
                   disabled={isSavingPersonalInfo}
+                  className={cn(inputClassName)}
                 />
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="last-name">{t.account.personal.lastNameLabel}</Label>
+                <Label htmlFor="last-name" className={cn(labelClassName)}>
+                  {t.account.personal.lastNameLabel}
+                </Label>
                 <Input
                   id="last-name"
                   value={lastName}
                   onChange={event => setLastName(event.target.value)}
                   placeholder={t.account.personal.lastNamePlaceholder}
                   disabled={isSavingPersonalInfo}
+                  className={cn(inputClassName)}
                 />
               </div>
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="subject">{t.account.personal.subjectLabel}</Label>
+              <Label htmlFor="subject" className={cn(labelClassName)}>
+                {t.account.personal.subjectLabel}
+              </Label>
               <Input
                 id="subject"
                 value={subject}
                 onChange={event => setSubject(event.target.value)}
                 placeholder={t.account.personal.subjectPlaceholder}
                 disabled={isSavingPersonalInfo}
+                className={cn(inputClassName)}
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="phone">{t.account.personal.phoneLabel}</Label>
+              <Label htmlFor="phone" className={cn(labelClassName)}>
+                {t.account.personal.phoneLabel}
+              </Label>
               <Input
                 id="phone"
                 value={phoneNumber}
                 onChange={event => setPhoneNumber(event.target.value)}
                 placeholder={t.account.personal.phonePlaceholder}
                 disabled={isSavingPersonalInfo}
+                className={cn(inputClassName)}
               />
             </div>
           </CardContent>
           <CardFooter>
-            <Button type="submit" disabled={isSavingPersonalInfo}>
+            <Button type="submit" disabled={isSavingPersonalInfo} className={cn(primaryButtonClassName)}>
               {isSavingPersonalInfo ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -761,26 +814,36 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
         </form>
       </Card>
 
-      <Card>
+      <Card className={cn(cardClassName)}>
         <form onSubmit={handleSchoolInfoSubmit} className="space-y-0">
           <CardHeader>
             <CardTitle>{t.account.school.title}</CardTitle>
-            <CardDescription>{t.account.school.description}</CardDescription>
+            <CardDescription className={cn(subtleTextClassName)}>
+              {t.account.school.description}
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-2">
-              <Label htmlFor="school-name">{t.account.school.nameLabel}</Label>
+              <Label htmlFor="school-name" className={cn(labelClassName)}>
+                {t.account.school.nameLabel}
+              </Label>
               <Input
                 id="school-name"
                 value={schoolName}
                 onChange={event => setSchoolName(event.target.value)}
                 placeholder={t.account.school.namePlaceholder}
+                className={cn(inputClassName)}
               />
             </div>
             <div className="space-y-2">
-              <Label>{t.account.school.logoLabel}</Label>
+              <Label className={cn(labelClassName)}>{t.account.school.logoLabel}</Label>
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-                <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-md border border-border/70 bg-muted/40">
+                <div
+                  className={cn(
+                    "flex h-16 w-16 items-center justify-center overflow-hidden rounded-md border",
+                    avatarContainerClassName,
+                  )}
+                >
                   {displayedSchoolLogo ? (
                     <img
                       src={displayedSchoolLogo}
@@ -788,7 +851,7 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
                       className="h-full w-full object-contain"
                     />
                   ) : (
-                    <span className="px-2 text-center text-xs text-muted-foreground">
+                    <span className={cn("px-2 text-center text-xs", helperTextClassName)}>
                       {t.account.school.logoPlaceholder}
                     </span>
                   )}
@@ -806,6 +869,7 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
                     variant="outline"
                     onClick={() => schoolLogoInputRef.current?.click()}
                     disabled={isSavingSchoolInfo}
+                    className={cn(outlineButtonClassName)}
                   >
                     {t.account.school.uploadButton}
                   </Button>
@@ -815,17 +879,18 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
                       variant="ghost"
                       onClick={handleSchoolLogoToggle}
                       disabled={isSavingSchoolInfo}
+                      className={cn(ghostButtonClassName)}
                     >
                       {isLogoRemoved ? t.account.school.restoreButton : t.account.school.removeButton}
                     </Button>
                   ) : null}
                 </div>
               </div>
-              <p className="text-xs text-muted-foreground">{t.account.school.logoHelp}</p>
+              <p className={cn("text-xs", helperTextClassName)}>{t.account.school.logoHelp}</p>
             </div>
           </CardContent>
           <CardFooter>
-            <Button type="submit" disabled={isSavingSchoolInfo}>
+            <Button type="submit" disabled={isSavingSchoolInfo} className={cn(primaryButtonClassName)}>
               {isSavingSchoolInfo ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -839,15 +904,19 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
         </form>
       </Card>
 
-      <Card>
+      <Card className={cn(cardClassName)}>
         <form onSubmit={handlePasswordSubmit} className="space-y-0">
           <CardHeader>
             <CardTitle>{t.account.security.title}</CardTitle>
-            <CardDescription>{t.account.security.description}</CardDescription>
+            <CardDescription className={cn(subtleTextClassName)}>
+              {t.account.security.description}
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-2">
-              <Label htmlFor="new-password">{t.account.security.newPasswordLabel}</Label>
+              <Label htmlFor="new-password" className={cn(labelClassName)}>
+                {t.account.security.newPasswordLabel}
+              </Label>
               <Input
                 id="new-password"
                 type="password"
@@ -857,10 +926,13 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
                   setPasswordForm(previous => ({ ...previous, newPassword: event.target.value }))
                 }
                 placeholder="••••••••"
+                className={cn(inputClassName)}
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="confirm-password">{t.account.security.confirmPasswordLabel}</Label>
+              <Label htmlFor="confirm-password" className={cn(labelClassName)}>
+                {t.account.security.confirmPasswordLabel}
+              </Label>
               <Input
                 id="confirm-password"
                 type="password"
@@ -870,11 +942,12 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
                   setPasswordForm(previous => ({ ...previous, confirmPassword: event.target.value }))
                 }
                 placeholder="••••••••"
+                className={cn(inputClassName)}
               />
             </div>
           </CardContent>
           <CardFooter>
-            <Button type="submit" disabled={isUpdatingPassword}>
+            <Button type="submit" disabled={isUpdatingPassword} className={cn(primaryButtonClassName)}>
               {isUpdatingPassword ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -888,44 +961,62 @@ export const SettingsPanel = ({ user }: SettingsPanelProps) => {
         </form>
       </Card>
 
-      <Card>
+      <Card className={cn(cardClassName)}>
         <form onSubmit={handlePreferencesSubmit} className="space-y-0">
           <CardHeader>
             <CardTitle>{t.account.settings.title}</CardTitle>
-            <CardDescription>{t.account.settings.description}</CardDescription>
+            <CardDescription className={cn(subtleTextClassName)}>
+              {t.account.settings.description}
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-2">
-              <Label htmlFor="timezone">{t.account.settings.timezone}</Label>
+              <Label htmlFor="timezone" className={cn(labelClassName)}>
+                {t.account.settings.timezone}
+              </Label>
               <Input
                 id="timezone"
                 value={timezone}
                 onChange={event => setTimezone(event.target.value)}
                 placeholder={t.account.settings.timezonePlaceholder}
+                className={cn(inputClassName)}
               />
             </div>
             <div className="grid gap-2">
-              <Label>{t.account.settings.language}</Label>
-              <div className="rounded-md border border-input bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+              <Label className={cn(labelClassName)}>{t.account.settings.language}</Label>
+              <div
+                className={cn(
+                  "rounded-md border px-3 py-2 text-sm",
+                  isGlass
+                    ? "border-white/20 bg-white/5 text-white/80"
+                    : "border-input bg-muted/50 text-muted-foreground",
+                )}
+              >
                 {t.account.settings.languageValue}
               </div>
             </div>
             <div className="grid gap-2">
-              <Label>{t.account.settings.theme}</Label>
+              <Label className={cn(labelClassName)}>{t.account.settings.theme}</Label>
               <Select value={themePreference} onValueChange={value => setThemePreference(value as ThemePreference)}>
-                <SelectTrigger>
+                <SelectTrigger className={cn(selectTriggerClassName)}>
                   <SelectValue placeholder={t.account.settings.themePlaceholder} />
                 </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="system">{t.account.settings.themeOptions.system}</SelectItem>
-                  <SelectItem value="light">{t.account.settings.themeOptions.light}</SelectItem>
-                  <SelectItem value="dark">{t.account.settings.themeOptions.dark}</SelectItem>
+                <SelectContent className={cn(selectContentClassName)}>
+                  <SelectItem value="system" className={cn(selectItemClassName)}>
+                    {t.account.settings.themeOptions.system}
+                  </SelectItem>
+                  <SelectItem value="light" className={cn(selectItemClassName)}>
+                    {t.account.settings.themeOptions.light}
+                  </SelectItem>
+                  <SelectItem value="dark" className={cn(selectItemClassName)}>
+                    {t.account.settings.themeOptions.dark}
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </div>
           </CardContent>
           <CardFooter>
-            <Button type="submit" disabled={isSavingPreferences}>
+            <Button type="submit" disabled={isSavingPreferences} className={cn(primaryButtonClassName)}>
               {isSavingPreferences ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />


### PR DESCRIPTION
## Summary
- restyle the My Profile page with a glassmorphism layout, gradient background, and feature hero
- add glass-themed variants for the settings panel controls to match the refreshed profile aesthetics
- update profile information and security sections to use frosted cards with improved typography

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e28c4b1a1c8331aac8cc2956e9a43b