### PR TITLE
Remove footer logo image

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -55,11 +55,9 @@ const Footer = () => {
             {/* Brand */}
             <div className="space-y-4">
               <div className="flex items-center">
-                <img
-                  src="/logo.png"
-                  alt="School Tech Hub Solutions"
-                  className="h-10 w-auto"
-                />
+                <span className="text-lg font-semibold">
+                  School Tech Hub Solutions
+                </span>
               </div>
               <p className="text-sm text-muted-foreground">
                 {t.footer.tagline}


### PR DESCRIPTION
## Summary
- replace the footer logo image with text-only branding to remove the SchoolTech PNG

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e3352e0f508331bb94fc9ef9cb0f57