### PR TITLE
Improve login dialogs and gate teacher/student prototypes

### DIFF
--- a/src/components/auth/RoleAuthDialog.tsx
+++ b/src/components/auth/RoleAuthDialog.tsx
@@ -109,6 +109,14 @@ export const RoleAuthDialog = ({ open, role, onOpenChange, onSuccess }: RoleAuth
 
   const copy = roleCopy[role];
 
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const handleOverlayClick = () => {
+    handleClose();
+  };
+
   return (
     <div
       id="role-auth-dialog"
@@ -117,6 +125,14 @@ export const RoleAuthDialog = ({ open, role, onOpenChange, onSuccess }: RoleAuth
       role="dialog"
       aria-modal="true"
       aria-labelledby="role-auth-title"
+      onClick={handleOverlayClick}
+      onKeyDown={event => {
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          handleClose();
+        }
+      }}
+      tabIndex={-1}
     >
       <div
         className="relative w-full max-w-md overflow-hidden rounded-3xl border border-white/30 bg-white/10 text-white shadow-[0_18px_60px_-30px_rgba(15,23,42,1)] backdrop-blur-2xl"
@@ -124,7 +140,7 @@ export const RoleAuthDialog = ({ open, role, onOpenChange, onSuccess }: RoleAuth
       >
         <button
           type="button"
-          onClick={() => onOpenChange(false)}
+          onClick={handleClose}
           className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/30 bg-white/10 text-white/70 transition hover:text-white"
           aria-label="Close login dialog"
         >

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -158,6 +158,13 @@ export default function DashboardPage() {
   const [activeCurriculumId, setActiveCurriculumId] = useState<string | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const [hasEnteredPrototype, setHasEnteredPrototype] = useState(() => Boolean(user));
+  const prototypeLockedToast = useMemo(
+    () => ({
+      title: t.dashboard.toasts.prototypeLocked,
+      description: t.dashboard.toasts.prototypeLockedDescription,
+    }),
+    [t.dashboard.toasts.prototypeLocked, t.dashboard.toasts.prototypeLockedDescription],
+  );
   const journeyContentRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -175,8 +182,13 @@ export default function DashboardPage() {
   }, [hasEnteredPrototype, user]);
 
   const handleEnterPrototype = useCallback(() => {
+    if (!user) {
+      toast(prototypeLockedToast);
+      return;
+    }
+
     setHasEnteredPrototype(true);
-  }, []);
+  }, [prototypeLockedToast, toast, user]);
 
   const updateSearchParams = useCallback(
     (mutator: (params: URLSearchParams) => void, options: { replace?: boolean } = {}) => {

--- a/src/pages/Student.tsx
+++ b/src/pages/Student.tsx
@@ -11,6 +11,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { StudentSkillChart } from "@/components/students/StudentSkillChart";
 import { DASHBOARD_EXAMPLE_CLASS } from "@/features/dashboard/examples";
 import { DASHBOARD_EXAMPLE_SKILLS, DASHBOARD_EXAMPLE_STUDENTS } from "@/features/students/examples";
+import { useToast } from "@/hooks/use-toast";
 import { CalendarDays, CheckCircle2, Clock, LogIn, Notebook, Sparkles, TrendingUp, Trophy } from "lucide-react";
 
 const getInitials = (name: string): string => {
@@ -56,6 +57,12 @@ const overallLatestAverageDisplay = Math.round(overallLatestAverage);
 const observationCheckIns = exampleStudentSkills.reduce((max, skill) => Math.max(max, skill.scores.length), 0);
 const observationLabel = observationCheckIns > 0 ? `${observationCheckIns} check-ins` : "recent updates";
 const emptySkillChartLabel = "Skill trend data will appear once your teacher shares updates.";
+
+const STUDENT_LOCKED_TOAST = {
+  title: "Student login coming soon",
+  description:
+    "We're still building secure student authentication, so the dashboard preview stays locked for now.",
+} as const;
 
 const fallbackStudentName = "Jordan Martinez";
 const exampleStudentFullName = exampleStudent?.fullName ?? fallbackStudentName;
@@ -201,6 +208,7 @@ const timeline = [
 ];
 
 export default function StudentPage() {
+  const { toast } = useToast();
   const [hasEntered, setHasEntered] = useState(false);
   const journeyContentRef = useRef<HTMLElement | null>(null);
 
@@ -212,10 +220,21 @@ export default function StudentPage() {
     journeyContentRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, [hasEntered]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("preview") === "student") {
+      setHasEntered(true);
+    }
+  }, []);
+
   const handleEnterJourney = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
-    setHasEntered(true);
+    toast(STUDENT_LOCKED_TOAST);
   };
 
   return (

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -99,6 +99,9 @@ export const en = {
       resourceShortcutMissing: "No quick resources are available yet for this lesson.",
       resourceAttached: "Resource attached to the lesson plan.",
       resourceAttachError: "We couldn't attach that resource. Please try again.",
+      prototypeLocked: "Teacher login coming soon.",
+      prototypeLockedDescription:
+        "Secure authentication is still in progress, so this preview stays locked for now.",
       error: "Something went wrong. Please try again.",
       blogUnavailable: "Blog submissions are currently unavailable.",
     },


### PR DESCRIPTION
## Summary
- ensure the role auth dialog can be dismissed via the close button, the overlay, or Escape
- prevent the teacher prototype dashboard from opening without authentication and show a toast instead
- block the student dashboard preview behind a toast with an optional preview query unlock and add matching copy

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e334b4331483319bd91cfa576fd3cf