### PR TITLE
Remove homepage CTA buttons

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -473,23 +473,7 @@ const Index = () => {
                     From interactive lessons to AI readiness, SchoolTech Hub brings every initiative under one collaborative roof. Partner with us to coach staff, embed digital citizenship, and track impact across campuses.
                   </p>
                 </div>
-                <div className="relative z-10 flex w-full flex-col items-center justify-center gap-4 sm:flex-row">
-                  <Reveal direction="up">
-                    <Link to={getLocalizedPath("/contact", language)}>
-                      <Button size="lg" className="neon-pulse">
-                        Talk with our team
-                      </Button>
-                    </Link>
-                  </Reveal>
-                  <Reveal delay={120} direction="up">
-                    <Link to={getLocalizedPath("/events", language)}>
-                      <Button size="lg" variant="outline" className="border-white/30 bg-white/10 backdrop-blur">
-                        <MessageSquare className="mr-2 h-5 w-5" />
-                        Join a training session
-                      </Button>
-                    </Link>
-                  </Reveal>
-                </div>
+                <div className="relative z-10" />
               </Card>
             </Reveal>
           </div>


### PR DESCRIPTION
## Summary
- remove the "Talk with our team" and "Join a training session" buttons from the homepage hero card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e32c7b8210833188adc3893b154288