### PR TITLE
Center hero role buttons

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -350,11 +350,11 @@ const Index = () => {
                   <span className="bolt-fastener absolute left-8 bottom-6 z-20 md:left-12 md:bottom-8" aria-hidden />
                   <span className="bolt-fastener absolute right-8 bottom-6 z-20 md:right-12 md:bottom-8" aria-hidden />
                   <div className="relative z-10 flex flex-col items-start gap-8 text-left">
-                    <div className="flex flex-col gap-3 sm:flex-row">
+                    <div className="flex flex-col gap-3 self-center sm:flex-row sm:justify-center">
                       <Button
                         type="button"
                         variant="outline"
-                        className="border-white/40 bg-white/10 px-4 py-1 text-xs uppercase tracking-[0.28em] text-white/70 backdrop-blur"
+                        className="border-white/40 bg-white/10 px-4 py-1 text-xs uppercase tracking-[0.28em] text-white/70 backdrop-blur focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
                         onClick={() => setAuthRole("teacher")}
                       >
                         I am a teacher
@@ -362,7 +362,7 @@ const Index = () => {
                       <Button
                         type="button"
                         variant="outline"
-                        className="border-white/40 bg-white/10 px-4 py-1 text-xs uppercase tracking-[0.28em] text-white/70 backdrop-blur"
+                        className="border-white/40 bg-white/10 px-4 py-1 text-xs uppercase tracking-[0.28em] text-white/70 backdrop-blur focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
                         onClick={() => setAuthRole("student")}
                       >
                         I am a student


### PR DESCRIPTION
## Summary
- center the hero role selection buttons within the glass board layout
- remove the blue focus ring effect from the role buttons when clicked

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e340b69a548331aa3535bdb8afd99f