### PR TITLE
Run sitemap generation during build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "npm run generate:sitemap && vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,63 +7,63 @@
   <!-- Core English pages -->
   <url>
     <loc>https://schooltechhub.com/</loc>
-    <lastmod>2025-10-04</lastmod>
+    <lastmod>2025-10-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/about</loc>
-    <lastmod>2025-10-04</lastmod>
+    <lastmod>2025-10-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/services</loc>
-    <lastmod>2025-10-04</lastmod>
+    <lastmod>2025-10-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/blog</loc>
-    <lastmod>2025-10-04</lastmod>
+    <lastmod>2025-10-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/events</loc>
-    <lastmod>2025-10-04</lastmod>
+    <lastmod>2025-10-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/contact</loc>
-    <lastmod>2025-10-04</lastmod>
+    <lastmod>2025-10-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/faq</loc>
-    <lastmod>2025-10-04</lastmod>
+    <lastmod>2025-10-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/auth</loc>
-    <lastmod>2025-10-04</lastmod>
+    <lastmod>2025-10-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
 
   <url>
     <loc>https://schooltechhub.com/sitemap</loc>
-    <lastmod>2025-10-04</lastmod>
+    <lastmod>2025-10-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": "npm run build",
   "headers": [
     {
       "source": "/assets/(.*)",


### PR DESCRIPTION
## Summary
- update the build script to generate the sitemap before running Vite
- configure Netlify and Vercel deployments to invoke the new npm build command
- refresh the committed sitemap so deployments ship the latest metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e345ddd9a083319a4fa459fcc502d4