### PR TITLE
Remove teacher/student navigation buttons

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -51,8 +51,6 @@ const Navigation = () => {
   const navItems: NavItem[] = useMemo(() => {
     const items: NavItem[] = [
       { name: t.nav.home, path: "/" },
-      { name: t.nav.dashboard, path: "/teacher", type: "teacher-auth" },
-      { name: t.nav.student, path: "/student", type: "student-auth" },
       { name: t.nav.blog, path: "/blog" },
       { name: t.nav.events, path: "/events" },
       { name: t.nav.services, path: "/services" },
@@ -61,12 +59,10 @@ const Navigation = () => {
 
     return items;
   }, [
-    t.nav.dashboard,
     t.nav.about,
     t.nav.blog,
     t.nav.events,
     t.nav.home,
-    t.nav.student,
     t.nav.services,
   ]);
 


### PR DESCRIPTION
## Summary
- remove the teacher and student buttons from the navigation bar now that the glass board provides those entry points

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e342e8651c8331a7f4eb888d59b6f3