### PR TITLE
Add hero board stickers for ChatGPT and Wordwall

### DIFF
--- a/public/chatgpt-sticker.svg
+++ b/public/chatgpt-sticker.svg
@@ -1,0 +1,40 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  width="220"
+  height="96"
+  viewBox="0 0 220 96"
+  role="img"
+  aria-labelledby="title"
+>
+  <title id="title">ChatGPT sticker</title>
+  <defs>
+    <filter id="shadow" x="-12%" y="-25%" width="124%" height="150%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="6" stdDeviation="6" flood-color="#101020" flood-opacity="0.35" />
+    </filter>
+  </defs>
+  <g filter="url(#shadow)">
+    <path
+      d="M28 8h164c11.046 0 20 8.954 20 20v40c0 11.046-8.954 20-20 20H28c-11.046 0-20-8.954-20-20V28C8 16.954 16.954 8 28 8z"
+      fill="#fff"
+    />
+    <path
+      d="M29 9h162c11.046 0 20 8.954 20 20v38c0 11.046-8.954 20-20 20H29c-11.046 0-20-8.954-20-20V29C9 17.954 17.954 9 29 9z"
+      fill="none"
+      stroke="#d9d9e0"
+      stroke-width="2"
+    />
+    <g transform="translate(34 20) scale(0.032)">
+      <path d="M1 578.4C1 259.5 259.5 1 578.4 1h1249.1c319 0 577.5 258.5 577.5 577.4V2406H578.4C259.5 2406 1 2147.5 1 1828.6V578.4z" fill="#74aa9c"/>
+      <path id="chatgpt-arm" d="M1107.3 299.1c-197.999 0-373.9 127.3-435.2 315.3L650 743.5v427.9c0 21.4 11 40.4 29.4 51.4l344.5 198.515V833.3h.1v-27.9L1372.7 604c33.715-19.52 70.44-32.857 108.47-39.828L1447.6 450.3C1361 353.5 1237.1 298.5 1107.3 299.1zm0 117.5-.6.6c79.699 0 156.3 27.5 217.6 78.4-2.5 1.2-7.4 4.3-11 6.1L952.8 709.3c-18.4 10.4-29.4 30-29.4 51.4V1248l-155.1-89.4V755.8c-.1-187.099 151.601-338.9 339-339.2z" fill="#fff"/>
+      <use xlink:href="#chatgpt-arm" transform="rotate(60 1203 1203)"/>
+      <use xlink:href="#chatgpt-arm" transform="rotate(120 1203 1203)"/>
+      <use xlink:href="#chatgpt-arm" transform="rotate(180 1203 1203)"/>
+      <use xlink:href="#chatgpt-arm" transform="rotate(240 1203 1203)"/>
+      <use xlink:href="#chatgpt-arm" transform="rotate(300 1203 1203)"/>
+    </g>
+    <text x="108" y="58" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" font-weight="600" fill="#0f172a" letter-spacing="0.4">
+      ChatGPT
+    </text>
+  </g>
+</svg>

--- a/public/wordwall-sticker.svg
+++ b/public/wordwall-sticker.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="230" height="96" viewBox="0 0 230 96" role="img" aria-labelledby="title">
+  <title id="title">Wordwall sticker</title>
+  <defs>
+    <filter id="shadow" x="-12%" y="-25%" width="124%" height="150%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="6" stdDeviation="6" flood-color="#101020" flood-opacity="0.3" />
+    </filter>
+    <linearGradient id="blue-grid" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#36a8ff" />
+      <stop offset="1" stop-color="#1c7cd6" />
+    </linearGradient>
+  </defs>
+  <g filter="url(#shadow)">
+    <path
+      d="M30 8h170c11.046 0 20 8.954 20 20v40c0 11.046-8.954 20-20 20H30c-11.046 0-20-8.954-20-20V28C10 16.954 18.954 8 30 8z"
+      fill="#fff"
+    />
+    <path
+      d="M31 9h168c11.046 0 20 8.954 20 20v38c0 11.046-8.954 20-20 20H31c-11.046 0-20-8.954-20-20V29C11 17.954 19.954 9 31 9z"
+      fill="none"
+      stroke="#d9d9e0"
+      stroke-width="2"
+    />
+    <g transform="translate(38 20)">
+      <rect x="0" y="0" width="44" height="44" rx="10" fill="#e7f5ff" />
+      <g fill="url(#blue-grid)">
+        <rect x="6" y="6" width="13" height="13" rx="2.5" />
+        <rect x="25" y="6" width="13" height="13" rx="2.5" />
+        <rect x="6" y="25" width="13" height="13" rx="2.5" />
+        <rect x="25" y="25" width="13" height="13" rx="2.5" />
+      </g>
+      <rect x="18" y="18" width="8" height="8" rx="1.5" fill="#fff" opacity="0.8" />
+    </g>
+    <text x="110" y="58" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" font-weight="600" fill="#0f172a">
+      Wordwall
+    </text>
+  </g>
+</svg>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -328,7 +328,31 @@ const Index = () => {
                     <div className="flex flex-col items-center text-center">
                       <div className="text-sm uppercase tracking-[0.28em] text-white/60">Workflow brilliance</div>
                       <h2 className="mt-5 text-4xl font-semibold text-white md:text-5xl">
-                        Power every lesson with organised workflows and luminous insights
+                        {"Power every lesson with "}
+                        <span className="relative inline-flex flex-col items-center">
+                          <span>organised</span>
+                          <span className="pointer-events-none mt-3 inline-block w-24 max-w-[40vw] -rotate-2 sm:w-28 md:mt-4 md:w-32">
+                            <img
+                              src="/chatgpt-sticker.svg"
+                              alt="ChatGPT sticker"
+                              className="w-full drop-shadow-[0_10px_25px_rgba(15,23,42,0.35)]"
+                              loading="lazy"
+                            />
+                          </span>
+                        </span>
+                        {" workflows and "}
+                        <span className="relative inline-flex flex-col items-center">
+                          <span>luminous</span>
+                          <span className="pointer-events-none mt-3 inline-block w-24 max-w-[40vw] rotate-3 sm:w-28 md:mt-4 md:w-32">
+                            <img
+                              src="/wordwall-sticker.svg"
+                              alt="Wordwall sticker"
+                              className="w-full drop-shadow-[0_10px_25px_rgba(15,23,42,0.35)]"
+                              loading="lazy"
+                            />
+                          </span>
+                        </span>
+                        {" insights"}
                       </h2>
                       <p className="mt-6 max-w-xl text-base text-white/60 md:text-lg">
                         SchoolTech Hub helps teachers orchestrate their workflow, collaborate with colleagues, and weave technology into every learning moment. Plan lessons, track progress, and publish AI-guided reports without leaving your digital staffroom.


### PR DESCRIPTION
## Summary
- add custom ChatGPT and Wordwall sticker assets for the hero board
- position the stickers inline beneath the “organised” and “luminous” keywords in the headline so they stay inside the glass panel

## Testing
- npm run lint *(fails due to pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e30979b9748331b83890b29baed62f