### PR TITLE
Add teacher authentication preview dialog

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,7 +5,6 @@ import {
   Menu,
   User,
   LogOut,
-  BookOpen,
   IdCard,
 } from "lucide-react";
 import { useState, useEffect, useMemo } from "react";
@@ -21,8 +20,17 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
+import TeacherAuthDialog from "@/components/auth/TeacherAuthDialog";
+
+type NavItem = {
+  name: string;
+  path: string;
+  type?: "link" | "teacher-auth";
+};
+
 const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isTeacherAuthOpen, setIsTeacherAuthOpen] = useState(false);
   const [user, setUser] = useState<SupabaseUser | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
@@ -40,10 +48,10 @@ const Navigation = () => {
     return () => subscription.unsubscribe();
   }, []);
 
-  const navItems = useMemo(() => {
-    const items = [
+  const navItems: NavItem[] = useMemo(() => {
+    const items: NavItem[] = [
       { name: t.nav.home, path: "/" },
-      { name: t.nav.dashboard, path: "/teacher" },
+      { name: t.nav.dashboard, path: "/teacher", type: "teacher-auth" },
       { name: t.nav.student, path: "/student" },
       { name: t.nav.blog, path: "/blog" },
       { name: t.nav.events, path: "/events" },
@@ -70,7 +78,8 @@ const Navigation = () => {
   };
 
   return (
-    <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <>
+      <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
@@ -99,6 +108,27 @@ const Navigation = () => {
                 targetParams.toString().length === 0 ||
                 Array.from(targetParams.entries()).every(([key, value]) => currentParams.get(key) === value);
               const isActive = matchesPath && matchesQuery;
+
+              if (item.type === "teacher-auth") {
+                return (
+                  <button
+                    key={item.path}
+                    type="button"
+                    onClick={() => setIsTeacherAuthOpen(true)}
+                    aria-current={isActive ? "page" : undefined}
+                    aria-haspopup="dialog"
+                    aria-expanded={isTeacherAuthOpen}
+                    aria-controls="teacher-auth-dialog"
+                    className={cn(
+                      "rounded-full px-4 py-2 text-sm font-semibold transition-all whitespace-nowrap",
+                      "border border-transparent hover:border-white/40 hover:bg-white/20 hover:text-foreground hover:backdrop-blur-sm",
+                      "text-muted-foreground"
+                    )}
+                  >
+                    {item.name}
+                  </button>
+                );
+              }
 
               return (
                 <Link
@@ -178,6 +208,29 @@ const Navigation = () => {
                     Array.from(targetParams.entries()).every(([key, value]) => currentParams.get(key) === value);
                   const isActive = matchesPath && matchesQuery;
 
+                  if (item.type === "teacher-auth") {
+                    return (
+                      <button
+                        key={item.path}
+                        type="button"
+                        onClick={() => {
+                          setIsTeacherAuthOpen(true);
+                          setIsOpen(false);
+                        }}
+                        aria-current={isActive ? "page" : undefined}
+                        aria-haspopup="dialog"
+                        aria-expanded={isTeacherAuthOpen}
+                        aria-controls="teacher-auth-dialog"
+                        className={cn(
+                          "py-2 text-left text-lg font-medium transition-colors",
+                          "text-muted-foreground hover:text-primary"
+                        )}
+                      >
+                        {item.name}
+                      </button>
+                    );
+                  }
+
                   return (
                     <Link
                       key={item.path}
@@ -228,6 +281,15 @@ const Navigation = () => {
         </div>
       </div>
     </nav>
+      <TeacherAuthDialog
+        open={isTeacherAuthOpen}
+        onOpenChange={setIsTeacherAuthOpen}
+        onConfirm={() => {
+          setIsTeacherAuthOpen(false);
+          navigate(getLocalizedNavPath("/teacher"));
+        }}
+      />
+    </>
   );
 };
 

--- a/src/components/auth/TeacherAuthDialog.tsx
+++ b/src/components/auth/TeacherAuthDialog.tsx
@@ -1,0 +1,133 @@
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Sparkles, TrendingUp, Notebook, Trophy, CalendarDays, LogIn } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ReactNode } from "react";
+
+interface TeacherAuthDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+const featureItems: Array<{ icon: ReactNode; label: string }> = [
+  {
+    icon: <TrendingUp className="mt-0.5 h-4 w-4 shrink-0 text-white/80" />,
+    label: "Guided skill growth updates",
+  },
+  {
+    icon: <Notebook className="mt-0.5 h-4 w-4 shrink-0 text-white/80" />,
+    label: "Real-time homework tracking",
+  },
+  {
+    icon: <Trophy className="mt-0.5 h-4 w-4 shrink-0 text-white/80" />,
+    label: "Focus highlights from teachers",
+  },
+  {
+    icon: <CalendarDays className="mt-0.5 h-4 w-4 shrink-0 text-white/80" />,
+    label: "Upcoming sessions overview",
+  },
+];
+
+export const TeacherAuthDialog = ({ open, onOpenChange, onConfirm }: TeacherAuthDialogProps) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        id="teacher-auth-dialog"
+        className="max-w-2xl border-none bg-transparent p-0 shadow-none"
+      >
+        <div className="relative overflow-hidden rounded-3xl border border-white/20 bg-slate-950 text-white shadow-[0_30px_120px_-40px_rgba(15,23,42,1)]">
+          <div className="pointer-events-none absolute inset-0 opacity-70">
+            <div className="absolute -left-32 -top-32 h-80 w-80 rounded-full bg-cyan-500/40 blur-3xl" />
+            <div className="absolute -bottom-32 -right-32 h-96 w-96 rounded-full bg-purple-500/30 blur-3xl" />
+          </div>
+          <div className="relative space-y-8 p-8 md:p-12">
+            <div className="flex flex-col items-center gap-3 text-center">
+              <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-sm font-medium text-white/80 backdrop-blur">
+                <Sparkles className="h-4 w-4" />
+                Teacher preview access
+              </div>
+              <h2 className="text-3xl font-semibold">Log in to your journey</h2>
+              <p className="max-w-xl text-balance text-sm text-white/75">
+                Access assignments, celebrate streaks, and follow teacher guidance the moment you sign in.
+              </p>
+            </div>
+
+            <div className="flex items-center gap-4 rounded-2xl border border-white/20 bg-white/5 p-4">
+              <Avatar className="h-12 w-12 border border-white/30">
+                <AvatarFallback className="bg-white/10 text-lg text-white">AJ</AvatarFallback>
+              </Avatar>
+              <div className="text-left">
+                <p className="text-xs uppercase tracking-wide text-white/60">Previewing as</p>
+                <p className="text-lg font-medium text-white">Amelia Johnson</p>
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="teacher-email" className="text-xs uppercase tracking-wide text-white/60">
+                  School email
+                </Label>
+                <Input
+                  id="teacher-email"
+                  type="email"
+                  placeholder="you@studenthub.com"
+                  className={cn(
+                    "h-12 rounded-2xl border-white/20 bg-white/10 text-base text-white placeholder:text-white/40",
+                    "focus-visible:ring-white/40"
+                  )}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="teacher-code" className="text-xs uppercase tracking-wide text-white/60">
+                  Access code
+                </Label>
+                <Input
+                  id="teacher-code"
+                  type="text"
+                  placeholder="6-digit code"
+                  className={cn(
+                    "h-12 rounded-2xl border-white/20 bg-white/10 text-base text-white placeholder:text-white/40",
+                    "focus-visible:ring-white/40"
+                  )}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-3 text-sm text-white/75">
+              <p className="font-medium text-white">What you'll unlock</p>
+              <ul className="grid gap-2 text-left sm:grid-cols-2">
+                {featureItems.map((item) => (
+                  <li key={item.label} className="flex items-start gap-2">
+                    {item.icon}
+                    {item.label}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="space-y-3">
+              <Button
+                type="button"
+                size="lg"
+                onClick={onConfirm}
+                className="h-12 w-full rounded-2xl bg-white/95 text-base font-semibold text-slate-900 shadow-[0_10px_40px_-20px_rgba(226,232,240,0.95)] hover:bg-white"
+              >
+                <LogIn className="mr-2 h-5 w-5" />
+                Log in to my journey
+              </Button>
+              <p className="text-center text-xs text-white/60">
+                Need help? Ask your teacher to resend the code or reset your password.
+              </p>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default TeacherAuthDialog;


### PR DESCRIPTION
## Summary
- add a dedicated teacher authentication preview dialog component with the prototype messaging
- wire the navigation "Teacher" tab to open the dialog on desktop and mobile before navigating
- keep navigation routing after confirmation so the prototype dashboard remains accessible

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2918651cc833195398ba0ea871e33