### PR TITLE
Retire legacy routes

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -4,23 +4,15 @@ import Index from '@/pages/Index';
 import About from '@/pages/About';
 import Services from '@/pages/Services';
 import Blog from '@/pages/Blog';
-import BlogPost from '@/pages/BlogPost';
-import BlogBuilderPage from '@/pages/BlogBuilderPage';
-import Resources from '@/pages/resources';
 import Events from '@/pages/Events';
-import EventDetail from '@/pages/EventDetail';
 import Contact from '@/pages/Contact';
 import FAQ from '@/pages/FAQ';
-import BuilderLessonPlan from '@/pages/BuilderLessonPlan';
-import BuilderLessonPlanDetail from '@/pages/BuilderLessonPlanDetail';
 import Auth from '@/pages/Auth';
 import Profile from '@/pages/Profile';
-import ClassDashboard from '@/pages/account/ClassDashboard';
 import AccountResources from '@/pages/AccountResources';
 import AccountResourceNew from '@/pages/AccountResourceNew';
 import AccountResourceEdit from '@/pages/AccountResourceEdit';
 import LessonBuilderPage from '@/pages/lesson-builder/LessonBuilderPage';
-import LessonBuilderWorkspace from '@/pages/lesson-builder/LessonBuilderWorkspace';
 import NotFound from '@/pages/NotFound';
 import Sitemap from '@/pages/Sitemap';
 import Navigation from '@/components/Navigation';
@@ -46,8 +38,8 @@ const RouteWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => 
 const LegacyBuilderRedirect: React.FC = () => {
   const params = useParams<{ id?: string }>();
   const destination = params.id
-    ? `/builder/lesson-plans/${params.id}`
-    : `/builder/lesson-plans`;
+    ? `/lesson-builder?id=${encodeURIComponent(params.id)}`
+    : `/lesson-builder`;
 
   return <Navigate to={destination} replace />;
 };
