### PR TITLE
Highlight School text in navigation bar

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -84,7 +84,9 @@ const Navigation = () => {
             <div className="h-10 w-10 rounded-lg border border-white bg-muted flex items-center justify-center">
               <BookOpen className="h-6 w-6 text-primary" />
             </div>
-            <span className="text-xl font-bold">SchoolTech</span>
+            <span className="text-xl font-bold">
+              <span className="text-red-500">School</span>Tech
+            </span>
           </div>
         </Link>
 


### PR DESCRIPTION
## Summary
- update the navigation logo to render the word "School" in red for emphasis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28d916e6c8331ab1c0302e55caed2