### PR TITLE
Embed VR classroom blog post video

### DIFF
--- a/src/data/sampleBlogPosts.ts
+++ b/src/data/sampleBlogPosts.ts
@@ -6,12 +6,13 @@ interface TextChild {
 }
 
 interface ContentBlock {
-  type: "paragraph" | "heading" | "image";
+  type: "paragraph" | "heading" | "image" | "youtube";
   level?: number;
   children?: TextChild[];
   src?: string;
   alt?: string;
   caption?: string;
+  videoId?: string;
 }
 
 interface AuthorInfo {
@@ -131,7 +132,7 @@ export const SAMPLE_BLOG_POSTS: SampleBlogPost[] = [
           },
         ],
       },
-      {
+      { 
         type: "paragraph",
         children: [
           {
@@ -139,6 +140,10 @@ export const SAMPLE_BLOG_POSTS: SampleBlogPost[] = [
               "While half the class dives into the virtual reef, the other half completes observation sketches at an analog station. The teacher circulates between groups, using the AI-generated prompts on a tablet to ask guiding questions tailored to each student’s journal responses.",
           },
         ],
+      },
+      {
+        type: "youtube",
+        videoId: "TVLqVTtCneE",
       },
       {
         type: "heading",


### PR DESCRIPTION
## Summary
- allow sample blog post content blocks to include YouTube embeds
- add the VR field trip classroom video to the virtual reality field trip blog post

## Testing
- npm run lint *(fails: pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e2968a99548331834b9608cadfc3d3