### PR TITLE
Enable prototype logins for teacher and student flows

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -158,12 +158,12 @@ export default function DashboardPage() {
   const [activeCurriculumId, setActiveCurriculumId] = useState<string | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const [hasEnteredPrototype, setHasEnteredPrototype] = useState(() => Boolean(user));
-  const prototypeLockedToast = useMemo(
+  const prototypeAccessToast = useMemo(
     () => ({
-      title: t.dashboard.toasts.prototypeLocked,
-      description: t.dashboard.toasts.prototypeLockedDescription,
+      title: t.dashboard.toasts.prototypeUnlocked,
+      description: t.dashboard.toasts.prototypeUnlockedDescription,
     }),
-    [t.dashboard.toasts.prototypeLocked, t.dashboard.toasts.prototypeLockedDescription],
+    [t.dashboard.toasts.prototypeUnlocked, t.dashboard.toasts.prototypeUnlockedDescription],
   );
   const journeyContentRef = useRef<HTMLDivElement | null>(null);
 
@@ -182,13 +182,13 @@ export default function DashboardPage() {
   }, [hasEnteredPrototype, user]);
 
   const handleEnterPrototype = useCallback(() => {
-    if (!user) {
-      toast(prototypeLockedToast);
+    if (hasEnteredPrototype) {
       return;
     }
 
     setHasEnteredPrototype(true);
-  }, [prototypeLockedToast, toast, user]);
+    toast(prototypeAccessToast);
+  }, [hasEnteredPrototype, prototypeAccessToast, toast]);
 
   const updateSearchParams = useCallback(
     (mutator: (params: URLSearchParams) => void, options: { replace?: boolean } = {}) => {

--- a/src/pages/Student.tsx
+++ b/src/pages/Student.tsx
@@ -58,10 +58,9 @@ const observationCheckIns = exampleStudentSkills.reduce((max, skill) => Math.max
 const observationLabel = observationCheckIns > 0 ? `${observationCheckIns} check-ins` : "recent updates";
 const emptySkillChartLabel = "Skill trend data will appear once your teacher shares updates.";
 
-const STUDENT_LOCKED_TOAST = {
-  title: "Student login coming soon",
-  description:
-    "We're still building secure student authentication, so the dashboard preview stays locked for now.",
+const STUDENT_UNLOCKED_TOAST = {
+  title: "Prototype login successful",
+  description: "Explore the student journey preview—no real credentials required.",
 } as const;
 
 const fallbackStudentName = "Jordan Martinez";
@@ -234,7 +233,12 @@ export default function StudentPage() {
   const handleEnterJourney = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
-    toast(STUDENT_LOCKED_TOAST);
+    if (hasEntered) {
+      return;
+    }
+
+    setHasEntered(true);
+    toast(STUDENT_UNLOCKED_TOAST);
   };
 
   return (

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -99,9 +99,9 @@ export const en = {
       resourceShortcutMissing: "No quick resources are available yet for this lesson.",
       resourceAttached: "Resource attached to the lesson plan.",
       resourceAttachError: "We couldn't attach that resource. Please try again.",
-      prototypeLocked: "Teacher login coming soon.",
-      prototypeLockedDescription:
-        "Secure authentication is still in progress, so this preview stays locked for now.",
+      prototypeUnlocked: "Prototype login ready.",
+      prototypeUnlockedDescription:
+        "Jump straight into the teacher workspace preview—no secure credentials required yet.",
       error: "Something went wrong. Please try again.",
       blogUnavailable: "Blog submissions are currently unavailable.",
     },


### PR DESCRIPTION
## Summary
- allow the teacher dashboard prototype login button to unlock the preview without requiring an authenticated user
- update the student journey login button to unlock the preview and show a confirmation toast
- refresh teacher toast copy to reflect the unlocked prototype experience

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e3400886cc8331a225bcecf9da2513