### PR TITLE
Adjust teacher dashboard tab container padding

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -673,7 +673,7 @@ export default function DashboardPage() {
         />
         <section className="rounded-[2.5rem] border border-white/10 bg-white/5 p-6 shadow-[0_25px_90px_-35px_rgba(15,23,42,0.9)] backdrop-blur-2xl md:p-10">
           <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-8">
-            <TabsList className="mx-auto grid w-full gap-2 border-0 text-white/70 sm:w-auto sm:auto-cols-max sm:grid-flow-col">
+            <TabsList className="mx-auto grid w-full gap-2 border-0 px-2 text-white/70 sm:w-auto sm:auto-cols-max sm:grid-flow-col sm:px-4">
               <TabsTrigger
                 value="curriculum"
                 className={GLASS_TAB_TRIGGER_CLASS}


### PR DESCRIPTION
## Summary
- increase the horizontal padding on the teacher dashboard tab list so the blue outline fully wraps around the buttons

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173` *(fails: duplicate constant declaration in src/pages/Index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e311382f108331867183109bfd1a70