### PR TITLE
Add profile quick action to teacher dashboard

### DIFF
--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -4,7 +4,8 @@ import { useLanguage } from "@/contexts/LanguageContext";
 
 export type DashboardQuickAction =
   | "ask-question"
-  | "post-blog";
+  | "post-blog"
+  | "open-profile";
 
 export interface DashboardHeaderNameParts {
   honorific?: string | null;
@@ -65,7 +66,7 @@ export function DashboardHeader({
             </p>
           </div>
         </div>
-        <div className="grid w-full gap-3 sm:grid-cols-2 lg:w-auto">
+        <div className="grid w-full gap-3 sm:grid-cols-2 lg:grid-cols-3 lg:w-auto">
           <Button
             onClick={() => onQuickAction("ask-question")}
             variant="outline"
@@ -81,6 +82,14 @@ export function DashboardHeader({
             aria-label={t.dashboard.quickActions.postBlog}
           >
             {t.dashboard.quickActions.postBlog}
+          </Button>
+          <Button
+            onClick={() => onQuickAction("open-profile")}
+            variant="outline"
+            className="h-12 w-full justify-center rounded-2xl border-white/40 bg-white/10 text-sm font-semibold text-white/90 transition hover:border-white/60 hover:bg-white/20"
+            aria-label={t.dashboard.quickActions.profile}
+          >
+            {t.dashboard.quickActions.profile}
           </Button>
         </div>
       </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -419,6 +419,9 @@ export default function DashboardPage() {
       case "post-blog":
         toast({ description: t.dashboard.toasts.blogUnavailable, variant: "destructive" });
         return;
+      case "open-profile":
+        navigate("/my-profile");
+        return;
       default:
         return;
     }

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -61,6 +61,7 @@ export const en = {
     quickActions: {
       askQuestion: "Ask",
       postBlog: "Write",
+      profile: "My Profile",
       newLessonPlan: "New Lesson Plan",
       newLessonPlanTooltip: "Create a curriculum first to unlock lesson planning.",
       newCurriculum: "New Curriculum",


### PR DESCRIPTION
## Summary
- add a "My Profile" quick action button to the teacher dashboard header
- route the new quick action to the teacher profile settings page and localize its label

## Testing
- npm run lint (fails: existing lint violations in unrelated files)

------
https://chatgpt.com/codex/tasks/task_e_68e30abdb9148331a8ccc413e465dbe4