@@ -72,7 +64,9 @@ const LegacyAccountRedirect: React.FC = () => {
 
 const LegacyClassDashboardRedirect: React.FC = () => {
   const params = useParams<{ id?: string }>();
-  const destination = params.id ? `/teacher/classes/${params.id}` : `/teacher?tab=classes`;
+  const destination = params.id
+    ? `/teacher?tab=classes&classId=${encodeURIComponent(params.id)}`
+    : `/teacher?tab=classes`;
   return <Navigate to={destination} replace />;
 };
 
@@ -93,25 +87,25 @@ export const LocalizedRoutes = () => {
       <Route path="/about" element={<RouteWrapper><About /></RouteWrapper>} />
       <Route path="/services" element={<RouteWrapper><Services /></RouteWrapper>} />
       <Route path="/blog" element={<RouteWrapper><Blog /></RouteWrapper>} />
-      <Route path="/blog/new" element={<RouteWrapper><BlogBuilderPage /></RouteWrapper>} />
-      <Route path="/blog/:slug" element={<RouteWrapper><BlogPost /></RouteWrapper>} />
-      <Route path="/builder/lesson-plans" element={<RouteWrapper><BuilderLessonPlan /></RouteWrapper>} />
-      <Route path="/builder/lesson-plans/:id" element={<RouteWrapper><BuilderLessonPlanDetail /></RouteWrapper>} />
+      <Route path="/blog/new" element={<Navigate to="/" replace />} />
+      <Route path="/blog/:slug" element={<Navigate to="/blog" replace />} />
+      <Route path="/builder/lesson-plans" element={<Navigate to="/lesson-builder" replace />} />
+      <Route path="/builder/lesson-plans/:id" element={<LegacyBuilderRedirect />} />
       <Route path="/curriculum" element={<Navigate to="/teacher?tab=curriculum" replace />} />
       <Route path="/lesson-plans/builder" element={<LegacyBuilderRedirect />} />
       <Route path="/lesson-plans/builder/:id" element={<LegacyBuilderRedirect />} />
       <Route path="/lesson-builder" element={<RouteWrapper><LessonBuilderPage /></RouteWrapper>} />
-      <Route path="/lesson-builder/:id" element={<RouteWrapper><LessonBuilderWorkspace /></RouteWrapper>} />
-      <Route path="/resources" element={<RouteWrapper><Resources /></RouteWrapper>} />
+      <Route path="/lesson-builder/:id" element={<LegacyBuilderRedirect />} />
+      <Route path="/resources" element={<Navigate to="/" replace />} />
       <Route path="/events" element={<RouteWrapper><Events /></RouteWrapper>} />
-      <Route path="/events/:slug" element={<RouteWrapper><EventDetail /></RouteWrapper>} />
+      <Route path="/events/:slug" element={<Navigate to="/events" replace />} />
       <Route path="/contact" element={<RouteWrapper><Contact /></RouteWrapper>} />
       <Route path="/faq" element={<RouteWrapper><FAQ /></RouteWrapper>} />
       <Route path="/auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
       <Route path="/account" element={<LegacyAccountRedirect />} />
       <Route path="/teacher" element={<RouteWrapper><DashboardPage /></RouteWrapper>} />
       <Route path="/teacher/curriculum/:id" element={<RouteWrapper><TeacherCurriculumDetailPage /></RouteWrapper>} />
-      <Route path="/teacher/classes/:id" element={<RouteWrapper><ClassDashboard /></RouteWrapper>} />
+      <Route path="/teacher/classes/:id" element={<LegacyClassDashboardRedirect />} />
       <Route path="/dashboard" element={<Navigate to="/teacher" replace />} />
       <Route path="/student" element={<RouteWrapper><StudentPage /></RouteWrapper>} />
       <Route path="/teacher/students/:id" element={<RouteWrapper><StudentDashboardPage /></RouteWrapper>} />

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import {
   Search,
   Tag,
@@ -627,23 +627,29 @@ const Blog = () => {
       return null;
     }
 
-    const items = filteredPosts.map((post, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      item: {
-        "@type": "BlogPosting",
-        headline: post.title,
-        url: `https://schooltechub.com${getLocalizedPath(`/blog/${post.slug}`, language)}`,
-        datePublished: post.published_at ?? post.created_at ?? undefined,
-        dateModified: post.updated_at ?? undefined,
-        description: post.excerpt ?? undefined,
-        image: post.featured_image ?? undefined,
-        author: {
-          "@type": "Person",
-          name: getAuthorName(post),
+    const baseBlogUrl = `https://schooltechub.com${getLocalizedPath("/blog", language)}`;
+
+    const items = filteredPosts.map((post, index) => {
+      const anchorId = post.slug ? `post-${post.slug}` : `post-${post.id}`;
+
+      return {
+        "@type": "ListItem",
+        position: index + 1,
+        item: {
+          "@type": "BlogPosting",
+          headline: post.title,
+          url: `${baseBlogUrl}#${anchorId}`,
+          datePublished: post.published_at ?? post.created_at ?? undefined,
+          dateModified: post.updated_at ?? undefined,
+          description: post.excerpt ?? undefined,
+          image: post.featured_image ?? undefined,
+          author: {
+            "@type": "Person",
+            name: getAuthorName(post),
+          },
         },
-      },
-    }));
+      };
+    });
 
     return {
       "@context": "https://schema.org",
@@ -952,13 +958,10 @@ const Blog = () => {
                     <div className="grid gap-5 md:grid-cols-2">
                       {featuredPosts.map(post => {
                         const imageSrc = post.featured_image?.trim() ? post.featured_image : FALLBACK_BLOG_IMAGE;
+                        const anchorId = post.slug ? `post-${post.slug}` : `post-${post.id}`;
 
                         return (
-                          <Link
-                            key={post.id}
-                            to={getLocalizedPath(`/blog/${post.slug}`, language)}
-                            className="group block"
-                          >
+                          <article key={post.id} id={anchorId} className="group block">
                             <Card className="overflow-hidden border-white/20 bg-white/10 text-white shadow-[0_25px_80px_-30px_rgba(15,23,42,1)] transition-transform hover:-translate-y-1 hover:border-white/40">
                               <figure className="relative h-48 overflow-hidden">
                                 <img
@@ -977,7 +980,7 @@ const Blog = () => {
                                 ) : null}
                               </CardHeader>
                             </Card>
-                          </Link>
+                          </article>
                         );
                       })}
                     </div>
@@ -995,13 +998,10 @@ const Blog = () => {
                     <div className="grid gap-5 md:grid-cols-2">
                       {regularPosts.map(post => {
                         const imageSrc = post.featured_image?.trim() ? post.featured_image : FALLBACK_BLOG_IMAGE;
+                        const anchorId = post.slug ? `post-${post.slug}` : `post-${post.id}`;
 
                         return (
-                          <Link
-                            key={post.id}
-                            to={getLocalizedPath(`/blog/${post.slug}`, language)}
-                            className="group block h-full"
-                          >
+                          <article key={post.id} id={anchorId} className="group block h-full">
                             <Card className="flex h-full flex-col overflow-hidden border-white/15 bg-white/5 text-white shadow-[0_20px_60px_-30px_rgba(15,23,42,1)] transition-transform hover:-translate-y-1 hover:border-white/30">
                               <figure className="relative h-40 overflow-hidden">
                                 <img
@@ -1020,7 +1020,7 @@ const Blog = () => {
                                 ) : null}
                               </CardHeader>
                             </Card>
-                          </Link>
+                          </article>
                         );
                       })}
                     </div>

--- a/src/pages/BuilderLessonPlan.tsx
+++ b/src/pages/BuilderLessonPlan.tsx
@@ -15,7 +15,7 @@ const BuilderLessonPlan = () => {
   const mutation = useMutation({
     mutationFn: createLessonBuilderDraft,
     onSuccess: (plan) => {
-      const path = getLocalizedPath(`/builder/lesson-plans/${plan.id}`, language);
+      const path = getLocalizedPath(`/lesson-builder?id=${encodeURIComponent(plan.id)}`, language);
       navigate(path, { replace: true });
     },
   });

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -293,7 +293,7 @@ const CurriculumPage = () => {
         title: "Lesson plan created",
         description: "Opening the lesson builder so you can finish planning.",
       });
-      navigate(`/builder/lesson-plans/${plan.id}`);
+      navigate(`/lesson-builder?id=${encodeURIComponent(plan.id)}`);
     },
     onError: (error) => {
       const description =

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -417,7 +417,7 @@ export default function DashboardPage() {
         navigate("/forum/new");
         return;
       case "post-blog":
-        navigate("/blog/new");
+        toast({ description: t.dashboard.toasts.blogUnavailable, variant: "destructive" });
         return;
       default:
         return;
@@ -521,7 +521,7 @@ export default function DashboardPage() {
         return;
       }
 
-      navigate(`/builder/lesson-plans/${item.lesson_plan_id}`);
+      navigate(`/lesson-builder?id=${encodeURIComponent(item.lesson_plan_id)}`);
     },
     [navigate, t.dashboard.toasts.lessonPlanMissing, toast],
   );
@@ -743,8 +743,12 @@ export default function DashboardPage() {
                 classes={classes}
                 loading={classesQuery.isLoading}
                 onNewClass={() => setClassDialogOpen(true)}
-                onViewClass={classId => navigate(`/teacher/classes/${classId}`)}
-                onEditClass={classId => navigate(`/teacher/classes/${classId}`)}
+                onViewClass={classId =>
+                  navigate(`/teacher?tab=classes&classId=${encodeURIComponent(classId)}`)
+                }
+                onEditClass={classId =>
+                  navigate(`/teacher?tab=classes&classId=${encodeURIComponent(classId)}`)
+                }
               />
             </TabsContent>
             <TabsContent value="lessonBuilder" className="space-y-6">

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -43,24 +43,7 @@ const createDetailedSections = (dictionary: TranslationDictionary): DetailedSect
         { title: nav.about, url: "/about", description: sitemap.details.about },
         { title: nav.services, url: "/services", description: sitemap.details.services },
         { title: nav.blog, url: "/blog", description: sitemap.details.blog },
-        {
-          title: sitemap.linkTitles.blogPost,
-          url: "/blog/:slug",
-          description: sitemap.details.blogPost,
-          badges: ["dynamic"],
-        },
-        {
-          title: sitemap.linkTitles.resources,
-          url: "/resources",
-          description: sitemap.details.resources,
-        },
         { title: nav.events, url: "/events", description: sitemap.details.events },
-        {
-          title: sitemap.linkTitles.eventsDetail,
-          url: "/events/:slug",
-          description: sitemap.details.eventDetail,
-          badges: ["dynamic"],
-        },
         { title: nav.contact, url: "/contact", description: sitemap.details.contact },
         { title: nav.faq, url: "/faq", description: sitemap.details.faq },
         {
@@ -71,44 +54,14 @@ const createDetailedSections = (dictionary: TranslationDictionary): DetailedSect
       ],
     },
     {
-      title: sitemap.sections.contentAndPublishing,
-      description: sitemap.descriptions.contentAndPublishing,
-      links: [
-        {
-          title: sitemap.linkTitles.blogBuilder,
-          url: "/blog/new",
-          description: sitemap.details.blogBuilder,
-          badges: ["requiresAuth"],
-        },
-      ],
-    },
-    {
       title: sitemap.sections.lessonPlanning,
       description: sitemap.descriptions.lessonPlanning,
       links: [
-        {
-          title: sitemap.linkTitles.builderLessonPlans,
-          url: "/builder/lesson-plans",
-          description: sitemap.details.builderLessonPlans,
-          badges: ["requiresAuth"],
-        },
-        {
-          title: sitemap.linkTitles.builderLessonPlanDetail,
-          url: "/builder/lesson-plans/:id",
-          description: sitemap.details.builderLessonPlanDetail,
-          badges: ["requiresAuth", "dynamic"],
-        },
         {
           title: sitemap.linkTitles.lessonBuilder,
           url: "/lesson-builder",
           description: sitemap.details.lessonBuilder,
           badges: ["requiresAuth"],
-        },
-        {
-          title: sitemap.linkTitles.lessonBuilderDetail,
-          url: "/lesson-builder/:id",
-          description: sitemap.details.lessonBuilderDetail,
-          badges: ["requiresAuth", "dynamic"],
         },
       ],
     },
@@ -126,12 +79,6 @@ const createDetailedSections = (dictionary: TranslationDictionary): DetailedSect
           title: sitemap.linkTitles.teacherCurriculumDetail,
           url: "/teacher/curriculum/:id",
           description: sitemap.details.teacherCurriculumDetail,
-          badges: ["requiresAuth", "dynamic"],
-        },
-        {
-          title: sitemap.linkTitles.teacherClassDashboard,
-          url: "/teacher/classes/:id",
-          description: sitemap.details.teacherClassDashboard,
           badges: ["requiresAuth", "dynamic"],
         },
         {
@@ -314,39 +261,21 @@ const Sitemap = () => {
     }
   });
 
-  const { data: events = [] } = useQuery({
-    queryKey: ["sitemap-events"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("events")
-        .select("slug, title, updated_at, start_datetime")
-        .eq("is_published", true)
-        .order("start_datetime", { ascending: false });
-
-      if (error) throw error;
-      return data ?? [];
-    }
-  });
-
   const detailedSections = createDetailedSections(t);
   const badgeLabels = t.sitemap.badges;
 
   const dynamicSections: { title: string; links: DynamicLink[] }[] = [
     {
       title: t.sitemap.sections.blogPosts,
-      links: blogPosts.map((post) => ({
-        title: post.title || post.slug,
-        url: getLocalizedPath(`/blog/${post.slug}`, 'en'),
-        updatedAt: formatUpdatedAt(post.updated_at ?? post.published_at ?? undefined)
-      }))
-    },
-    {
-      title: t.sitemap.sections.events,
-      links: events.map((event) => ({
-        title: event.title || event.slug,
-        url: getLocalizedPath(`/events/${event.slug}`, 'en'),
-        updatedAt: formatUpdatedAt(event.updated_at ?? event.start_datetime ?? undefined)
-      }))
+      links: blogPosts.map((post) => {
+        const anchor = post.slug ? `#post-${post.slug}` : "";
+
+        return {
+          title: post.title || post.slug,
+          url: `${getLocalizedPath('/blog', 'en')}${anchor}`,
+          updatedAt: formatUpdatedAt(post.updated_at ?? post.published_at ?? undefined)
+        };
+      })
     }
   ].map((section) => ({
     ...section,

--- a/src/pages/account/ClassDashboard.tsx
+++ b/src/pages/account/ClassDashboard.tsx
@@ -195,7 +195,7 @@ export function ClassDashboard() {
                       </Link>
                     </Button>
                     <Button className="w-full" variant="outline" asChild>
-                      <Link to={getLocalizedPath("/builder/lesson-plans", language)}>
+                      <Link to={getLocalizedPath("/lesson-builder", language)}>
                         {t.account.classes.dashboard.managePlans}
                       </Link>
                     </Button>

--- a/src/pages/lesson-builder/LessonBuilderWorkspace.tsx
+++ b/src/pages/lesson-builder/LessonBuilderWorkspace.tsx
@@ -304,10 +304,12 @@ export default function LessonBuilderWorkspace() {
       stage,
       date,
       links: {
-        lesson: `/builder/lesson-plans/${planQuery.data.id}`,
-        class: planQuery.data.class?.id ? `/teacher/classes/${planQuery.data.class.id}` : undefined,
-        stage: `/builder/lesson-plans/${planQuery.data.id}`,
-        date: `/builder/lesson-plans/${planQuery.data.id}`,
+        lesson: `/lesson-builder?id=${encodeURIComponent(planQuery.data.id)}`,
+        class: planQuery.data.class?.id
+          ? `/teacher?tab=classes&classId=${encodeURIComponent(planQuery.data.class.id)}`
+          : undefined,
+        stage: `/lesson-builder?id=${encodeURIComponent(planQuery.data.id)}`,
+        date: `/lesson-builder?id=${encodeURIComponent(planQuery.data.id)}`,
       },
     } as const;
   }, [planQuery.data, t.lessonBuilder.editor.unknownClass, t.lessonBuilder.editor.loadingTitle]);

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -99,6 +99,7 @@ export const en = {
       resourceAttached: "Resource attached to the lesson plan.",
       resourceAttachError: "We couldn't attach that resource. Please try again.",
       error: "Something went wrong. Please try again.",
+      blogUnavailable: "Blog submissions are currently unavailable.",
     },
     classes: {
       title: "My Classes",


### PR DESCRIPTION
## Summary
- redirect legacy blog, resources, events, and lesson builder routes to supported destinations
- remove blog post deep-links and adjust structured data to point at on-page anchors
- refresh dashboard, lesson builder, and sitemap flows to work without deprecated pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2978793d88331bd138c68cc7f2f58