### PR TITLE
Refine teacher authentication dialog styling

### DIFF
--- a/src/components/auth/TeacherAuthDialog.tsx
+++ b/src/components/auth/TeacherAuthDialog.tsx
@@ -37,32 +37,32 @@ export const TeacherAuthDialog = ({ open, onOpenChange, onConfirm }: TeacherAuth
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         id="teacher-auth-dialog"
-        className="max-w-2xl border-none bg-transparent p-0 shadow-none"
+        className="left-1/2 top-[calc(4rem+10px)] w-full max-w-xl -translate-x-1/2 translate-y-0 border-none bg-transparent p-0 shadow-none"
       >
-        <div className="relative overflow-hidden rounded-3xl border border-white/20 bg-slate-950 text-white shadow-[0_30px_120px_-40px_rgba(15,23,42,1)]">
-          <div className="pointer-events-none absolute inset-0 opacity-70">
-            <div className="absolute -left-32 -top-32 h-80 w-80 rounded-full bg-cyan-500/40 blur-3xl" />
-            <div className="absolute -bottom-32 -right-32 h-96 w-96 rounded-full bg-purple-500/30 blur-3xl" />
+        <div className="relative overflow-hidden rounded-[26px] border border-white/30 bg-white/10 text-white shadow-[0_20px_80px_-40px_rgba(15,23,42,1)] backdrop-blur-2xl">
+          <div className="pointer-events-none absolute inset-0 opacity-80">
+            <div className="absolute -left-24 -top-32 h-72 w-72 rounded-full bg-cyan-300/30 blur-3xl" />
+            <div className="absolute -bottom-28 -right-28 h-80 w-80 rounded-full bg-purple-400/25 blur-3xl" />
           </div>
-          <div className="relative space-y-8 p-8 md:p-12">
-            <div className="flex flex-col items-center gap-3 text-center">
-              <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-sm font-medium text-white/80 backdrop-blur">
+          <div className="relative space-y-6 p-6 md:space-y-7 md:p-10">
+            <div className="flex flex-col items-center gap-2.5 text-center">
+              <div className="inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/15 px-3.5 py-1 text-xs font-semibold uppercase tracking-wide text-white/80 backdrop-blur">
                 <Sparkles className="h-4 w-4" />
                 Teacher preview access
               </div>
-              <h2 className="text-3xl font-semibold">Log in to your journey</h2>
-              <p className="max-w-xl text-balance text-sm text-white/75">
+              <h2 className="text-2xl font-semibold md:text-[26px]">Log in to your journey</h2>
+              <p className="max-w-lg text-balance text-sm text-white/75">
                 Access assignments, celebrate streaks, and follow teacher guidance the moment you sign in.
               </p>
             </div>
 
-            <div className="flex items-center gap-4 rounded-2xl border border-white/20 bg-white/5 p-4">
-              <Avatar className="h-12 w-12 border border-white/30">
-                <AvatarFallback className="bg-white/10 text-lg text-white">AJ</AvatarFallback>
+            <div className="flex items-center gap-3.5 rounded-[22px] border border-white/30 bg-white/10 p-4 backdrop-blur">
+              <Avatar className="h-10 w-10 border border-white/30">
+                <AvatarFallback className="bg-white/10 text-base font-medium text-white">AJ</AvatarFallback>
               </Avatar>
               <div className="text-left">
-                <p className="text-xs uppercase tracking-wide text-white/60">Previewing as</p>
-                <p className="text-lg font-medium text-white">Amelia Johnson</p>
+                <p className="text-[11px] uppercase tracking-[0.18em] text-white/60">Previewing as</p>
+                <p className="text-base font-medium text-white">Amelia Johnson</p>
               </div>
             </div>
 
@@ -76,8 +76,8 @@ export const TeacherAuthDialog = ({ open, onOpenChange, onConfirm }: TeacherAuth
                   type="email"
                   placeholder="you@studenthub.com"
                   className={cn(
-                    "h-12 rounded-2xl border-white/20 bg-white/10 text-base text-white placeholder:text-white/40",
-                    "focus-visible:ring-white/40"
+                    "h-11 rounded-2xl border-white/30 bg-white/10 text-sm text-white placeholder:text-white/40 backdrop-blur",
+                    "focus-visible:ring-white/50"
                   )}
                 />
               </div>
@@ -90,16 +90,16 @@ export const TeacherAuthDialog = ({ open, onOpenChange, onConfirm }: TeacherAuth
                   type="text"
                   placeholder="6-digit code"
                   className={cn(
-                    "h-12 rounded-2xl border-white/20 bg-white/10 text-base text-white placeholder:text-white/40",
-                    "focus-visible:ring-white/40"
+                    "h-11 rounded-2xl border-white/30 bg-white/10 text-sm text-white placeholder:text-white/40 backdrop-blur",
+                    "focus-visible:ring-white/50"
                   )}
                 />
               </div>
             </div>
 
             <div className="space-y-3 text-sm text-white/75">
-              <p className="font-medium text-white">What you'll unlock</p>
-              <ul className="grid gap-2 text-left sm:grid-cols-2">
+              <p className="text-sm font-semibold text-white">What you'll unlock</p>
+              <ul className="grid gap-2 text-left text-xs sm:grid-cols-2">
                 {featureItems.map((item) => (
                   <li key={item.label} className="flex items-start gap-2">
                     {item.icon}
@@ -114,12 +114,12 @@ export const TeacherAuthDialog = ({ open, onOpenChange, onConfirm }: TeacherAuth
                 type="button"
                 size="lg"
                 onClick={onConfirm}
-                className="h-12 w-full rounded-2xl bg-white/95 text-base font-semibold text-slate-900 shadow-[0_10px_40px_-20px_rgba(226,232,240,0.95)] hover:bg-white"
+                className="h-11 w-full rounded-2xl bg-white/90 text-sm font-semibold text-slate-900 shadow-[0_15px_50px_-35px_rgba(226,232,240,0.95)] transition hover:bg-white"
               >
                 <LogIn className="mr-2 h-5 w-5" />
                 Log in to my journey
               </Button>
-              <p className="text-center text-xs text-white/60">
+              <p className="text-center text-[11px] text-white/60">
                 Need help? Ask your teacher to resend the code or reset your password.
               </p>
             </div>


### PR DESCRIPTION
## Summary
- restyle the teacher authentication dialog with a lighter glassmorphism treatment and reduced spacing
- reposition the dialog just beneath the navigation bar for improved context when opened
- tweak input, button, and typography scales to better suit the compact layout

## Testing
- npm run lint *(fails: existing lint errors in src/features/students/api.ts and related files)*

------
https://chatgpt.com/codex/tasks/task_e_68e294cae954833187b499f6d3ca680f