### PR TITLE
Remove legacy marketing and account routes

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -1,26 +1,14 @@
 import React from 'react';
-import { Routes, Route, Navigate, useParams, useLocation } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import Index from '@/pages/Index';
 import About from '@/pages/About';
 import Services from '@/pages/Services';
 import Blog from '@/pages/Blog';
-import BlogPost from '@/pages/BlogPost';
-import BlogBuilderPage from '@/pages/BlogBuilderPage';
-import Resources from '@/pages/resources';
 import Events from '@/pages/Events';
-import EventDetail from '@/pages/EventDetail';
 import Contact from '@/pages/Contact';
 import FAQ from '@/pages/FAQ';
-import BuilderLessonPlan from '@/pages/BuilderLessonPlan';
-import BuilderLessonPlanDetail from '@/pages/BuilderLessonPlanDetail';
 import Auth from '@/pages/Auth';
-import Profile from '@/pages/Profile';
-import ClassDashboard from '@/pages/account/ClassDashboard';
-import AccountResources from '@/pages/AccountResources';
-import AccountResourceNew from '@/pages/AccountResourceNew';
-import AccountResourceEdit from '@/pages/AccountResourceEdit';
 import LessonBuilderPage from '@/pages/lesson-builder/LessonBuilderPage';
-import LessonBuilderWorkspace from '@/pages/lesson-builder/LessonBuilderWorkspace';
 import NotFound from '@/pages/NotFound';
 import Sitemap from '@/pages/Sitemap';
 import Navigation from '@/components/Navigation';
@@ -30,8 +18,6 @@ import AdminPage from '@/pages/admin/AdminPage';
 import AdminLoginPrototype from '@/pages/admin/AdminLoginPrototype';
 import DashboardPage from '@/pages/Dashboard';
 import StudentPage from '@/pages/Student';
-import StudentDashboardPage from '@/pages/StudentDashboard';
-import TeacherCurriculumDetailPage from '@/pages/TeacherCurriculumDetail';
 
 const RouteWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <>
@@ -43,47 +29,6 @@ const RouteWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => 
   </>
 );
 
