### PR TITLE
Refine teacher tab triggers with shared glass style

### DIFF
--- a/src/components/dashboard/AssessmentsSection.tsx
+++ b/src/components/dashboard/AssessmentsSection.tsx
@@ -44,6 +44,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
 
 const gradeScales: Array<{ value: GradeScale; label: string }> = [
   { value: "letter", label: "Letter" },
@@ -66,7 +67,7 @@ const formatDate = (value: string | null | undefined) => {
   return format(parsed, "PPP");
 };
 
-export const AssessmentsSection = () => {
+export const AssessmentsSection = ({ className }: { className?: string }) => {
   const { user } = useOptionalUser();
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -199,6 +200,7 @@ export const AssessmentsSection = () => {
           setGradingDialogOpen(true);
         }}
         canManage={canManage}
+        className={className}
       />
       <GradingDialog
         open={gradingDialogOpen}
@@ -231,6 +233,7 @@ interface AssessmentsPanelProps {
   isCreating: boolean;
   onOpenGrades: (assessment: AssessmentTemplate) => void;
   canManage: boolean;
+  className?: string;
 }
 
 const AssessmentsPanel = ({
@@ -242,6 +245,7 @@ const AssessmentsPanel = ({
   isCreating,
   onOpenGrades,
   canManage,
+  className,
 }: AssessmentsPanelProps) => {
   const [selectedClassId, setSelectedClassId] = useState<string | null>(null);
   const [form, setForm] = useState({
@@ -307,28 +311,50 @@ const AssessmentsPanel = ({
   };
 
   return (
-    <Card>
-      <CardHeader className="flex flex-col gap-3">
+    <Card
+      className={cn(
+        "rounded-[2rem] border border-white/15 bg-white/10 text-white shadow-[0_35px_120px_-50px_rgba(15,23,42,0.95)] backdrop-blur-2xl",
+        className,
+      )}
+    >
+      <CardHeader className="flex flex-col gap-4">
         {selectedClass ? (
           <>
-            <Button variant="ghost" size="sm" className="w-fit pl-0" onClick={() => setSelectedClassId(null)}>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-fit rounded-xl border border-white/30 bg-white/10 px-4 py-2 text-white/80 transition hover:bg-white/20"
+              onClick={() => setSelectedClassId(null)}
+            >
               <ArrowLeft className="mr-2 h-4 w-4" /> Back to classes
             </Button>
             <div>
-              <CardTitle>{selectedClass.title}</CardTitle>
-              <CardDescription>
+              <CardTitle className="text-2xl font-semibold text-white">
+                {selectedClass.title}
+              </CardTitle>
+              <CardDescription className="text-white/70">
                 Review assessments, track submissions, and record grades for this class.
               </CardDescription>
             </div>
-            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-              {selectedClass.stage ? <Badge variant="outline">{selectedClass.stage}</Badge> : null}
-              {selectedClass.subject ? <Badge variant="outline">{selectedClass.subject}</Badge> : null}
+            <div className="flex flex-wrap gap-2 text-xs text-white/70">
+              {selectedClass.stage ? (
+                <Badge variant="outline" className="border-white/40 bg-white/10 text-white/80">
+                  {selectedClass.stage}
+                </Badge>
+              ) : null}
+              {selectedClass.subject ? (
+                <Badge variant="outline" className="border-white/40 bg-white/10 text-white/80">
+                  {selectedClass.subject}
+                </Badge>
+              ) : null}
             </div>
           </>
         ) : (
           <>
-            <CardTitle>Assessment tracking</CardTitle>
-            <CardDescription>
+            <CardTitle className="text-2xl font-semibold text-white">
+              Assessment tracking
+            </CardTitle>
+            <CardDescription className="text-white/70">
               Choose a class to review assessments, track submissions, and add new ones.
             </CardDescription>
           </>
@@ -339,33 +365,33 @@ const AssessmentsPanel = ({
           <div className="space-y-6">
             {isLoading ? (
               <div className="flex justify-center py-10">
-                <Loader2 className="h-5 w-5 animate-spin" />
+                <Loader2 className="h-5 w-5 animate-spin text-white/80" />
               </div>
             ) : error ? (
-              <div className="rounded-lg border border-destructive bg-destructive/10 p-4 text-destructive">
+              <div className="rounded-2xl border border-red-500/60 bg-red-500/10 p-4 text-sm text-red-100">
                 {error.message}
               </div>
             ) : classAssessments.length === 0 ? (
-              <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+              <div className="rounded-2xl border border-dashed border-white/30 bg-white/5 p-8 text-center text-sm text-white/70">
                 No assessments for this class yet. Use the form below to create one.
               </div>
             ) : (
-              <div className="overflow-hidden rounded-lg border">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
+              <div className="overflow-hidden rounded-2xl border border-white/20 bg-white/5 shadow-[0_25px_80px_-40px_rgba(15,23,42,0.9)] backdrop-blur-xl">
+                <Table className="text-white/80">
+                  <TableHeader className="bg-white/5 text-white/70 [&_tr]:border-white/10 [&_th]:text-white/70 [&_th]:font-semibold">
+                    <TableRow className="border-white/10">
                       <TableHead>Assessment</TableHead>
                       <TableHead>Due</TableHead>
                       <TableHead>Scale</TableHead>
                       <TableHead className="w-[140px]" />
                     </TableRow>
                   </TableHeader>
-                  <TableBody>
+                  <TableBody className="[&_tr]:border-white/10">
                     {classAssessments.map(assessment => (
-                      <TableRow key={assessment.id}>
-                        <TableCell className="font-medium text-foreground">{assessment.title}</TableCell>
-                        <TableCell className="text-sm text-muted-foreground">{formatDate(assessment.dueDate)}</TableCell>
-                        <TableCell className="text-sm text-muted-foreground">{assessment.gradingScale}</TableCell>
+                      <TableRow key={assessment.id} className="border-white/10 transition hover:bg-white/15">
+                        <TableCell className="font-semibold text-white">{assessment.title}</TableCell>
+                        <TableCell className="text-sm text-white/70">{formatDate(assessment.dueDate)}</TableCell>
+                        <TableCell className="text-sm text-white/70">{assessment.gradingScale}</TableCell>
                         <TableCell className="text-right">
                           <Button
                             size="sm"
@@ -380,6 +406,7 @@ const AssessmentsPanel = ({
                               onOpenGrades(assessment);
                             }}
                             disabled={readOnly}
+                            className="rounded-lg border border-white/40 bg-white/90 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-white disabled:border-white/20 disabled:text-slate-700"
                           >
                             Record grades
                           </Button>
@@ -391,35 +418,43 @@ const AssessmentsPanel = ({
               </div>
             )}
 
-            <section className="rounded-lg border bg-muted/20 p-4">
-              <h3 className="text-sm font-semibold text-foreground">Add new assessment</h3>
-              <p className="mt-1 text-sm text-muted-foreground">
+            <section className="rounded-2xl border border-white/15 bg-white/10 p-6 text-white shadow-[0_25px_80px_-40px_rgba(15,23,42,0.9)] backdrop-blur-xl">
+              <h3 className="text-lg font-semibold text-white">Add new assessment</h3>
+              <p className="mt-2 text-sm text-white/70">
                 Share expectations, due dates, and grading scales with your class.
               </p>
               <div className="mt-4 space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="assessment-title">Title</Label>
+                  <Label htmlFor="assessment-title" className="text-sm font-medium text-white/80">
+                    Title
+                  </Label>
                   <Input
                     id="assessment-title"
                     value={form.title}
                     onChange={event => setForm(current => ({ ...current, title: event.target.value }))}
                     placeholder="Forces and motion quiz"
                     disabled={readOnly}
+                    className="rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-white/60 focus:border-white/60 focus:ring-white/40 disabled:border-white/10 disabled:text-white/40"
                   />
                 </div>
                 <div className="grid gap-4 sm:grid-cols-2">
                   <div className="space-y-2">
-                    <Label htmlFor="assessment-due">Due date</Label>
+                    <Label htmlFor="assessment-due" className="text-sm font-medium text-white/80">
+                      Due date
+                    </Label>
                     <Input
                       id="assessment-due"
                       type="date"
                       value={form.dueDate}
                       onChange={event => setForm(current => ({ ...current, dueDate: event.target.value }))}
                       disabled={readOnly}
+                      className="rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-white/60 focus:border-white/60 focus:ring-white/40 disabled:border-white/10 disabled:text-white/40"
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="assessment-scale">Grading scale</Label>
+                    <Label htmlFor="assessment-scale" className="text-sm font-medium text-white/80">
+                      Grading scale
+                    </Label>
                     <Select
                       value={form.scale}
                       onValueChange={value =>
@@ -427,10 +462,13 @@ const AssessmentsPanel = ({
                       }
                       disabled={readOnly}
                     >
-                      <SelectTrigger id="assessment-scale">
+                      <SelectTrigger
+                        id="assessment-scale"
+                        className="rounded-xl border border-white/30 bg-white/10 text-white focus:ring-white/40 disabled:border-white/10 disabled:text-white/40"
+                      >
                         <SelectValue />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent className="border-white/20 bg-slate-900/90 text-white backdrop-blur-xl">
                         {gradeScales.map(option => (
                           <SelectItem key={option.value} value={option.value}>
                             {option.label}
@@ -441,17 +479,24 @@ const AssessmentsPanel = ({
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="assessment-description">Instructions</Label>
+                  <Label htmlFor="assessment-description" className="text-sm font-medium text-white/80">
+                    Instructions
+                  </Label>
                   <Textarea
                     id="assessment-description"
                     value={form.description}
                     onChange={event => setForm(current => ({ ...current, description: event.target.value }))}
                     placeholder="Outline objectives, required materials, and success criteria"
                     disabled={readOnly}
+                    className="rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-white/60 focus:border-white/60 focus:ring-white/40 disabled:border-white/10 disabled:text-white/40"
                   />
                 </div>
                 <div className="flex justify-end">
-                  <Button onClick={handleSubmit} disabled={!form.title.trim() || isCreating || readOnly}>
+                  <Button
+                    onClick={handleSubmit}
+                    disabled={!form.title.trim() || isCreating || readOnly}
+                    className="rounded-xl border border-white/40 bg-white/90 px-5 py-2 text-sm font-semibold text-slate-900 shadow-[0_15px_45px_-25px_rgba(255,255,255,0.9)] transition hover:bg-white disabled:border-white/20 disabled:text-slate-700"
+                  >
                     {isCreating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
                     Add assessment
                   </Button>
@@ -462,17 +507,17 @@ const AssessmentsPanel = ({
         ) : (
           <div className="space-y-4">
             {readOnly ? (
-              <div className="rounded-lg border border-dashed border-primary/40 bg-primary/5 p-4 text-sm text-muted-foreground">
+              <div className="rounded-2xl border border-dashed border-white/30 bg-white/5 p-4 text-sm text-white/70">
                 Browse example assessment tracking. Sign in to create assignments, record submissions, and grade students.
               </div>
             ) : null}
             {error ? (
-              <div className="rounded-lg border border-destructive bg-destructive/10 p-4 text-destructive">
+              <div className="rounded-2xl border border-red-500/60 bg-red-500/10 p-4 text-sm text-red-100">
                 {error.message}
               </div>
             ) : null}
             {classes.length === 0 ? (
-              <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+              <div className="rounded-2xl border border-dashed border-white/30 bg-white/5 p-8 text-center text-sm text-white/70">
                 Create a class to start tracking assessments.
               </div>
             ) : (
@@ -482,22 +527,30 @@ const AssessmentsPanel = ({
                     key={classItem.id}
                     type="button"
                     onClick={() => setSelectedClassId(classItem.id)}
-                    className="flex w-full flex-col items-start gap-3 rounded-xl border bg-background/80 p-4 text-left shadow-sm transition hover:border-primary/60 hover:shadow"
+                    className="flex w-full flex-col items-start gap-3 rounded-2xl border border-white/20 bg-white/10 p-5 text-left text-white shadow-[0_20px_60px_-30px_rgba(15,23,42,0.85)] transition hover:border-white/40 hover:bg-white/15"
                   >
                     <div className="flex w-full items-start justify-between gap-3">
                       <div>
-                        <h3 className="text-lg font-semibold text-foreground">{classItem.title}</h3>
-                        <p className="text-sm text-muted-foreground">
+                        <h3 className="text-lg font-semibold text-white">{classItem.title}</h3>
+                        <p className="text-sm text-white/70">
                           {classItem.summary ?? "Track assignments, submissions, and feedback in one place."}
                         </p>
                       </div>
-                      <Badge variant="outline">
+                      <Badge variant="outline" className="border-white/40 bg-white/10 text-white/80">
                         {assessmentCounts.get(classItem.id) ?? 0} assessments
                       </Badge>
                     </div>
-                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                      {classItem.stage ? <Badge variant="outline">{classItem.stage}</Badge> : null}
-                      {classItem.subject ? <Badge variant="outline">{classItem.subject}</Badge> : null}
+                    <div className="flex flex-wrap gap-2 text-xs text-white/70">
+                      {classItem.stage ? (
+                        <Badge variant="outline" className="border-white/40 bg-white/10 text-white/80">
+                          {classItem.stage}
+                        </Badge>
+                      ) : null}
+                      {classItem.subject ? (
+                        <Badge variant="outline" className="border-white/40 bg-white/10 text-white/80">
+                          {classItem.subject}
+                        </Badge>
+                      ) : null}
                     </div>
                   </button>
                 ))}
@@ -505,7 +558,7 @@ const AssessmentsPanel = ({
             )}
             {isLoading ? (
               <div className="flex justify-center py-6">
-                <Loader2 className="h-5 w-5 animate-spin" />
+                <Loader2 className="h-5 w-5 animate-spin text-white/80" />
               </div>
             ) : null}
           </div>
@@ -549,39 +602,48 @@ const GradingDialog = ({
 }: GradingDialogProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl border border-white/20 bg-white/10 text-white shadow-[0_35px_120px_-50px_rgba(15,23,42,0.95)] backdrop-blur-2xl">
         <DialogHeader>
-          <DialogTitle>Grade submissions</DialogTitle>
-          <DialogDescription>Record progress and share personalised feedback.</DialogDescription>
+          <DialogTitle className="text-2xl font-semibold text-white">Grade submissions</DialogTitle>
+          <DialogDescription className="text-white/70">
+            Record progress and share personalised feedback.
+          </DialogDescription>
         </DialogHeader>
         {context.assessment ? (
           <div className="space-y-6">
-            <div className="rounded-lg border bg-muted/20 p-4">
-              <p className="text-sm font-medium text-foreground">{context.assessment.title}</p>
-              <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <div className="rounded-2xl border border-white/15 bg-white/10 p-4 text-white shadow-[0_20px_60px_-30px_rgba(15,23,42,0.85)]">
+              <p className="text-sm font-semibold text-white">{context.assessment.title}</p>
+              <div className="mt-2 flex flex-wrap gap-2 text-xs text-white/70">
                 {context.assessment.dueDate ? (
-                  <Badge variant="outline">Due {formatDate(context.assessment.dueDate)}</Badge>
+                  <Badge variant="outline" className="border-white/40 bg-white/10 text-white/80">
+                    Due {formatDate(context.assessment.dueDate)}
+                  </Badge>
                 ) : null}
-                <Badge variant="outline">Scale: {context.assessment.gradingScale}</Badge>
+                <Badge variant="outline" className="border-white/40 bg-white/10 text-white/80">
+                  Scale: {context.assessment.gradingScale}
+                </Badge>
               </div>
             </div>
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="grade-student">Student ID</Label>
+                <Label htmlFor="grade-student" className="text-sm font-medium text-white/80">
+                  Student ID
+                </Label>
                 <Input
                   id="grade-student"
                   value={context.studentId}
                   onChange={event => onChange({ ...context, studentId: event.target.value })}
                   placeholder="Enter student identifier"
+                  className="rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-white/60 focus:border-white/60 focus:ring-white/40"
                 />
               </div>
               <div className="space-y-2">
-                <Label>Scale</Label>
+                <Label className="text-sm font-medium text-white/80">Scale</Label>
                 <Select value={context.scale} onValueChange={value => onChange({ ...context, scale: value as GradeScale })}>
-                  <SelectTrigger>
+                  <SelectTrigger className="rounded-xl border border-white/30 bg-white/10 text-white focus:ring-white/40">
                     <SelectValue />
                   </SelectTrigger>
-                  <SelectContent>
+                  <SelectContent className="border-white/20 bg-slate-900/90 text-white backdrop-blur-xl">
                     {gradeScales.map(option => (
                       <SelectItem key={option.value} value={option.value}>
                         {option.label}
@@ -593,12 +655,17 @@ const GradingDialog = ({
             </div>
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="grade-value">Grade</Label>
+                <Label htmlFor="grade-value" className="text-sm font-medium text-white/80">
+                  Grade
+                </Label>
                 <Select value={context.grade} onValueChange={value => onChange({ ...context, grade: value })}>
-                  <SelectTrigger id="grade-value">
+                  <SelectTrigger
+                    id="grade-value"
+                    className="rounded-xl border border-white/30 bg-white/10 text-white focus:ring-white/40"
+                  >
                     <SelectValue placeholder="Select or type" />
                   </SelectTrigger>
-                  <SelectContent>
+                  <SelectContent className="border-white/20 bg-slate-900/90 text-white backdrop-blur-xl">
                     {presets[context.scale].map(option => (
                       <SelectItem key={option} value={option}>
                         {option}
@@ -607,35 +674,41 @@ const GradingDialog = ({
                   </SelectContent>
                 </Select>
                 <Input
-                  className="mt-2"
+                  className="mt-2 rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-white/60 focus:border-white/60 focus:ring-white/40"
                   placeholder="Custom grade"
                   value={context.grade}
                   onChange={event => onChange({ ...context, grade: event.target.value })}
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="grade-numeric">Numeric value</Label>
+                <Label htmlFor="grade-numeric" className="text-sm font-medium text-white/80">
+                  Numeric value
+                </Label>
                 <Input
                   id="grade-numeric"
                   type="number"
                   value={context.numeric}
                   onChange={event => onChange({ ...context, numeric: event.target.value })}
                   placeholder="Optional"
+                  className="rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-white/60 focus:border-white/60 focus:ring-white/40"
                 />
               </div>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="grade-feedback">Feedback</Label>
+              <Label htmlFor="grade-feedback" className="text-sm font-medium text-white/80">
+                Feedback
+              </Label>
               <Textarea
                 id="grade-feedback"
                 value={context.feedback}
                 onChange={event => onChange({ ...context, feedback: event.target.value })}
                 placeholder="Celebrate wins and outline next steps"
+                className="rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-white/60 focus:border-white/60 focus:ring-white/40"
               />
             </div>
-            <div className="rounded-lg border bg-muted/20 p-4">
-              <p className="text-sm font-medium text-foreground">Recent submissions</p>
-              <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+            <div className="rounded-2xl border border-white/15 bg-white/10 p-4 text-white">
+              <p className="text-sm font-medium text-white">Recent submissions</p>
+              <ul className="mt-2 space-y-1 text-xs text-white/70">
                 {submissions.length ? (
                   submissions.map(item => (
                     <li key={item.id}>
@@ -648,9 +721,9 @@ const GradingDialog = ({
                 )}
               </ul>
             </div>
-            <div className="rounded-lg border bg-muted/20 p-4">
-              <p className="text-sm font-medium text-foreground">Recent grades</p>
-              <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+            <div className="rounded-2xl border border-white/15 bg-white/10 p-4 text-white">
+              <p className="text-sm font-medium text-white">Recent grades</p>
+              <ul className="mt-2 space-y-1 text-xs text-white/70">
                 {grades.length ? (
                   grades.map(grade => (
                     <li key={grade.id}>
@@ -665,10 +738,18 @@ const GradingDialog = ({
           </div>
         ) : null}
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            className="border-white/40 text-white hover:bg-white/15"
+          >
             Close
           </Button>
-          <Button onClick={onSubmit} disabled={!context.assessment || !context.studentId || isSubmitting}>
+          <Button
+            onClick={onSubmit}
+            disabled={!context.assessment || !context.studentId || isSubmitting}
+            className="border border-white/40 bg-white/90 text-slate-900 hover:bg-white disabled:border-white/20 disabled:text-slate-700"
+          >
             {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
             Save grade
           </Button>

--- a/src/components/dashboard/ClassesTable.tsx
+++ b/src/components/dashboard/ClassesTable.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { cn } from "@/lib/utils";
 import type { Class } from "../../../types/supabase-tables";
 import { format } from "date-fns";
 
@@ -11,6 +12,7 @@ interface ClassesTableProps {
   onNewClass: () => void;
   onViewClass?: (classId: string) => void;
   onEditClass?: (classId: string) => void;
+  className?: string;
 }
 
 const formatDate = (value?: string | null) => {
@@ -23,24 +25,42 @@ const formatDate = (value?: string | null) => {
   }
 };
 
-export function ClassesTable({ classes, loading, onNewClass, onViewClass, onEditClass }: ClassesTableProps) {
+export function ClassesTable({
+  classes,
+  loading,
+  onNewClass,
+  onViewClass,
+  onEditClass,
+  className,
+}: ClassesTableProps) {
   const { t } = useLanguage();
 
   return (
-    <section className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">{t.dashboard.classes.title}</h2>
-          <p className="text-sm text-muted-foreground">{t.dashboard.classes.subtitle}</p>
+    <section
+      className={cn(
+        "space-y-6 rounded-[2rem] border border-white/15 bg-white/10 p-6 text-white shadow-[0_35px_120px_-50px_rgba(15,23,42,0.95)] backdrop-blur-2xl md:p-8",
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold leading-tight text-white md:text-3xl">
+            {t.dashboard.classes.title}
+          </h2>
+          <p className="text-sm text-white/70">{t.dashboard.classes.subtitle}</p>
         </div>
-        <Button onClick={onNewClass} aria-label={t.dashboard.quickActions.newClass}>
+        <Button
+          onClick={onNewClass}
+          aria-label={t.dashboard.quickActions.newClass}
+          className="h-11 rounded-xl border border-white/40 bg-white/90 px-5 text-sm font-semibold text-slate-900 shadow-[0_15px_45px_-25px_rgba(255,255,255,0.9)] transition hover:bg-white"
+        >
           {t.dashboard.quickActions.newClass}
         </Button>
       </div>
-      <div className="overflow-hidden rounded-lg border">
-        <Table>
-          <TableHeader>
-            <TableRow>
+      <div className="overflow-hidden rounded-3xl border border-white/20 bg-white/5 shadow-[0_25px_80px_-40px_rgba(15,23,42,0.9)] backdrop-blur-xl">
+        <Table className="text-white/80">
+          <TableHeader className="bg-white/5 text-white/70 [&_tr]:border-white/10 [&_th]:text-white/70 [&_th]:font-semibold">
+            <TableRow className="border-white/10">
               <TableHead>{t.dashboard.classes.columns.title}</TableHead>
               <TableHead>{t.dashboard.classes.columns.stage}</TableHead>
               <TableHead>{t.dashboard.classes.columns.subject}</TableHead>
@@ -48,43 +68,55 @@ export function ClassesTable({ classes, loading, onNewClass, onViewClass, onEdit
               <TableHead className="text-right">{t.dashboard.classes.columns.actions}</TableHead>
             </TableRow>
           </TableHeader>
-          <TableBody>
+          <TableBody className="[&_tr]:border-white/10">
             {loading ? (
               <TableRow>
-                <TableCell colSpan={5} className="py-10 text-center text-muted-foreground">
+                <TableCell colSpan={5} className="py-10 text-center text-white/70">
                   {t.dashboard.common.loading}
                 </TableCell>
               </TableRow>
             ) : classes.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={5} className="py-10 text-center text-muted-foreground">
+                <TableCell colSpan={5} className="py-10 text-center text-white/70">
                   {t.dashboard.classes.empty}
                 </TableCell>
               </TableRow>
             ) : (
               classes.map(item => (
-                <TableRow key={item.id}>
-                  <TableCell>
+                <TableRow key={item.id} className="border-white/10 transition hover:bg-white/15">
+                  <TableCell className="align-top">
                     <div className="flex items-center gap-2">
-                      <div className="font-medium">{item.title}</div>
+                      <div className="font-semibold text-white">{item.title}</div>
                       {item.isExample ? (
-                        <Badge variant="outline" className="text-xs font-normal uppercase tracking-wide">
+                        <Badge variant="outline" className="border-white/40 bg-white/10 text-xs font-normal uppercase tracking-wide text-white/80">
                           {t.dashboard.common.exampleTag}
                         </Badge>
                       ) : null}
                     </div>
                     {item.isExample ? (
-                      <p className="mt-1 text-xs text-muted-foreground">{t.dashboard.common.exampleDescription}</p>
+                      <p className="mt-1 text-xs text-white/60">{t.dashboard.common.exampleDescription}</p>
                     ) : null}
                   </TableCell>
-                  <TableCell>
-                    {item.stage ? <Badge variant="secondary">{item.stage}</Badge> : "—"}
+                  <TableCell className="align-top">
+                    {item.stage ? (
+                      <Badge variant="secondary" className="border-white/30 bg-white/15 text-white">
+                        {item.stage}
+                      </Badge>
+                    ) : (
+                      <span className="text-white/50">—</span>
+                    )}
                   </TableCell>
-                  <TableCell>{item.subject || "—"}</TableCell>
-                  <TableCell>
-                    <div className="flex flex-col text-sm text-muted-foreground">
-                      <span>{t.dashboard.classes.labels.start}: {formatDate(item.start_date)}</span>
-                      <span>{t.dashboard.classes.labels.end}: {formatDate(item.end_date)}</span>
+                  <TableCell className="align-top text-white">
+                    {item.subject || "—"}
+                  </TableCell>
+                  <TableCell className="align-top">
+                    <div className="flex flex-col text-sm text-white/70">
+                      <span>
+                        {t.dashboard.classes.labels.start}: {formatDate(item.start_date)}
+                      </span>
+                      <span>
+                        {t.dashboard.classes.labels.end}: {formatDate(item.end_date)}
+                      </span>
                     </div>
                   </TableCell>
                   <TableCell className="text-right">
@@ -95,6 +127,7 @@ export function ClassesTable({ classes, loading, onNewClass, onViewClass, onEdit
                         disabled={item.isExample}
                         onClick={() => onViewClass?.(item.id)}
                         aria-label={t.dashboard.classes.actions.view}
+                        className="text-white transition hover:bg-white/15 disabled:text-white/40"
                       >
                         {t.dashboard.classes.actions.view}
                       </Button>
@@ -104,12 +137,13 @@ export function ClassesTable({ classes, loading, onNewClass, onViewClass, onEdit
                         disabled={item.isExample}
                         onClick={() => onEditClass?.(item.id)}
                         aria-label={t.dashboard.classes.actions.edit}
+                        className="text-white transition hover:bg-white/15 disabled:text-white/40"
                       >
                         {t.dashboard.classes.actions.edit}
                       </Button>
                     </div>
                     {item.isExample ? (
-                      <p className="mt-2 text-xs text-muted-foreground">{t.dashboard.common.exampleActionsDisabled}</p>
+                      <p className="mt-2 text-xs text-white/60">{t.dashboard.common.exampleActionsDisabled}</p>
                     ) : null}
                   </TableCell>
                 </TableRow>

--- a/src/components/dashboard/CurriculaList.tsx
+++ b/src/components/dashboard/CurriculaList.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { cn } from "@/lib/utils";
 import type { Class, Curriculum } from "../../../types/supabase-tables";
 
 type CurriculumSummary = Curriculum & {
@@ -21,6 +22,7 @@ interface CurriculaListProps {
   onNewCurriculum: () => void;
   onOpenCurriculum: (curriculumId: string) => void;
   onExportCurriculum: (curriculumId: string) => void;
+  className?: string;
 }
 
 const formatYear = (value?: string | null) => (value ? value : "—");
@@ -34,23 +36,41 @@ const formatCreatedAt = (value?: string) => {
   }
 };
 
-export function CurriculaList({ curricula, loading, onNewCurriculum, onOpenCurriculum, onExportCurriculum }: CurriculaListProps) {
+export function CurriculaList({
+  curricula,
+  loading,
+  onNewCurriculum,
+  onOpenCurriculum,
+  onExportCurriculum,
+  className,
+}: CurriculaListProps) {
   const { t } = useLanguage();
 
   return (
-    <section className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">{t.dashboard.curriculum.title}</h2>
-          <p className="text-sm text-muted-foreground">{t.dashboard.curriculum.subtitle}</p>
+    <section
+      className={cn(
+        "space-y-6 rounded-[2rem] border border-white/15 bg-white/10 p-6 text-white shadow-[0_35px_120px_-50px_rgba(15,23,42,0.95)] backdrop-blur-2xl md:p-8",
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold leading-tight text-white md:text-3xl">
+            {t.dashboard.curriculum.title}
+          </h2>
+          <p className="text-sm text-white/70">{t.dashboard.curriculum.subtitle}</p>
         </div>
-        <Button onClick={onNewCurriculum} aria-label={t.dashboard.quickActions.newCurriculum}>
+        <Button
+          onClick={onNewCurriculum}
+          aria-label={t.dashboard.quickActions.newCurriculum}
+          className="h-11 rounded-xl border border-white/40 bg-white/90 px-5 text-sm font-semibold text-slate-900 shadow-[0_15px_45px_-25px_rgba(255,255,255,0.9)] transition hover:bg-white"
+        >
           {t.dashboard.quickActions.newCurriculum}
         </Button>
       </div>
 
       {loading ? (
-        <div className="rounded-lg border bg-muted/20 p-8 text-center text-sm text-muted-foreground">
+        <div className="rounded-2xl border border-white/20 bg-white/5 p-8 text-center text-sm text-white/70 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.85)]">
           {t.dashboard.common.loading}
         </div>
       ) : (
@@ -58,7 +78,7 @@ export function CurriculaList({ curricula, loading, onNewCurriculum, onOpenCurri
           <button
             type="button"
             onClick={onNewCurriculum}
-            className="group flex h-full min-h-[220px] flex-col items-center justify-center rounded-3xl border border-dashed border-white/30 bg-white/5 p-6 text-white/80 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.85)] transition hover:border-white/60 hover:bg-white/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-slate-900 md:min-h-[240px]"
+            className="group flex h-full min-h-[220px] flex-col items-center justify-center rounded-3xl border border-dashed border-white/30 bg-white/5 p-6 text-white/80 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.85)] transition hover:border-white/60 hover:bg-white/15 hover:text-white focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-slate-900 md:min-h-[240px]"
             aria-label={t.dashboard.quickActions.newCurriculum}
           >
             <span className="flex h-16 w-16 items-center justify-center rounded-full border border-white/40 bg-white/10 text-white shadow-inner transition group-hover:border-white/70 group-hover:bg-white/20">
@@ -72,52 +92,58 @@ export function CurriculaList({ curricula, loading, onNewCurriculum, onOpenCurri
             </span>
           </button>
           {curricula.map(item => (
-            <Card key={item.id} className="flex flex-col justify-between">
-              <CardHeader className="space-y-2 p-4 pb-2">
-                <div className="flex items-start justify-between gap-2">
-                  <CardTitle className="text-lg font-semibold leading-tight">
+            <Card
+              key={item.id}
+              className="flex flex-col justify-between rounded-3xl border border-white/20 bg-white/10 text-white/80 shadow-[0_25px_80px_-40px_rgba(15,23,42,0.9)] transition hover:border-white/40 hover:bg-white/15"
+            >
+              <CardHeader className="space-y-3 p-6 pb-4">
+                <div className="flex items-start justify-between gap-3">
+                  <CardTitle className="text-xl font-semibold leading-tight text-white">
                     {item.title}
                   </CardTitle>
                   {item.isExample ? (
-                    <Badge variant="outline" className="text-xs font-normal uppercase tracking-wide">
+                    <Badge variant="outline" className="border-white/40 bg-white/10 text-xs font-normal uppercase tracking-wide text-white/80">
                       {t.dashboard.common.exampleTag}
                     </Badge>
                   ) : null}
                 </div>
-                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                <div className="flex flex-wrap items-center gap-2 text-xs text-white/70">
                   {item.class ? (
-                    <Badge variant="secondary">{item.class.title}</Badge>
+                    <Badge variant="secondary" className="border-white/30 bg-white/15 text-white">
+                      {item.class.title}
+                    </Badge>
                   ) : null}
                   <span>{item.subject}</span>
                   {item.class?.stage ? <span>· {item.class.stage}</span> : null}
                 </div>
                 {item.isExample ? (
-                  <p className="text-xs text-muted-foreground">{t.dashboard.common.exampleDescription}</p>
+                  <p className="text-xs text-white/60">{t.dashboard.common.exampleDescription}</p>
                 ) : null}
               </CardHeader>
-              <CardContent className="flex flex-col gap-2 p-4 pt-1">
-                <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+              <CardContent className="flex flex-col gap-3 p-6 pt-0 text-sm text-white/70">
+                <div className="flex items-center justify-between font-medium">
                   <span>{t.dashboard.curriculum.labels.academicYear}</span>
-                  <span>{formatYear(item.academic_year)}</span>
+                  <span className="text-white">{formatYear(item.academic_year)}</span>
                 </div>
-                <Separator />
-                <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+                <Separator className="border-white/10" />
+                <div className="flex items-center justify-between font-medium">
                   <span>{t.dashboard.curriculum.labels.itemsCount}</span>
-                  <span>{item.items_count}</span>
+                  <span className="text-white">{item.items_count}</span>
                 </div>
                 {item.created_at ? (
-                  <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+                  <div className="flex items-center justify-between font-medium">
                     <span>{t.dashboard.curriculum.labels.createdOn}</span>
-                    <span>{formatCreatedAt(item.created_at)}</span>
+                    <span className="text-white/80">{formatCreatedAt(item.created_at)}</span>
                   </div>
                 ) : null}
               </CardContent>
-              <CardFooter className="flex items-center justify-between gap-2 p-4 pt-1">
+              <CardFooter className="flex items-center justify-between gap-2 p-6 pt-0">
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => onOpenCurriculum(item.id)}
                   aria-label={t.dashboard.curriculum.actions.open}
+                  className="text-white transition hover:bg-white/15"
                 >
                   {t.dashboard.curriculum.actions.open}
                 </Button>
@@ -127,6 +153,7 @@ export function CurriculaList({ curricula, loading, onNewCurriculum, onOpenCurri
                   disabled={item.isExample}
                   onClick={() => onExportCurriculum(item.id)}
                   aria-label={t.dashboard.curriculum.actions.exportCsv}
+                  className="border-white/40 text-white transition hover:bg-white/15 disabled:border-white/20 disabled:text-white/50"
                 >
                   {t.dashboard.curriculum.actions.exportCsv}
                 </Button>
@@ -136,8 +163,8 @@ export function CurriculaList({ curricula, loading, onNewCurriculum, onOpenCurri
         </div>
       )}
       {!loading && curricula.length === 0 ? (
-        <div className="rounded-3xl border border-white/20 bg-white/5 p-10 text-center text-white shadow-[0_20px_70px_-25px_rgba(15,23,42,0.85)]">
-          <h3 className="text-lg font-semibold">{t.dashboard.curriculum.empty.title}</h3>
+        <div className="rounded-3xl border border-white/20 bg-white/5 p-10 text-center text-white shadow-[0_25px_80px_-40px_rgba(15,23,42,0.9)]">
+          <h3 className="text-xl font-semibold">{t.dashboard.curriculum.empty.title}</h3>
           <p className="mt-2 text-sm text-white/70">{t.dashboard.curriculum.empty.description}</p>
         </div>
       ) : null}

--- a/src/components/dashboard/SkillsSection.tsx
+++ b/src/components/dashboard/SkillsSection.tsx
@@ -21,12 +21,14 @@ import {
   shouldUseStudentExamples,
 } from "@/features/students/api";
 import type { Class } from "../../../types/supabase-tables";
+import { cn } from "@/lib/utils";
 
 type SkillsSectionProps = {
   classes: Class[];
+  className?: string;
 };
 
-export function SkillsSection({ classes }: SkillsSectionProps) {
+export function SkillsSection({ classes, className }: SkillsSectionProps) {
   const { t } = useLanguage();
   const { toast } = useToast();
   const { user } = useOptionalUser();
@@ -94,21 +96,35 @@ export function SkillsSection({ classes }: SkillsSectionProps) {
   };
 
   return (
-    <Card>
-      <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <Card
+      className={cn(
+        "rounded-[2rem] border border-white/15 bg-white/10 text-white shadow-[0_35px_120px_-50px_rgba(15,23,42,0.95)] backdrop-blur-2xl",
+        className,
+      )}
+    >
+      <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-1">
-          <CardTitle>{t.dashboard.skills.title}</CardTitle>
-          <CardDescription>{t.dashboard.skills.subtitle}</CardDescription>
+          <CardTitle className="text-2xl font-semibold text-white md:text-3xl">
+            {t.dashboard.skills.title}
+          </CardTitle>
+          <CardDescription className="text-white/70">
+            {t.dashboard.skills.subtitle}
+          </CardDescription>
         </div>
-        <Button onClick={() => setDialogOpen(true)}>{t.dashboard.skills.actions.add}</Button>
+        <Button
+          onClick={() => setDialogOpen(true)}
+          className="h-11 rounded-xl border border-white/40 bg-white/90 px-5 text-sm font-semibold text-slate-900 shadow-[0_15px_45px_-25px_rgba(255,255,255,0.9)] transition hover:bg-white"
+        >
+          {t.dashboard.skills.actions.add}
+        </Button>
       </CardHeader>
-      <CardContent className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <CardContent className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
         {skillsQuery.isLoading ? (
-          <div className="col-span-full rounded-lg border border-dashed bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+          <div className="col-span-full rounded-2xl border border-dashed border-white/30 bg-white/5 p-8 text-center text-sm text-white/70">
             {t.dashboard.common.loading}
           </div>
         ) : skills.length === 0 ? (
-          <div className="col-span-full rounded-lg border border-dashed bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+          <div className="col-span-full rounded-2xl border border-dashed border-white/30 bg-white/5 p-8 text-center text-sm text-white/70">
             {t.dashboard.skills.empty}
           </div>
         ) : (
@@ -116,22 +132,27 @@ export function SkillsSection({ classes }: SkillsSectionProps) {
             const skillClass = classOptions.find(option => option.id === skill.classId);
             const studentCount = students.filter(student => student.classId === skill.classId).length;
             return (
-              <div key={skill.id} className="rounded-xl border bg-card p-5 shadow-sm">
+              <div
+                key={skill.id}
+                className="rounded-2xl border border-white/15 bg-white/10 p-6 text-white/80 shadow-[0_25px_80px_-40px_rgba(15,23,42,0.9)] backdrop-blur-xl"
+              >
                 <div className="flex items-start justify-between gap-3">
                   <div>
-                    <h3 className="text-base font-semibold leading-tight">{skill.title}</h3>
+                    <h3 className="text-lg font-semibold leading-tight text-white">{skill.title}</h3>
                     {skill.description ? (
-                      <p className="mt-1 text-sm text-muted-foreground">{skill.description}</p>
+                      <p className="mt-2 text-sm text-white/70">{skill.description}</p>
                     ) : null}
                   </div>
                   {skill.isExample ? (
-                    <Badge variant="outline" className="text-xs uppercase text-muted-foreground">
+                    <Badge variant="outline" className="border-white/40 bg-white/10 text-xs uppercase text-white/80">
                       {t.dashboard.common.exampleTag}
                     </Badge>
                   ) : null}
                 </div>
-                <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                  <Badge variant="secondary">{skillClass?.title ?? t.dashboard.skills.labels.unknownClass}</Badge>
+                <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-white/70">
+                  <Badge variant="secondary" className="border-white/30 bg-white/15 text-white">
+                    {skillClass?.title ?? t.dashboard.skills.labels.unknownClass}
+                  </Badge>
                   <span>
                     {t.dashboard.skills.labels.studentCount
                       .replace("{count}", String(studentCount))
@@ -145,18 +166,18 @@ export function SkillsSection({ classes }: SkillsSectionProps) {
       </CardContent>
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent className="sm:max-w-lg">
+        <DialogContent className="sm:max-w-lg border border-white/20 bg-white/10 text-white shadow-[0_35px_120px_-50px_rgba(15,23,42,0.95)] backdrop-blur-2xl">
           <DialogHeader>
-            <DialogTitle>{t.dashboard.skills.dialog.title}</DialogTitle>
+            <DialogTitle className="text-2xl font-semibold text-white">{t.dashboard.skills.dialog.title}</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
             <div className="grid gap-2">
-              <Label>{t.dashboard.skills.dialog.classLabel}</Label>
+              <Label className="text-sm font-medium text-white/80">{t.dashboard.skills.dialog.classLabel}</Label>
               <Select value={classId} onValueChange={setClassId}>
-                <SelectTrigger>
+                <SelectTrigger className="rounded-xl border border-white/30 bg-white/5 text-white focus:ring-white/40">
                   <SelectValue placeholder={t.dashboard.skills.dialog.classPlaceholder} />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent className="border-white/20 bg-slate-900/90 text-white backdrop-blur-xl">
                   {classOptions.length === 0 ? (
                     <SelectItem value="none" disabled>
                       {t.dashboard.skills.dialog.noClasses}
@@ -171,31 +192,45 @@ export function SkillsSection({ classes }: SkillsSectionProps) {
               </Select>
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="skill-title">{t.dashboard.skills.dialog.nameLabel}</Label>
+              <Label htmlFor="skill-title" className="text-sm font-medium text-white/80">
+                {t.dashboard.skills.dialog.nameLabel}
+              </Label>
               <Input
                 id="skill-title"
                 value={title}
                 onChange={event => setTitle(event.target.value)}
                 placeholder={t.dashboard.skills.dialog.namePlaceholder}
+                className="rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-white/60 focus:border-white/60 focus:ring-white/40"
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="skill-description">{t.dashboard.skills.dialog.descriptionLabel}</Label>
+              <Label htmlFor="skill-description" className="text-sm font-medium text-white/80">
+                {t.dashboard.skills.dialog.descriptionLabel}
+              </Label>
               <Textarea
                 id="skill-description"
                 rows={4}
                 value={description}
                 onChange={event => setDescription(event.target.value)}
                 placeholder={t.dashboard.skills.dialog.descriptionPlaceholder}
+                className="rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-white/60 focus:border-white/60 focus:ring-white/40"
               />
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+              className="border-white/40 text-white hover:bg-white/15"
+            >
               {t.common.cancel}
             </Button>
-            <Button onClick={handleSubmit} disabled={!classId || !title.trim() || createSkillMutation.isPending}>
-              {t.dashboard.skills.dialog.submit}
+            <Button
+              onClick={handleSubmit}
+              disabled={!classId || !title.trim() || createSkillMutation.isPending}
+              className="border border-white/40 bg-white/90 text-slate-900 hover:bg-white disabled:border-white/20 disabled:text-slate-700"
+            >
+              {createSkillMutation.isPending ? t.common.loading : t.dashboard.skills.dialog.submit}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/dashboard/StudentsSection.tsx
+++ b/src/components/dashboard/StudentsSection.tsx
@@ -19,6 +19,7 @@ import {
   shouldUseStudentExamples,
 } from "@/features/students/api";
 import type { Class } from "../../../types/supabase-tables";
+import { cn } from "@/lib/utils";
 
 const splitNames = (input: string) =>
   input
@@ -29,9 +30,10 @@ const splitNames = (input: string) =>
 type StudentsSectionProps = {
   classes: Class[];
   onOpenStudent: (studentId: string) => void;
+  className?: string;
 };
 
-export function StudentsSection({ classes, onOpenStudent }: StudentsSectionProps) {
+export function StudentsSection({ classes, onOpenStudent, className }: StudentsSectionProps) {
   const { t } = useLanguage();
   const { toast } = useToast();
   const { user } = useOptionalUser();
@@ -109,18 +111,27 @@ export function StudentsSection({ classes, onOpenStudent }: StudentsSectionProps
   };
 
   return (
-    <Card>
-      <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <Card
+      className={cn(
+        "rounded-[2rem] border border-white/15 bg-white/10 text-white shadow-[0_35px_120px_-50px_rgba(15,23,42,0.95)] backdrop-blur-2xl",
+        className,
+      )}
+    >
+      <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-1">
-          <CardTitle>{t.dashboard.students.title}</CardTitle>
-          <CardDescription>{t.dashboard.students.subtitle}</CardDescription>
+          <CardTitle className="text-2xl font-semibold text-white md:text-3xl">
+            {t.dashboard.students.title}
+          </CardTitle>
+          <CardDescription className="text-white/70">
+            {t.dashboard.students.subtitle}
+          </CardDescription>
         </div>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <Select value={filterClassId} onValueChange={setFilterClassId}>
-            <SelectTrigger className="w-[220px]">
+            <SelectTrigger className="w-[220px] rounded-xl border border-white/30 bg-white/5 text-white transition focus:ring-white/40">
               <SelectValue placeholder={t.dashboard.students.filters.classPlaceholder} />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent className="border-white/20 bg-slate-900/90 text-white backdrop-blur-xl">
               <SelectItem value="all">{t.dashboard.students.filters.allClasses}</SelectItem>
               {classOptions.map(option => (
                 <SelectItem key={option.id} value={option.id}>
@@ -129,54 +140,58 @@ export function StudentsSection({ classes, onOpenStudent }: StudentsSectionProps
               ))}
             </SelectContent>
           </Select>
-          <Button onClick={() => setDialogOpen(true)} disabled={classOptions.length === 0}>
+          <Button
+            onClick={() => setDialogOpen(true)}
+            disabled={classOptions.length === 0}
+            className="h-11 rounded-xl border border-white/40 bg-white/90 px-5 text-sm font-semibold text-slate-900 shadow-[0_15px_45px_-25px_rgba(255,255,255,0.9)] transition hover:bg-white disabled:border-white/20 disabled:text-slate-700"
+          >
             {t.dashboard.students.actions.add}
           </Button>
         </div>
       </CardHeader>
       <CardContent>
         {studentsQuery.isLoading ? (
-          <div className="rounded-lg border border-dashed bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+          <div className="rounded-2xl border border-dashed border-white/30 bg-white/5 p-8 text-center text-sm text-white/70">
             {t.dashboard.common.loading}
           </div>
         ) : filteredStudents.length === 0 ? (
-          <div className="rounded-lg border border-dashed bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+          <div className="rounded-2xl border border-dashed border-white/30 bg-white/5 p-8 text-center text-sm text-white/70">
             {t.dashboard.students.empty}
           </div>
         ) : (
           <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
+            <Table className="min-w-full text-white/80">
+              <TableHeader className="bg-white/5 text-white/70 [&_tr]:border-white/10 [&_th]:text-white/70 [&_th]:font-semibold">
+                <TableRow className="border-white/10">
                   <TableHead>{t.dashboard.students.columns.student}</TableHead>
                   <TableHead>{t.dashboard.students.columns.class}</TableHead>
                   <TableHead>{t.dashboard.students.columns.skills}</TableHead>
                   <TableHead>{t.dashboard.students.columns.comments}</TableHead>
                 </TableRow>
               </TableHeader>
-              <TableBody>
+              <TableBody className="[&_tr]:border-white/10">
                 {filteredStudents.map(student => (
                   <TableRow
                     key={student.id}
-                    className="cursor-pointer"
+                    className="cursor-pointer transition hover:bg-white/15"
                     onClick={() => onOpenStudent(student.id)}
                   >
-                    <TableCell className="font-medium">
-                      <div className="flex items-center gap-2">
+                    <TableCell className="font-medium text-white">
+                      <div className="flex flex-wrap items-center gap-2">
                         <span>{student.fullName}</span>
                         {student.preferredName ? (
-                          <Badge variant="secondary" className="text-xs">
+                          <Badge variant="secondary" className="border-white/30 bg-white/15 text-xs text-white">
                             {t.dashboard.students.labels.preferred.replace("{name}", student.preferredName)}
                           </Badge>
                         ) : null}
                         {student.isExample ? (
-                          <Badge variant="outline" className="text-xs uppercase text-muted-foreground">
+                          <Badge variant="outline" className="border-white/40 bg-white/10 text-xs uppercase text-white/80">
                             {t.dashboard.common.exampleTag}
                           </Badge>
                         ) : null}
                       </div>
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="text-white/80">
                       {classOptions.find(item => item.id === student.classId)?.title ??
                         t.dashboard.students.labels.unknownClass}
                     </TableCell>
@@ -184,21 +199,21 @@ export function StudentsSection({ classes, onOpenStudent }: StudentsSectionProps
                       {student.skills.length > 0 ? (
                         <div className="flex flex-wrap gap-1">
                           {student.skills.map(skill => (
-                            <Badge key={skill.skillId} variant="secondary">
+                            <Badge key={skill.skillId} variant="secondary" className="border-white/30 bg-white/15 text-white">
                               {skill.skillName}
                             </Badge>
                           ))}
                         </div>
                       ) : (
-                        <span className="text-muted-foreground">
+                        <span className="text-white/60">
                           {t.dashboard.students.labels.noSkills}
                         </span>
                       )}
                     </TableCell>
-                    <TableCell className="max-w-[260px] text-sm text-muted-foreground">
+                    <TableCell className="max-w-[260px] text-sm text-white/70">
                       {student.academicComment || student.behaviorComment
                         ? `${student.behaviorComment ?? ""}${
-                            student.behaviorComment && student.academicComment ? " · " : ""
+                            student.behaviorComment && student.academicComment ? " • " : ""
                           }${student.academicComment ?? ""}`
                         : t.dashboard.students.labels.noComments}
                     </TableCell>
@@ -211,18 +226,18 @@ export function StudentsSection({ classes, onOpenStudent }: StudentsSectionProps
       </CardContent>
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent className="sm:max-w-lg">
+        <DialogContent className="sm:max-w-lg border border-white/20 bg-white/10 text-white shadow-[0_35px_120px_-50px_rgba(15,23,42,0.95)] backdrop-blur-2xl">
           <DialogHeader>
-            <DialogTitle>{t.dashboard.students.dialog.title}</DialogTitle>
+            <DialogTitle className="text-2xl font-semibold text-white">{t.dashboard.students.dialog.title}</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
             <div className="grid gap-2">
-              <Label>{t.dashboard.students.dialog.classLabel}</Label>
+              <Label className="text-sm font-medium text-white/80">{t.dashboard.students.dialog.classLabel}</Label>
               <Select value={selectedClassId} onValueChange={setSelectedClassId}>
-                <SelectTrigger>
+                <SelectTrigger className="rounded-xl border border-white/30 bg-white/5 text-white focus:ring-white/40">
                   <SelectValue placeholder={t.dashboard.students.dialog.classPlaceholder} />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent className="border-white/20 bg-slate-900/90 text-white backdrop-blur-xl">
                   {classOptions.length === 0 ? (
                     <SelectItem value="none" disabled>
                       {t.dashboard.students.dialog.noClasses}
@@ -237,28 +252,34 @@ export function StudentsSection({ classes, onOpenStudent }: StudentsSectionProps
               </Select>
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="student-names">{t.dashboard.students.dialog.namesLabel}</Label>
+              <Label htmlFor="student-names" className="text-sm font-medium text-white/80">
+                {t.dashboard.students.dialog.namesLabel}
+              </Label>
               <Textarea
                 id="student-names"
                 rows={6}
                 placeholder={t.dashboard.students.dialog.namesPlaceholder}
                 value={namesInput}
                 onChange={event => setNamesInput(event.target.value)}
+                className="rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-white/60 focus:border-white/60 focus:ring-white/40"
               />
-              <p className="text-xs text-muted-foreground">
-                {t.dashboard.students.dialog.helper}
-              </p>
+              <p className="text-xs text-white/60">{t.dashboard.students.dialog.helper}</p>
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+              className="border-white/40 text-white hover:bg-white/15"
+            >
               {t.common.cancel}
             </Button>
             <Button
               onClick={handleSubmit}
               disabled={!selectedClassId || !namesInput.trim() || addStudentsMutation.isPending}
+              className="border border-white/40 bg-white/90 text-slate-900 hover:bg-white disabled:border-white/20 disabled:text-slate-700"
             >
-              {t.dashboard.students.dialog.submit}
+              {addStudentsMutation.isPending ? t.common.loading : t.dashboard.students.dialog.submit}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -19,6 +19,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useToast } from "@/hooks/use-toast";
 import { useOptionalUser } from "@/hooks/useOptionalUser";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { cn } from "@/lib/utils";
 import { DashboardHeader, DashboardQuickAction } from "@/components/dashboard/DashboardHeader";
 import { ClassesTable } from "@/components/dashboard/ClassesTable";
 import { CurriculaList } from "@/components/dashboard/CurriculaList";
@@ -131,6 +132,12 @@ type DashboardTab = (typeof DASHBOARD_TABS)[number];
 
 const isDashboardTab = (value: string | null): value is DashboardTab =>
   Boolean(value && (DASHBOARD_TABS as readonly string[]).includes(value));
+
+const GLASS_PANEL_CLASS =
+  "rounded-[2rem] border border-white/15 bg-white/10 p-6 text-white shadow-[0_40px_120px_-50px_rgba(15,23,42,0.95)] backdrop-blur-2xl md:p-8";
+
+const GLASS_TAB_TRIGGER_CLASS =
+  "w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white/70 transition backdrop-blur-xl hover:border-white/40 hover:bg-white/15 hover:text-white data-[state=active]:border-white/60 data-[state=active]:bg-white/25 data-[state=active]:text-white data-[state=active]:shadow-[0_15px_45px_-25px_rgba(15,23,42,0.85)]";
 
 export default function DashboardPage() {
   const { t } = useLanguage();
@@ -659,48 +666,49 @@ export default function DashboardPage() {
           avatarUrl={avatarUrl}
           onQuickAction={handleQuickAction}
         />
-        <section className="rounded-[2.5rem] border border-white/10 bg-white/5 p-6 shadow-[0_20px_70px_-25px_rgba(15,23,42,0.85)] backdrop-blur-2xl md:p-10">
+        <section className="rounded-[2.5rem] border border-white/10 bg-white/5 p-6 shadow-[0_25px_90px_-35px_rgba(15,23,42,0.9)] backdrop-blur-2xl md:p-10">
           <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-8">
-            <TabsList className="grid w-full gap-3 border border-white/20 bg-white/10 p-2 text-white/70 shadow-[0_15px_40px_-20px_rgba(15,23,42,0.75)] sm:grid-cols-6">
+            <TabsList className="grid w-full gap-3 rounded-[1.75rem] border border-white/20 bg-white/10 p-3 text-white/70 shadow-[0_30px_100px_-45px_rgba(15,23,42,0.9)] backdrop-blur-2xl sm:grid-cols-6">
               <TabsTrigger
                 value="curriculum"
-                className="w-full rounded-xl border border-transparent bg-transparent text-sm font-semibold text-white/70 transition data-[state=active]:border-white/60 data-[state=active]:bg-white/20 data-[state=active]:text-white"
+                className={GLASS_TAB_TRIGGER_CLASS}
               >
                 {t.dashboard.tabs.curriculum}
               </TabsTrigger>
               <TabsTrigger
                 value="classes"
-                className="w-full rounded-xl border border-transparent bg-transparent text-sm font-semibold text-white/70 transition data-[state=active]:border-white/60 data-[state=active]:bg-white/20 data-[state=active]:text-white"
+                className={GLASS_TAB_TRIGGER_CLASS}
               >
                 {t.dashboard.tabs.classes}
               </TabsTrigger>
               <TabsTrigger
                 value="lessonBuilder"
-                className="w-full rounded-xl border border-transparent bg-transparent text-sm font-semibold text-white/70 transition data-[state=active]:border-white/60 data-[state=active]:bg-white/20 data-[state=active]:text-white"
+                className={GLASS_TAB_TRIGGER_CLASS}
               >
                 {t.dashboard.tabs.lessonBuilder}
               </TabsTrigger>
               <TabsTrigger
                 value="students"
-                className="w-full rounded-xl border border-transparent bg-transparent text-sm font-semibold text-white/70 transition data-[state=active]:border-white/60 data-[state=active]:bg-white/20 data-[state=active]:text-white"
+                className={GLASS_TAB_TRIGGER_CLASS}
               >
                 {t.dashboard.tabs.students}
               </TabsTrigger>
               <TabsTrigger
                 value="skills"
-                className="w-full rounded-xl border border-transparent bg-transparent text-sm font-semibold text-white/70 transition data-[state=active]:border-white/60 data-[state=active]:bg-white/20 data-[state=active]:text-white"
+                className={GLASS_TAB_TRIGGER_CLASS}
               >
                 {t.dashboard.tabs.skills}
               </TabsTrigger>
               <TabsTrigger
                 value="assessments"
-                className="w-full rounded-xl border border-transparent bg-transparent text-sm font-semibold text-white/70 transition data-[state=active]:border-white/60 data-[state=active]:bg-white/20 data-[state=active]:text-white"
+                className={GLASS_TAB_TRIGGER_CLASS}
               >
                 {t.dashboard.tabs.assessments ?? "Assessments"}
               </TabsTrigger>
             </TabsList>
             <TabsContent value="curriculum" className="space-y-6">
               <CurriculaList
+                className={cn(GLASS_PANEL_CLASS, "space-y-6")}
                 curricula={curricula}
                 loading={curriculaQuery.isLoading}
                 onNewCurriculum={() => setCurriculumDialogOpen(true)}
@@ -711,7 +719,7 @@ export default function DashboardPage() {
                 onExportCurriculum={id => toast({ description: t.dashboard.toasts.exportUnavailable })}
               />
               {selectedCurriculum ? (
-                <div className="space-y-4">
+                <div className={cn(GLASS_PANEL_CLASS, "space-y-4")}>
                   <h3 className="text-lg font-semibold">
                     {t.dashboard.curriculumView.title.replace("{title}", selectedCurriculum.title)}
                   </h3>
@@ -728,6 +736,7 @@ export default function DashboardPage() {
             </TabsContent>
             <TabsContent value="classes" className="space-y-6">
               <ClassesTable
+                className={cn(GLASS_PANEL_CLASS, "space-y-6")}
                 classes={classes}
                 loading={classesQuery.isLoading}
                 onNewClass={() => setClassDialogOpen(true)}
@@ -738,7 +747,7 @@ export default function DashboardPage() {
             <TabsContent value="lessonBuilder" className="space-y-6">
               {lessonBuilderContext ? (
                 <div className="space-y-6">
-                  <div className="rounded-3xl border border-white/15 bg-white/10 p-6 text-white shadow-[0_20px_60px_-30px_rgba(15,23,42,0.9)] backdrop-blur-xl">
+                  <div className={cn(GLASS_PANEL_CLASS, "space-y-6")}>
                     <h3 className="text-lg font-semibold">
                       {t.dashboard.lessonBuilder.contextTitle}
                     </h3>
@@ -755,17 +764,24 @@ export default function DashboardPage() {
                       ))}
                     </dl>
                   </div>
-                  <LessonBuilderPage
-                    layoutMode="embedded"
-                    initialMeta={{
-                      title: lessonBuilderContext.title,
-                      date: lessonBuilderContext.date ?? null,
-                    }}
-                    initialClassId={lessonBuilderContext.classId ?? null}
-                  />
+                  <div className={cn(GLASS_PANEL_CLASS, "overflow-hidden p-0 md:p-0")}>
+                    <LessonBuilderPage
+                      layoutMode="embedded"
+                      initialMeta={{
+                        title: lessonBuilderContext.title,
+                        date: lessonBuilderContext.date ?? null,
+                      }}
+                      initialClassId={lessonBuilderContext.classId ?? null}
+                    />
+                  </div>
                 </div>
               ) : (
-                <div className="rounded-3xl border border-dashed border-white/20 bg-white/5 p-10 text-center text-white shadow-[0_20px_60px_-30px_rgba(15,23,42,0.9)] backdrop-blur-xl">
+                <div
+                  className={cn(
+                    GLASS_PANEL_CLASS,
+                    "border-dashed border-white/25 bg-white/5 text-center shadow-[0_25px_80px_-40px_rgba(15,23,42,0.9)]",
+                  )}
+                >
                   <h3 className="text-lg font-semibold">
                     {t.dashboard.lessonBuilder.intercept.title}
                   </h3>
@@ -784,15 +800,16 @@ export default function DashboardPage() {
             </TabsContent>
             <TabsContent value="students" className="space-y-6">
               <StudentsSection
+                className={GLASS_PANEL_CLASS}
                 classes={classes}
                 onOpenStudent={studentId => navigate(`/teacher/students/${studentId}`)}
               />
             </TabsContent>
             <TabsContent value="skills" className="space-y-6">
-              <SkillsSection classes={classes} />
+              <SkillsSection className={GLASS_PANEL_CLASS} classes={classes} />
             </TabsContent>
             <TabsContent value="assessments" className="space-y-6">
-              <AssessmentsSection />
+              <AssessmentsSection className={GLASS_PANEL_CLASS} />
             </TabsContent>
           </Tabs>
         </section>


### PR DESCRIPTION
## Summary
- extract a shared glassmorphism trigger class for the teacher dashboard tabs
- add a backdrop blur to each trigger for a richer glass appearance while keeping existing states intact

## Testing
- npm run lint *(fails: existing lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e29103640883318801915aa1e4f0da