### PR TITLE
Refactor navigation into modular subcomponents

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,32 +1,14 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
-import {
-  Menu,
-  User,
-  LogOut,
-  IdCard,
-} from "lucide-react";
-import { useState, useEffect, useMemo } from "react";
-import { cn } from "@/lib/utils";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { User as SupabaseUser } from "@supabase/supabase-js";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 import RoleAuthDialog, { type AuthRole } from "@/components/auth/RoleAuthDialog";
-
-type NavItem = {
-  name: string;
-  path: string;
-  type?: "link" | "teacher-auth" | "student-auth";
-};
+import DesktopNavLinks from "@/components/navigation/DesktopNavLinks";
+import AccountMenu from "@/components/navigation/AccountMenu";
+import MobileNavSheet from "@/components/navigation/MobileNavSheet";
+import type { LocalizedNavItem, NavItem } from "@/components/navigation/types";
 
 const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -66,12 +48,31 @@ const Navigation = () => {
     t.nav.services,
   ]);
 
-  const getLocalizedNavPath = (path: string) => getLocalizedPath(path, "en");
+  const getLocalizedNavPath = useCallback(
+    (path: string) => getLocalizedPath(path, "en"),
+    []
+  );
 
-  const handleSignOut = async () => {
-    await supabase.auth.signOut();
-    navigate(getLocalizedNavPath("/"));
-  };
+  const localizedNavItems: LocalizedNavItem[] = useMemo(() => {
+    return navItems.map(item => {
+      const localizedPath = getLocalizedNavPath(item.path);
+      const [targetPath, queryString] = localizedPath.split("?");
+      const matchesPath =
+        location.pathname === targetPath ||
+        (item.path !== "/" && targetPath && location.pathname.startsWith(targetPath));
+      const targetParams = new URLSearchParams(queryString ?? "");
+      const currentParams = new URLSearchParams(location.search);
+      const matchesQuery =
+        targetParams.toString().length === 0 ||
+        Array.from(targetParams.entries()).every(([key, value]) => currentParams.get(key) === value);
+
+      return {
+        ...item,
+        localizedPath,
+        isActive: matchesPath && matchesQuery,
+      };
+    });
+  }, [getLocalizedNavPath, location.pathname, location.search, navItems]);
 
   const isAuthDialogOpen = authRole !== null;
 
@@ -82,210 +83,74 @@ const Navigation = () => {
     navigate(localizedTarget);
   };
 
