### PR TITLE
Adjust blog highlight padding

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -702,7 +702,7 @@ const Blog = () => {
   ];
 
   const highlightCardClassName =
-    "flex h-full flex-col rounded-2xl border border-white/15 bg-white/10 p-4 shadow-[0_10px_40px_-20px_rgba(15,23,42,0.7)] backdrop-blur-xl";
+    "flex h-full flex-col rounded-2xl border border-white/15 bg-white/10 p-[13px] shadow-[0_10px_40px_-20px_rgba(15,23,42,0.7)] backdrop-blur-xl";
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-black text-white">


### PR DESCRIPTION
## Summary
- update the blog page highlight cards to use 13px padding so their content sits away from the background edges

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e299bc07508331bb102758f65c1d3e