-const LegacyBuilderRedirect: React.FC = () => {
-  const params = useParams<{ id?: string }>();
-  const destination = params.id
-    ? `/builder/lesson-plans/${params.id}`
-    : `/builder/lesson-plans`;
-
-  return <Navigate to={destination} replace />;
-};
-
-const LegacyAccountRedirect: React.FC = () => {
-  const location = useLocation();
-  const searchParams = new URLSearchParams(location.search);
-  const tab = searchParams.get('tab');
-  const tabMap: Record<string, string> = {
-    classes: 'classes',
-    students: 'students',
-    curriculum: 'curriculum',
-    builder: 'lessonBuilder',
-    assessments: 'assessments',
-  };
-
-  const mappedTab = tab ? tabMap[tab] : undefined;
-  const destination = mappedTab ? `/teacher?tab=${mappedTab}` : '/teacher';
-
-  return <Navigate to={destination} replace />;
-};
-
-const LegacyClassDashboardRedirect: React.FC = () => {
-  const params = useParams<{ id?: string }>();
-  const destination = params.id ? `/teacher/classes/${params.id}` : `/teacher?tab=classes`;
-  return <Navigate to={destination} replace />;
-};
-
-const LegacyStudentDashboardRedirect: React.FC = () => {
-  const params = useParams<{ id?: string }>();
-  const destination = params.id
-    ? `/teacher/students/${params.id}`
-    : `/teacher?tab=students`;
-  return <Navigate to={destination} replace />;
-};
-
 export const LocalizedRoutes = () => {
   return (
     <Routes>
@@ -93,35 +38,35 @@ export const LocalizedRoutes = () => {
       <Route path="/about" element={<RouteWrapper><About /></RouteWrapper>} />
       <Route path="/services" element={<RouteWrapper><Services /></RouteWrapper>} />
       <Route path="/blog" element={<RouteWrapper><Blog /></RouteWrapper>} />
-      <Route path="/blog/new" element={<RouteWrapper><BlogBuilderPage /></RouteWrapper>} />
-      <Route path="/blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
-      <Route path="/builder/lesson-plans" element={<RouteWrapper><BuilderLessonPlan /></RouteWrapper>} />
-      <Route path="/builder/lesson-plans/:id" element={<RouteWrapper><BuilderLessonPlanDetail /></RouteWrapper>} />
+      <Route path="/blog/new" element={<Navigate to="/blog" replace />} />
+      <Route path="/blog/:slug" element={<Navigate to="/blog" replace />} />
+      <Route path="/builder/lesson-plans" element={<Navigate to="/teacher?tab=curriculum" replace />} />
+      <Route path="/builder/lesson-plans/:id" element={<Navigate to="/teacher?tab=curriculum" replace />} />
       <Route path="/curriculum" element={<Navigate to="/teacher?tab=curriculum" replace />} />
-      <Route path="/lesson-plans/builder" element={<LegacyBuilderRedirect />} />
-      <Route path="/lesson-plans/builder/:id" element={<LegacyBuilderRedirect />} />
+      <Route path="/lesson-plans/builder" element={<Navigate to="/teacher?tab=lessonBuilder" replace />} />
+      <Route path="/lesson-plans/builder/:id" element={<Navigate to="/teacher?tab=lessonBuilder" replace />} />
       <Route path="/lesson-builder" element={<RouteWrapper><LessonBuilderPage /></RouteWrapper>} />
-      <Route path="/lesson-builder/:id" element={<RouteWrapper><LessonBuilderWorkspace /></RouteWrapper>} />
-      <Route path="/resources" element={<RouteWrapper><Resources /></RouteWrapper>} />
+      <Route path="/lesson-builder/:id" element={<Navigate to="/lesson-builder" replace />} />
+      <Route path="/resources" element={<Navigate to="/lesson-builder" replace />} />
       <Route path="/events" element={<RouteWrapper><Events /></RouteWrapper>} />
-      <Route path="/events/:slug" element={<RouteWrapper><EventDetail /></RouteWrapper>} />
+      <Route path="/events/:slug" element={<Navigate to="/events" replace />} />
       <Route path="/contact" element={<RouteWrapper><Contact /></RouteWrapper>} />
       <Route path="/faq" element={<RouteWrapper><FAQ /></RouteWrapper>} />
       <Route path="/auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
-      <Route path="/account" element={<LegacyAccountRedirect />} />
+      <Route path="/account" element={<Navigate to="/teacher" replace />} />
       <Route path="/teacher" element={<RouteWrapper><DashboardPage /></RouteWrapper>} />
-      <Route path="/teacher/curriculum/:id" element={<RouteWrapper><TeacherCurriculumDetailPage /></RouteWrapper>} />
-      <Route path="/teacher/classes/:id" element={<RouteWrapper><ClassDashboard /></RouteWrapper>} />
+      <Route path="/teacher/curriculum/:id" element={<Navigate to="/teacher?tab=curriculum" replace />} />
+      <Route path="/teacher/classes/:id" element={<Navigate to="/teacher?tab=classes" replace />} />
       <Route path="/dashboard" element={<Navigate to="/teacher" replace />} />
       <Route path="/student" element={<RouteWrapper><StudentPage /></RouteWrapper>} />
-      <Route path="/teacher/students/:id" element={<RouteWrapper><StudentDashboardPage /></RouteWrapper>} />
-      <Route path="/dashboard/students/:id" element={<LegacyStudentDashboardRedirect />} />
-      <Route path="/my-profile" element={<RouteWrapper><Profile /></RouteWrapper>} />
-      <Route path="/profile" element={<Navigate to="/my-profile" replace />} />
-      <Route path="/account/classes/:id" element={<LegacyClassDashboardRedirect />} />
-      <Route path="/account/resources" element={<RouteWrapper><AccountResources /></RouteWrapper>} />
-      <Route path="/account/resources/new" element={<RouteWrapper><AccountResourceNew /></RouteWrapper>} />
-      <Route path="/account/resources/:id" element={<RouteWrapper><AccountResourceEdit /></RouteWrapper>} />
+      <Route path="/teacher/students/:id" element={<Navigate to="/teacher?tab=students" replace />} />
+      <Route path="/dashboard/students/:id" element={<Navigate to="/teacher?tab=students" replace />} />
+      <Route path="/my-profile" element={<Navigate to="/teacher" replace />} />
+      <Route path="/profile" element={<Navigate to="/teacher" replace />} />
+      <Route path="/account/classes/:id" element={<Navigate to="/teacher?tab=classes" replace />} />
+      <Route path="/account/resources" element={<Navigate to="/lesson-builder" replace />} />
+      <Route path="/account/resources/new" element={<Navigate to="/lesson-builder" replace />} />
+      <Route path="/account/resources/:id" element={<Navigate to="/lesson-builder" replace />} />
       <Route path="/sitemap" element={<RouteWrapper><Sitemap /></RouteWrapper>} />
       <Route path="/admin/login" element={<AdminLoginPrototype />} />
       <Route path="/admin" element={<AdminLayout />}>

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -2,9 +2,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { useLanguage } from "@/contexts/LanguageContext";
 
-export type DashboardQuickAction =
-  | "ask-question"
-  | "post-blog";
+export type DashboardQuickAction = "ask-question";
 
 export interface DashboardHeaderNameParts {
   honorific?: string | null;
@@ -65,7 +63,7 @@ export function DashboardHeader({
             </p>
           </div>
         </div>
-        <div className="grid w-full gap-3 sm:grid-cols-2 lg:w-auto">
+        <div className="grid w-full gap-3 sm:max-w-xs lg:w-auto">
           <Button
             onClick={() => onQuickAction("ask-question")}
             variant="outline"
@@ -73,14 +71,6 @@ export function DashboardHeader({
             aria-label={t.dashboard.quickActions.askQuestion}
           >
             {t.dashboard.quickActions.askQuestion}
-          </Button>
-          <Button
-            onClick={() => onQuickAction("post-blog")}
-            variant="outline"
-            className="h-12 w-full justify-center rounded-2xl border-white/40 bg-white/10 text-sm font-semibold text-white/90 transition hover:border-white/60 hover:bg-white/20"
-            aria-label={t.dashboard.quickActions.postBlog}
-          >
-            {t.dashboard.quickActions.postBlog}
           </Button>
         </div>
       </div>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import {
   Search,
   Tag,
@@ -311,6 +311,7 @@ const Blog = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filters, setFilters] = useState<BlogFilterState>(() => createEmptyFilters());
+  const blogCanonicalPath = useMemo(() => getLocalizedPath("/blog", language), [language]);
 
   useEffect(() => {
     setSearchValue(searchParamValue);
@@ -630,7 +631,7 @@ const Blog = () => {
       item: {
         "@type": "BlogPosting",
         headline: post.title,
-        url: `https://schooltechub.com${getLocalizedPath(`/blog/${post.slug}`, language)}`,
+        url: `https://schooltechub.com${blogCanonicalPath}#${post.slug}`,
         datePublished: post.published_at ?? post.created_at ?? undefined,
         dateModified: post.updated_at ?? undefined,
         description: post.excerpt ?? undefined,
@@ -647,7 +648,7 @@ const Blog = () => {
       "@type": "ItemList",
       itemListElement: items,
     };
-  }, [filteredPosts, language]);
+  }, [filteredPosts, blogCanonicalPath]);
 
   const getCategoryLabel = (value?: string | null) => {
     if (!value) {
@@ -703,7 +704,7 @@ const Blog = () => {
       <SEO
         title={t.blog.seo.title}
         description={t.blog.seo.description}
-        canonicalUrl={`https://schooltechub.com${getLocalizedPath("/blog", language)}`}
+        canonicalUrl={`https://schooltechub.com${blogCanonicalPath}`}
       />
 
       {structuredData ? <StructuredData data={structuredData} /> : null}
@@ -934,12 +935,8 @@ const Blog = () => {
                     </div>
                     <div className="grid gap-5 md:grid-cols-2">
                       {featuredPosts.map(post => (
-                        <Link
-                          key={post.id}
-                          to={getLocalizedPath(`/blog/${post.slug}`, language)}
-                          className="group block"
-                        >
-                          <Card className="overflow-hidden border-white/20 bg-white/10 text-white shadow-[0_25px_80px_-30px_rgba(15,23,42,1)] transition-transform hover:-translate-y-1 hover:border-white/40">
+                        <article key={post.id} className="group block">
+                          <Card className="overflow-hidden border-white/20 bg-white/10 text-white shadow-[0_25px_80px_-30px_rgba(15,23,42,1)] transition-transform group-hover:-translate-y-1 group-hover:border-white/40">
                             {post.featured_image ? (
                               <figure className="relative h-48 overflow-hidden">
                                 <img
@@ -959,7 +956,7 @@ const Blog = () => {
                               ) : null}
                             </CardHeader>
                           </Card>
-                        </Link>
+                        </article>
                       ))}
                     </div>
                   </div>
@@ -975,12 +972,8 @@ const Blog = () => {
                     </div>
                     <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
                       {regularPosts.map(post => (
-                        <Link
-                          key={post.id}
-                          to={getLocalizedPath(`/blog/${post.slug}`, language)}
-                          className="group block h-full"
-                        >
-                          <Card className="flex h-full flex-col overflow-hidden border-white/15 bg-white/5 text-white shadow-[0_20px_60px_-30px_rgba(15,23,42,1)] transition-transform hover:-translate-y-1 hover:border-white/30">
+                        <article key={post.id} className="group block h-full">
+                          <Card className="flex h-full flex-col overflow-hidden border-white/15 bg-white/5 text-white shadow-[0_20px_60px_-30px_rgba(15,23,42,1)] transition-transform group-hover:-translate-y-1 group-hover:border-white/30">
                             {post.featured_image ? (
                               <figure className="relative h-40 overflow-hidden">
                                 <img
@@ -1000,7 +993,7 @@ const Blog = () => {
                               ) : null}
                             </CardHeader>
                           </Card>
-                        </Link>
+                        </article>
                       ))}
                     </div>
                   </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -405,15 +405,8 @@ export default function DashboardPage() {
   });
 
   const handleQuickAction = (action: DashboardQuickAction) => {
-    switch (action) {
-      case "ask-question":
-        navigate("/forum/new");
-        return;
-      case "post-blog":
-        navigate("/blog/new");
-        return;
-      default:
-        return;
+    if (action === "ask-question") {
+      navigate("/forum/new");
     }
   };
 

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -10,7 +10,6 @@ import { supabase } from "@/integrations/supabase/client";
 import { SEO } from "@/components/SEO";
 import { format, differenceInMilliseconds } from "date-fns";
 import { useLanguage } from "@/contexts/LanguageContext";
-import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 import { cn } from "@/lib/utils";
 
 const Events = () => {
@@ -336,9 +335,9 @@ const Events = () => {
 
                         <div className="space-y-2">
                           <h3 className="text-2xl font-semibold text-white">
-                            <Link to={getLocalizedPath(`/events/${event.slug}`, language)} className="hover:text-white/80">
+                            <span className="block transition-colors hover:text-white/80">
                               {event.title}
-                            </Link>
+                            </span>
                           </h3>
                           {event.subtitle && <p className="text-sm text-white/70">{event.subtitle}</p>}
                           <p className="text-sm text-white/70">{event.excerpt || "Click for more details..."}</p>
@@ -374,7 +373,9 @@ const Events = () => {
                         <div className="flex flex-wrap gap-3">
                           {!isPast && event.registration_url && (
                             <Button asChild className="rounded-2xl bg-white/90 text-slate-900 shadow-[0_15px_45px_-25px_rgba(226,232,240,0.9)] hover:bg-white">
-                              <Link to={event.registration_url}>Register Now</Link>
+                              <a href={event.registration_url} target="_blank" rel="noopener noreferrer">
+                                Register Now
+                              </a>
                             </Button>
                           )}
                           {isPast && event.recording_url && (
@@ -384,13 +385,6 @@ const Events = () => {
                               </a>
                             </Button>
                           )}
-                          <Button
-                            variant="outline"
-                            asChild
-                            className="rounded-2xl border-white/30 text-white hover:bg-white/10 hover:text-white"
-                          >
-                            <Link to={getLocalizedPath(`/events/${event.slug}`, language)}>View Details</Link>
-                          </Button>
                         </div>
                       </CardContent>
                     </Card>

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -1,10 +1,6 @@
 import { Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SEO } from "@/components/SEO";
-import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
-import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
-import { format } from "date-fns";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { en } from "@/translations/en";
 
@@ -13,17 +9,9 @@ type RouteLink = {
   url: string;
 };
 
-type DynamicLink = RouteLink & {
-  updatedAt?: string | null;
-};
-
 type TranslationDictionary = typeof en;
 
 const createStaticRoutes = (dictionary: TranslationDictionary): RouteLink[] => [
-  {
-    title: dictionary.nav.my_profile ?? dictionary.nav.profile ?? dictionary.nav.dashboard,
-    url: "/my-profile"
-  },
   { title: dictionary.nav.home, url: "/home" },
   { title: dictionary.nav.about, url: "/about" },
   { title: dictionary.nav.services, url: "/services" },
@@ -35,46 +23,8 @@ const createStaticRoutes = (dictionary: TranslationDictionary): RouteLink[] => [
   { title: dictionary.sitemap.links.sitemap, url: "/sitemap" },
 ];
 
-const formatUpdatedAt = (value?: string | null) => {
-  if (!value) return null;
-  try {
-    return format(new Date(value), "MMM d, yyyy");
-  } catch (error) {
-    console.error("Error formatting date", error);
-    return null;
-  }
-};
-
 const Sitemap = () => {
   const { t } = useLanguage();
-
-  const { data: blogPosts = [] } = useQuery({
-    queryKey: ["sitemap-blog-posts"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("blogs")
-        .select("slug, title, updated_at, published_at")
-        .eq("is_published", true)
-        .order("published_at", { ascending: false });
-
-      if (error) throw error;
-      return data ?? [];
-    }
-  });
-
-  const { data: events = [] } = useQuery({
-    queryKey: ["sitemap-events"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("events")
-        .select("slug, title, updated_at, start_datetime")
-        .eq("is_published", true)
-        .order("start_datetime", { ascending: false });
-
-      if (error) throw error;
-      return data ?? [];
-    }
-  });
 
   const staticSections = [
     {
@@ -82,28 +32,6 @@ const Sitemap = () => {
       links: createStaticRoutes(en)
     }
   ];
-
-  const dynamicSections: { title: string; links: DynamicLink[] }[] = [
-    {
-      title: t.sitemap.sections.blogPosts,
-      links: blogPosts.map((post) => ({
-        title: post.title || post.slug,
-        url: getLocalizedPath(`/blog/${post.slug}`, 'en'),
-        updatedAt: formatUpdatedAt(post.updated_at ?? post.published_at ?? undefined)
-      }))
-    },
-    {
-      title: t.sitemap.sections.events,
-      links: events.map((event) => ({
-        title: event.title || event.slug,
-        url: getLocalizedPath(`/events/${event.slug}`, 'en'),
-        updatedAt: formatUpdatedAt(event.updated_at ?? event.start_datetime ?? undefined)
-      }))
-    }
-  ].map((section) => ({
-    ...section,
-    links: section.links.filter((link) => Boolean(link?.url && link?.title))
-  })).filter((section) => section.links.length > 0);
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -142,40 +70,6 @@ const Sitemap = () => {
               </Card>
             ))}
           </div>
-
-          {dynamicSections.length > 0 && (
-            <div className="mt-10 space-y-6">
-              <h2 className="text-2xl font-semibold">{t.sitemap.sections.freshContent}</h2>
-              <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-                {dynamicSections.map((section) => (
-                  <Card key={section.title}>
-                    <CardHeader>
-                      <CardTitle>{section.title}</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <ul className="space-y-3">
-                        {section.links.map((link) => (
-                          <li key={link.url}>
-                            <Link
-                              to={link.url}
-                              className="text-primary hover:underline"
-                            >
-                              {link.title}
-                            </Link>
-                            {link.updatedAt && (
-                              <div className="text-xs text-muted-foreground mt-1">
-                                Updated {link.updatedAt}
-                              </div>
-                            )}
-                          </li>
-                        ))}
-                      </ul>
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-            </div>
-          )}
 
           <Card className="mt-8">
             <CardHeader>

--- a/src/pages/lesson-builder/LessonBuilderWorkspace.tsx
+++ b/src/pages/lesson-builder/LessonBuilderWorkspace.tsx
@@ -304,10 +304,10 @@ export default function LessonBuilderWorkspace() {
       stage,
       date,
       links: {
-        lesson: `/builder/lesson-plans/${planQuery.data.id}`,
-        class: planQuery.data.class?.id ? `/teacher/classes/${planQuery.data.class.id}` : undefined,
-        stage: `/builder/lesson-plans/${planQuery.data.id}`,
-        date: `/builder/lesson-plans/${planQuery.data.id}`,
+        lesson: `/lesson-builder`,
+        class: planQuery.data.class?.id ? `/teacher?tab=classes` : undefined,
+        stage: `/lesson-builder`,
+        date: `/lesson-builder`,
       },
     } as const;
   }, [planQuery.data, t.lessonBuilder.editor.unknownClass, t.lessonBuilder.editor.loadingTitle]);

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1924,7 +1924,7 @@ export const en = {
       seo: {
         title: "My Resources | SchoolTech Hub",
         description: "Review, update, and share your classroom resources from a single dashboard.",
-        canonical: "https://schooltechhub.com/account/resources"
+        canonical: "https://schooltechhub.com/lesson-builder"
       },
       listTitle: "Your resources",
       listDescription: "Update details, refresh links, or share another resource with peers.",
@@ -1973,7 +1973,7 @@ export const en = {
         seo: {
           title: "Submit Resource | SchoolTech Hub",
           description: "Add a new classroom resource for teachers to discover.",
-          canonical: "https://schooltechhub.com/account/resources/new"
+          canonical: "https://schooltechhub.com/lesson-builder"
         }
       },
       edit: {
@@ -1982,7 +1982,7 @@ export const en = {
         seo: {
           title: "Edit {title} | SchoolTech Hub",
           description: "Update the metadata and notes for this teaching resource.",
-          canonical: "https://schooltechhub.com/account/resources"
+          canonical: "https://schooltechhub.com/lesson-builder"
         }
       }
     },
@@ -2155,7 +2155,7 @@ export const en = {
     seo: {
       title: "Build a blog post",
       description: "Draft your story, attach helpful links, and send it to our editorial team for review.",
-      canonical: "https://schooltechub.com/blog/new",
+      canonical: "https://schooltechub.com/blog",
     },
     heading: "Build a blog post",
     subheading: "Share classroom wins, reflections, and big ideas. Submissions are reviewed before publishing.",


### PR DESCRIPTION
## Summary
- replace retired blog, builder, and account endpoints with redirects to active teacher and lesson builder destinations
- simplify marketing pages by removing deep links from the blog grid, event listings, and sitemap
- update SEO metadata so retired URLs now point to the canonical blog and lesson builder routes

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e28ff1208c83318ae9cfcb7539028b