+  const homePath = getLocalizedNavPath("/");
+  const authPath = getLocalizedNavPath("/auth");
+  const profilePath = getLocalizedNavPath("/my-profile");
+  const authLabel = `${t.nav.signUp} / ${t.nav.signIn}`;
+  const myProfileLabel = t.nav.my_profile ?? t.nav.dashboard;
+  const signOutLabel = t.nav.signOut;
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+    navigate(homePath);
+  };
+
+  const handleNavigateToProfile = () => {
+    navigate(profilePath);
+  };
+
   return (
     <>
       <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
-      >
-        Skip to main content
-      </a>
-      <div className="container flex h-16 items-center gap-4">
-        <Link to={getLocalizedNavPath("/")} className="flex items-center gap-2 flex-shrink-0">
-          <span className="text-xl font-bold">
-            <span className="text-red-500">School</span>Tech
-          </span>
-        </Link>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
+        >
+          Skip to main content
+        </a>
+        <div className="container flex h-16 items-center gap-4">
+          <Link to={homePath} className="flex items-center gap-2 flex-shrink-0">
+            <span className="text-xl font-bold">
+              <span className="text-red-500">School</span>Tech
+            </span>
+          </Link>
 
-        <div className="flex flex-1 items-center justify-end gap-3">
-          {/* Desktop navigation links */}
-          <div className="hidden lg:flex items-center gap-1 xl:gap-2">
-            {navItems.map(item => {
-              const localizedPath = getLocalizedNavPath(item.path);
-              const [targetPath, queryString] = localizedPath.split("?");
-              const matchesPath =
-                location.pathname === targetPath ||
-                (item.path !== "/" && targetPath && location.pathname.startsWith(targetPath));
-              const targetParams = new URLSearchParams(queryString ?? "");
-              const currentParams = new URLSearchParams(location.search);
-              const matchesQuery =
-                targetParams.toString().length === 0 ||
-                Array.from(targetParams.entries()).every(([key, value]) => currentParams.get(key) === value);
-              const isActive = matchesPath && matchesQuery;
+          <div className="flex flex-1 items-center justify-end gap-3">
+            <DesktopNavLinks
+              items={localizedNavItems}
+              onAuthRoleSelect={role => setAuthRole(role)}
+              isAuthDialogOpen={isAuthDialogOpen}
+            />
 
-              if (item.type === "teacher-auth" || item.type === "student-auth") {
-                return (
-                  <button
-                    key={item.path}
-                    type="button"
-                    onClick={() => setAuthRole(item.type === "student-auth" ? "student" : "teacher")}
-                    aria-current={isActive ? "page" : undefined}
-                    aria-haspopup="dialog"
-                    aria-expanded={isAuthDialogOpen}
-                    aria-controls="role-auth-dialog"
-                    className={cn(
-                      "rounded-full px-4 py-2 text-sm font-semibold transition-all whitespace-nowrap",
-                      "border border-transparent hover:border-white/40 hover:bg-white/20 hover:text-foreground hover:backdrop-blur-sm",
-                      "text-muted-foreground"
-                    )}
-                  >
-                    {item.name}
-                  </button>
-                );
-              }
+            <div className="hidden items-center gap-3 md:flex">
+              <AccountMenu
+                user={user}
+                authPath={authPath}
+                authLabel={authLabel}
+                myProfileLabel={myProfileLabel}
+                signOutLabel={signOutLabel}
+                onNavigateToProfile={handleNavigateToProfile}
+                onSignOut={handleSignOut}
+              />
+            </div>
 
-              return (
-                <Link
-                  key={item.path}
-                  to={localizedPath}
-                  aria-current={isActive ? "page" : undefined}
-                  className={cn(
-                    "rounded-full px-4 py-2 text-sm font-semibold transition-all whitespace-nowrap",
-                    "border border-transparent hover:border-white/40 hover:bg-white/20 hover:text-foreground hover:backdrop-blur-sm",
-                    "text-muted-foreground"
-                  )}
-                >
-                  {item.name}
-                </Link>
-              );
-            })}
+            <MobileNavSheet
+              items={localizedNavItems}
+              isOpen={isOpen}
+              onOpenChange={setIsOpen}
+              onAuthRoleSelect={role => setAuthRole(role)}
+              isAuthDialogOpen={isAuthDialogOpen}
+              user={user}
+              authPath={authPath}
+              profilePath={profilePath}
+              authLabel={authLabel}
+              myProfileLabel={myProfileLabel}
+              signOutLabel={signOutLabel}
+              onSignOut={handleSignOut}
+            />
           </div>
-
-          {/* Desktop actions */}
-          <div className="hidden items-center gap-3 md:flex">
-            {user ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    className="flex items-center gap-2"
-                  >
-                    <User className="h-5 w-5" />
-                    <span className="text-sm font-medium">My account</span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-56">
-                  <DropdownMenuItem className="text-sm text-muted-foreground">
-                    {user.email}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() => navigate(getLocalizedNavPath("/my-profile"))}
-                  >
-                    <IdCard className="mr-2 h-4 w-4" />
-                    {t.nav.my_profile}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={handleSignOut}>
-                    <LogOut className="mr-2 h-4 w-4" />
-                    {t.nav.signOut}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : (
-              <Button asChild className="whitespace-nowrap">
-                <Link to={getLocalizedNavPath("/auth")}>{t.nav.signUp} / {t.nav.signIn}</Link>
-              </Button>
-            )}
-          </div>
-
-          {/* Mobile navigation */}
-          <Sheet open={isOpen} onOpenChange={setIsOpen}>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon" className="lg:hidden">
-                <Menu className="h-6 w-6" />
-                <span className="sr-only">Toggle menu</span>
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="right" className="w-[300px] sm:w-[380px]">
-              <div className="mt-8 flex flex-col space-y-4">
-                {navItems.map(item => {
-                  const localizedPath = getLocalizedNavPath(item.path);
-                  const [targetPath, queryString] = localizedPath.split("?");
-                  const matchesPath =
-                    location.pathname === targetPath ||
-                    (item.path !== "/" && targetPath && location.pathname.startsWith(targetPath));
-                  const targetParams = new URLSearchParams(queryString ?? "");
-                  const currentParams = new URLSearchParams(location.search);
-                  const matchesQuery =
-                    targetParams.toString().length === 0 ||
-                    Array.from(targetParams.entries()).every(([key, value]) => currentParams.get(key) === value);
-                  const isActive = matchesPath && matchesQuery;
-
-              if (item.type === "teacher-auth" || item.type === "student-auth") {
-                return (
-                  <button
-                    key={item.path}
-                    type="button"
-                    onClick={() => {
-                          setAuthRole(item.type === "student-auth" ? "student" : "teacher");
-                          setIsOpen(false);
-                        }}
-                    aria-current={isActive ? "page" : undefined}
-                    aria-haspopup="dialog"
-                        aria-expanded={isAuthDialogOpen}
-                        aria-controls="role-auth-dialog"
-                        className={cn(
-                          "py-2 text-left text-lg font-medium transition-colors",
-                          "text-muted-foreground hover:text-primary"
-                        )}
-                      >
-                        {item.name}
-                      </button>
-                    );
-                  }
-
-                  return (
-                    <Link
-                      key={item.path}
-                      to={localizedPath}
-                      aria-current={isActive ? "page" : undefined}
-                      onClick={() => setIsOpen(false)}
-                      className={cn(
-                        "py-2 text-lg font-medium transition-colors",
-                        "text-muted-foreground hover:text-primary"
-                      )}
-                    >
-                      {item.name}
-                    </Link>
-                  );
-                })}
-
-                {user ? (
-                  <div className="border-t pt-4 space-y-3">
-                    <p className="px-2 text-sm text-muted-foreground">{user.email}</p>
-                    <Link
-                      to={getLocalizedNavPath("/my-profile")}
-                      onClick={() => setIsOpen(false)}
-                    >
-                      <Button className="w-full" variant="secondary">
-                        {t.nav.my_profile ?? t.nav.dashboard}
-                      </Button>
-                    </Link>
-                    <Button
-                      onClick={() => {
-                        handleSignOut();
-                        setIsOpen(false);
-                      }}
-                      className="w-full"
-                      variant="outline"
-                    >
-                      <LogOut className="mr-2 h-4 w-4" />
-                      {t.nav.signOut}
-                    </Button>
-                  </div>
-                ) : (
-                  <Link to={getLocalizedNavPath("/auth")} onClick={() => setIsOpen(false)}>
-                    <Button className="w-full">{t.nav.signUp} / {t.nav.signIn}</Button>
-                  </Link>
-                )}
-              </div>
-            </SheetContent>
-          </Sheet>
         </div>
