### PR TITLE
Adjust blog glass board spacing near navigation

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -702,8 +702,8 @@ const Blog = () => {
         <div className="absolute top-1/3 left-[-10rem] h-[18rem] w-[18rem] rounded-full bg-emerald-500/20 blur-3xl" />
       </div>
 
-      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 py-24 md:px-8">
-        <section className="relative mt-[10px] overflow-hidden rounded-[2.5rem] border border-white/10 bg-white/10 p-8 shadow-[0_25px_80px_-20px_rgba(15,23,42,0.65)] backdrop-blur-2xl transition-colors duration-500 md:mt-[10px] md:p-12">
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 pb-24 pt-[10px] md:px-8 md:pt-[10px]">
+        <section className="relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-white/10 p-8 shadow-[0_25px_80px_-20px_rgba(15,23,42,0.65)] backdrop-blur-2xl transition-colors duration-500 md:p-12">
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.35)_0%,_rgba(15,23,42,0)_70%)] opacity-80" />
           <div className="absolute inset-y-0 right-[-20%] hidden w-[50%] rounded-full bg-gradient-to-br from-cyan-400/30 via-transparent to-transparent blur-3xl md:block" />
 


### PR DESCRIPTION
## Summary
- reduce the blog page container top padding so the glass board starts 10px below the navigation
- remove redundant top margin from the glass board section to keep the spacing tight across breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e32f33a08c8331a47b135ec7ee3ddd