-      </div>
-    </nav>
+      </nav>
       <RoleAuthDialog
         open={isAuthDialogOpen}
         role={authRole ?? "teacher"}

--- a/src/components/navigation/AccountMenu.tsx
+++ b/src/components/navigation/AccountMenu.tsx
@@ -1,0 +1,59 @@
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { IdCard, LogOut, User } from "lucide-react";
+import type { SupabaseUser } from "@supabase/supabase-js";
+
+type AccountMenuProps = {
+  user: SupabaseUser | null;
+  authPath: string;
+  authLabel: string;
+  myProfileLabel: string;
+  signOutLabel: string;
+  onSignOut: () => void | Promise<void>;
+  onNavigateToProfile: () => void;
+};
+
+const AccountMenu = ({
+  user,
+  authPath,
+  authLabel,
+  myProfileLabel,
+  signOutLabel,
+  onSignOut,
+  onNavigateToProfile,
+}: AccountMenuProps) => {
+  if (!user) {
+    return (
+      <Button asChild className="whitespace-nowrap">
+        <Link to={authPath}>{authLabel}</Link>
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="flex items-center gap-2">
+          <User className="h-5 w-5" />
+          <span className="text-sm font-medium">My account</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuItem className="text-sm text-muted-foreground">{user.email}</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={onNavigateToProfile}>
+          <IdCard className="mr-2 h-4 w-4" />
+          {myProfileLabel}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={onSignOut}>
+          <LogOut className="mr-2 h-4 w-4" />
+          {signOutLabel}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default AccountMenu;

--- a/src/components/navigation/DesktopNavLinks.tsx
+++ b/src/components/navigation/DesktopNavLinks.tsx
@@ -1,0 +1,56 @@
+import { Link } from "react-router-dom";
+import { cn } from "@/lib/utils";
+import type { AuthRole } from "@/components/auth/RoleAuthDialog";
+import type { LocalizedNavItem } from "./types";
+
+type DesktopNavLinksProps = {
+  items: LocalizedNavItem[];
+  onAuthRoleSelect: (role: AuthRole) => void;
+  isAuthDialogOpen: boolean;
+};
+
+const DesktopNavLinks = ({ items, onAuthRoleSelect, isAuthDialogOpen }: DesktopNavLinksProps) => {
+  return (
+    <div className="hidden lg:flex items-center gap-1 xl:gap-2">
+      {items.map(item => {
+        if (item.type === "teacher-auth" || item.type === "student-auth") {
+          return (
+            <button
+              key={item.path}
+              type="button"
+              onClick={() => onAuthRoleSelect(item.type === "student-auth" ? "student" : "teacher")}
+              aria-current={item.isActive ? "page" : undefined}
+              aria-haspopup="dialog"
+              aria-expanded={isAuthDialogOpen}
+              aria-controls="role-auth-dialog"
+              className={cn(
+                "rounded-full px-4 py-2 text-sm font-semibold transition-all whitespace-nowrap",
+                "border border-transparent hover:border-white/40 hover:bg-white/20 hover:text-foreground hover:backdrop-blur-sm",
+                "text-muted-foreground"
+              )}
+            >
+              {item.name}
+            </button>
+          );
+        }
+
+        return (
+          <Link
+            key={item.path}
+            to={item.localizedPath}
+            aria-current={item.isActive ? "page" : undefined}
+            className={cn(
+              "rounded-full px-4 py-2 text-sm font-semibold transition-all whitespace-nowrap",
+              "border border-transparent hover:border-white/40 hover:bg-white/20 hover:text-foreground hover:backdrop-blur-sm",
+              "text-muted-foreground"
+            )}
+          >
+            {item.name}
+          </Link>
+        );
+      })}
+    </div>
+  );
+};
+
+export default DesktopNavLinks;

--- a/src/components/navigation/MobileNavSheet.tsx
+++ b/src/components/navigation/MobileNavSheet.tsx
@@ -1,0 +1,113 @@
+import { Link } from "react-router-dom";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Menu, LogOut } from "lucide-react";
+import type { SupabaseUser } from "@supabase/supabase-js";
+import type { AuthRole } from "@/components/auth/RoleAuthDialog";
+import type { LocalizedNavItem } from "./types";
+
+export type MobileNavSheetProps = {
+  items: LocalizedNavItem[];
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAuthRoleSelect: (role: AuthRole) => void;
+  isAuthDialogOpen: boolean;
+  user: SupabaseUser | null;
+  authPath: string;
+  profilePath: string;
+  authLabel: string;
+  myProfileLabel: string;
+  signOutLabel: string;
+  onSignOut: () => Promise<void> | void;
+};
+
+const MobileNavSheet = ({
+  items,
+  isOpen,
+  onOpenChange,
+  onAuthRoleSelect,
+  isAuthDialogOpen,
+  user,
+  authPath,
+  profilePath,
+  authLabel,
+  myProfileLabel,
+  signOutLabel,
+  onSignOut,
+}: MobileNavSheetProps) => {
+  const handleClose = () => onOpenChange(false);
+
+  const handleSignOut = async () => {
+    await onSignOut();
+    handleClose();
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="icon" className="lg:hidden">
+          <Menu className="h-6 w-6" />
+          <span className="sr-only">Toggle menu</span>
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="w-[300px] sm:w-[380px]">
+        <div className="mt-8 flex flex-col space-y-4">
+          {items.map(item => {
+            if (item.type === "teacher-auth" || item.type === "student-auth") {
+              return (
+                <button
+                  key={item.path}
+                  type="button"
+                  onClick={() => {
+                    onAuthRoleSelect(item.type === "student-auth" ? "student" : "teacher");
+                    handleClose();
+                  }}
+                  aria-current={item.isActive ? "page" : undefined}
+                  aria-haspopup="dialog"
+                  aria-expanded={isAuthDialogOpen}
+                  aria-controls="role-auth-dialog"
+                  className="py-2 text-left text-lg font-medium transition-colors text-muted-foreground hover:text-primary"
+                >
+                  {item.name}
+                </button>
+              );
+            }
+
+            return (
+              <Link
+                key={item.path}
+                to={item.localizedPath}
+                aria-current={item.isActive ? "page" : undefined}
+                onClick={handleClose}
+                className="py-2 text-lg font-medium transition-colors text-muted-foreground hover:text-primary"
+              >
+                {item.name}
+              </Link>
+            );
+          })}
+
+          {user ? (
+            <div className="border-t pt-4 space-y-3">
+              <p className="px-2 text-sm text-muted-foreground">{user.email}</p>
+              <Link to={profilePath} onClick={handleClose}>
+                <Button className="w-full" variant="secondary">
+                  {myProfileLabel}
+                </Button>
+              </Link>
+              <Button onClick={handleSignOut} className="w-full" variant="outline">
+                <LogOut className="mr-2 h-4 w-4" />
+                {signOutLabel}
+              </Button>
+            </div>
+          ) : (
+            <Link to={authPath} onClick={handleClose}>
+              <Button className="w-full">{authLabel}</Button>
+            </Link>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default MobileNavSheet;

--- a/src/components/navigation/types.ts
+++ b/src/components/navigation/types.ts
@@ -1,0 +1,12 @@
+export type NavItemType = "link" | "teacher-auth" | "student-auth";
+
+export type NavItem = {
+  name: string;
+  path: string;
+  type?: NavItemType;
+};
+
+export type LocalizedNavItem = NavItem & {
+  localizedPath: string;
+  isActive: boolean;
+};


### PR DESCRIPTION
## Summary
- split the navigation UI into DesktopNavLinks, AccountMenu, and MobileNavSheet components
- keep Navigation responsible for localized nav item state and shared auth/session handling
- reuse computed nav metadata across desktop and mobile experiences via typed props

## Testing
- npm run test *(fails: existing builder tests require backend APIs, Supabase session helpers, and DOM features such as ResizeObserver in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e345b5b4588331bd4c8a9a963c9521