### PR TITLE
Extract navigation active state logic into reusable hook

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import {
@@ -21,6 +21,7 @@ import {
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getLocalizedPath } from "@/hooks/useLocalizedNavigate";
 import RoleAuthDialog, { type AuthRole } from "@/components/auth/RoleAuthDialog";
+import useNavItemActiveState from "@/components/navigation/useNavItemActiveState";
 
 type NavItem = {
   name: string;
@@ -32,9 +33,9 @@ const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [authRole, setAuthRole] = useState<AuthRole | null>(null);
   const [user, setUser] = useState<SupabaseUser | null>(null);
-  const location = useLocation();
   const navigate = useNavigate();
   const { t } = useLanguage();
+  const isNavItemActive = useNavItemActiveState();
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -85,45 +86,52 @@ const Navigation = () => {
   return (
     <>
       <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
-      >
-        Skip to main content
-      </a>
-      <div className="container flex h-16 items-center gap-4">
-        <Link to={getLocalizedNavPath("/")} className="flex items-center gap-2 flex-shrink-0">
-          <span className="text-xl font-bold">
-            <span className="text-red-500">School</span>Tech
-          </span>
-        </Link>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
+        >
+          Skip to main content
+        </a>
+        <div className="container flex h-16 items-center gap-4">
+          <Link to={getLocalizedNavPath("/")} className="flex items-center gap-2 flex-shrink-0">
+            <span className="text-xl font-bold">
+              <span className="text-red-500">School</span>Tech
+            </span>
+          </Link>
 
-        <div className="flex flex-1 items-center justify-end gap-3">
-          {/* Desktop navigation links */}
-          <div className="hidden lg:flex items-center gap-1 xl:gap-2">
-            {navItems.map(item => {
-              const localizedPath = getLocalizedNavPath(item.path);
-              const [targetPath, queryString] = localizedPath.split("?");
-              const matchesPath =
-                location.pathname === targetPath ||
-                (item.path !== "/" && targetPath && location.pathname.startsWith(targetPath));
-              const targetParams = new URLSearchParams(queryString ?? "");
-              const currentParams = new URLSearchParams(location.search);
-              const matchesQuery =
-                targetParams.toString().length === 0 ||
-                Array.from(targetParams.entries()).every(([key, value]) => currentParams.get(key) === value);
-              const isActive = matchesPath && matchesQuery;
+          <div className="flex flex-1 items-center justify-end gap-3">
+            {/* Desktop navigation links */}
+            <div className="hidden lg:flex items-center gap-1 xl:gap-2">
+              {navItems.map(item => {
+                const localizedPath = getLocalizedNavPath(item.path);
+                const isActive = isNavItemActive(item.path, localizedPath);
 
-              if (item.type === "teacher-auth" || item.type === "student-auth") {
+                if (item.type === "teacher-auth" || item.type === "student-auth") {
+                  return (
+                    <button
+                      key={item.path}
+                      type="button"
+                      onClick={() => setAuthRole(item.type === "student-auth" ? "student" : "teacher")}
+                      aria-current={isActive ? "page" : undefined}
+                      aria-haspopup="dialog"
+                      aria-expanded={isAuthDialogOpen}
+                      aria-controls="role-auth-dialog"
+                      className={cn(
+                        "rounded-full px-4 py-2 text-sm font-semibold transition-all whitespace-nowrap",
+                        "border border-transparent hover:border-white/40 hover:bg-white/20 hover:text-foreground hover:backdrop-blur-sm",
+                        "text-muted-foreground"
+                      )}
+                    >
+                      {item.name}
+                    </button>
+                  );
+                }
+
                 return (
-                  <button
+                  <Link
                     key={item.path}
-                    type="button"
-                    onClick={() => setAuthRole(item.type === "student-auth" ? "student" : "teacher")}
+                    to={localizedPath}
                     aria-current={isActive ? "page" : undefined}
-                    aria-haspopup="dialog"
-                    aria-expanded={isAuthDialogOpen}
-                    aria-controls="role-auth-dialog"
                     className={cn(
                       "rounded-full px-4 py-2 text-sm font-semibold transition-all whitespace-nowrap",
                       "border border-transparent hover:border-white/40 hover:bg-white/20 hover:text-foreground hover:backdrop-blur-sm",
@@ -131,161 +139,136 @@ const Navigation = () => {
                     )}
                   >
                     {item.name}
-                  </button>
+                  </Link>
                 );
-              }
+              })}
+            </div>
 
-              return (
-                <Link
-                  key={item.path}
-                  to={localizedPath}
-                  aria-current={isActive ? "page" : undefined}
-                  className={cn(
-                    "rounded-full px-4 py-2 text-sm font-semibold transition-all whitespace-nowrap",
-                    "border border-transparent hover:border-white/40 hover:bg-white/20 hover:text-foreground hover:backdrop-blur-sm",
-                    "text-muted-foreground"
-                  )}
-                >
-                  {item.name}
-                </Link>
-              );
-            })}
-          </div>
+            {/* Desktop actions */}
+            <div className="hidden items-center gap-3 md:flex">
+              {user ? (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      className="flex items-center gap-2"
+                    >
+                      <User className="h-5 w-5" />
+                      <span className="text-sm font-medium">My account</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-56">
+                    <DropdownMenuItem className="text-sm text-muted-foreground">
+                      {user.email}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={() => navigate(getLocalizedNavPath("/my-profile"))}
+                    >
+                      <IdCard className="mr-2 h-4 w-4" />
+                      {t.nav.my_profile}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onClick={handleSignOut}>
+                      <LogOut className="mr-2 h-4 w-4" />
+                      {t.nav.signOut}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ) : (
+                <Button asChild className="whitespace-nowrap">
+                  <Link to={getLocalizedNavPath("/auth")}>{t.nav.signUp} / {t.nav.signIn}</Link>
+                </Button>
+              )}
+            </div>
 
-          {/* Desktop actions */}
-          <div className="hidden items-center gap-3 md:flex">
-            {user ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    className="flex items-center gap-2"
-                  >
-                    <User className="h-5 w-5" />
-                    <span className="text-sm font-medium">My account</span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-56">
-                  <DropdownMenuItem className="text-sm text-muted-foreground">
-                    {user.email}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() => navigate(getLocalizedNavPath("/my-profile"))}
-                  >
-                    <IdCard className="mr-2 h-4 w-4" />
-                    {t.nav.my_profile}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={handleSignOut}>
-                    <LogOut className="mr-2 h-4 w-4" />
-                    {t.nav.signOut}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : (
-              <Button asChild className="whitespace-nowrap">
-                <Link to={getLocalizedNavPath("/auth")}>{t.nav.signUp} / {t.nav.signIn}</Link>
-              </Button>
-            )}
-          </div>
+            {/* Mobile navigation */}
+            <Sheet open={isOpen} onOpenChange={setIsOpen}>
+              <SheetTrigger asChild>
+                <Button variant="ghost" size="icon" className="lg:hidden">
+                  <Menu className="h-6 w-6" />
+                  <span className="sr-only">Toggle menu</span>
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="right" className="w-[300px] sm:w-[380px]">
+                <div className="mt-8 flex flex-col space-y-4">
+                  {navItems.map(item => {
+                    const localizedPath = getLocalizedNavPath(item.path);
+                    const isActive = isNavItemActive(item.path, localizedPath);
 
-          {/* Mobile navigation */}
-          <Sheet open={isOpen} onOpenChange={setIsOpen}>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon" className="lg:hidden">
-                <Menu className="h-6 w-6" />
-                <span className="sr-only">Toggle menu</span>
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="right" className="w-[300px] sm:w-[380px]">
-              <div className="mt-8 flex flex-col space-y-4">
-                {navItems.map(item => {
-                  const localizedPath = getLocalizedNavPath(item.path);
-                  const [targetPath, queryString] = localizedPath.split("?");
-                  const matchesPath =
-                    location.pathname === targetPath ||
-                    (item.path !== "/" && targetPath && location.pathname.startsWith(targetPath));
-                  const targetParams = new URLSearchParams(queryString ?? "");
-                  const currentParams = new URLSearchParams(location.search);
-                  const matchesQuery =
-                    targetParams.toString().length === 0 ||
-                    Array.from(targetParams.entries()).every(([key, value]) => currentParams.get(key) === value);
-                  const isActive = matchesPath && matchesQuery;
+                    if (item.type === "teacher-auth" || item.type === "student-auth") {
+                      return (
+                        <button
+                          key={item.path}
+                          type="button"
+                          onClick={() => {
+                            setAuthRole(item.type === "student-auth" ? "student" : "teacher");
+                            setIsOpen(false);
+                          }}
+                          aria-current={isActive ? "page" : undefined}
+                          aria-haspopup="dialog"
+                          aria-expanded={isAuthDialogOpen}
+                          aria-controls="role-auth-dialog"
+                          className={cn(
+                            "py-2 text-left text-lg font-medium transition-colors",
+                            "text-muted-foreground hover:text-primary"
+                          )}
+                        >
+                          {item.name}
+                        </button>
+                      );
+                    }
 
-              if (item.type === "teacher-auth" || item.type === "student-auth") {
-                return (
-                  <button
-                    key={item.path}
-                    type="button"
-                    onClick={() => {
-                          setAuthRole(item.type === "student-auth" ? "student" : "teacher");
-                          setIsOpen(false);
-                        }}
-                    aria-current={isActive ? "page" : undefined}
-                    aria-haspopup="dialog"
-                        aria-expanded={isAuthDialogOpen}
-                        aria-controls="role-auth-dialog"
+                    return (
+                      <Link
+                        key={item.path}
+                        to={localizedPath}
+                        aria-current={isActive ? "page" : undefined}
+                        onClick={() => setIsOpen(false)}
                         className={cn(
-                          "py-2 text-left text-lg font-medium transition-colors",
+                          "py-2 text-lg font-medium transition-colors",
                           "text-muted-foreground hover:text-primary"
                         )}
                       >
                         {item.name}
-                      </button>
+                      </Link>
                     );
-                  }
+                  })}
 
-                  return (
-                    <Link
-                      key={item.path}
-                      to={localizedPath}
-                      aria-current={isActive ? "page" : undefined}
-                      onClick={() => setIsOpen(false)}
-                      className={cn(
-                        "py-2 text-lg font-medium transition-colors",
-                        "text-muted-foreground hover:text-primary"
-                      )}
-                    >
-                      {item.name}
-                    </Link>
-                  );
-                })}
-
-                {user ? (
-                  <div className="border-t pt-4 space-y-3">
-                    <p className="px-2 text-sm text-muted-foreground">{user.email}</p>
-                    <Link
-                      to={getLocalizedNavPath("/my-profile")}
-                      onClick={() => setIsOpen(false)}
-                    >
-                      <Button className="w-full" variant="secondary">
-                        {t.nav.my_profile ?? t.nav.dashboard}
+                  {user ? (
+                    <div className="border-t pt-4 space-y-3">
+                      <p className="px-2 text-sm text-muted-foreground">{user.email}</p>
+                      <Link
+                        to={getLocalizedNavPath("/my-profile")}
+                        onClick={() => setIsOpen(false)}
+                      >
+                        <Button className="w-full" variant="secondary">
+                          {t.nav.my_profile ?? t.nav.dashboard}
+                        </Button>
+                      </Link>
+                      <Button
+                        onClick={() => {
+                          handleSignOut();
+                          setIsOpen(false);
+                        }}
+                        className="w-full"
+                        variant="outline"
+                      >
+                        <LogOut className="mr-2 h-4 w-4" />
+                        {t.nav.signOut}
                       </Button>
+                    </div>
+                  ) : (
+                    <Link to={getLocalizedNavPath("/auth")} onClick={() => setIsOpen(false)}>
+                      <Button className="w-full">{t.nav.signUp} / {t.nav.signIn}</Button>
                     </Link>
-                    <Button
-                      onClick={() => {
-                        handleSignOut();
-                        setIsOpen(false);
-                      }}
-                      className="w-full"
-                      variant="outline"
-                    >
-                      <LogOut className="mr-2 h-4 w-4" />
-                      {t.nav.signOut}
-                    </Button>
-                  </div>
-                ) : (
-                  <Link to={getLocalizedNavPath("/auth")} onClick={() => setIsOpen(false)}>
-                    <Button className="w-full">{t.nav.signUp} / {t.nav.signIn}</Button>
-                  </Link>
-                )}
-              </div>
-            </SheetContent>
-          </Sheet>
+                  )}
+                </div>
+              </SheetContent>
+            </Sheet>
+          </div>
         </div>
-      </div>
-    </nav>
+      </nav>
       <RoleAuthDialog
         open={isAuthDialogOpen}
         role={authRole ?? "teacher"}

--- a/src/components/navigation/useNavItemActiveState.test.ts
+++ b/src/components/navigation/useNavItemActiveState.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { isNavItemActive } from "./useNavItemActiveState";
+
+describe("isNavItemActive", () => {
+  it("matches localized routes without query parameters", () => {
+    const result = isNavItemActive({
+      itemPath: "/blog",
+      localizedPath: "/en/blog",
+      currentPathname: "/en/blog",
+      currentSearch: "",
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("matches when query parameters align", () => {
+    const result = isNavItemActive({
+      itemPath: "/events",
+      localizedPath: "/en/events?type=upcoming",
+      currentPathname: "/en/events",
+      currentSearch: "?type=upcoming",
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("does not match when query parameters differ", () => {
+    const result = isNavItemActive({
+      itemPath: "/events",
+      localizedPath: "/en/events?type=past",
+      currentPathname: "/en/events",
+      currentSearch: "?type=upcoming",
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("does not treat the home link as active for nested routes", () => {
+    const result = isNavItemActive({
+      itemPath: "/",
+      localizedPath: "/en",
+      currentPathname: "/en/about",
+      currentSearch: "",
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/components/navigation/useNavItemActiveState.ts
+++ b/src/components/navigation/useNavItemActiveState.ts
@@ -1,0 +1,48 @@
+import { useCallback } from "react";
+import { useLocation } from "react-router-dom";
+
+interface NavItemActiveStateInput {
+  itemPath: string;
+  localizedPath: string;
+  currentPathname: string;
+  currentSearch?: string;
+}
+
+export const isNavItemActive = ({
+  itemPath,
+  localizedPath,
+  currentPathname,
+  currentSearch = "",
+}: NavItemActiveStateInput): boolean => {
+  const [targetPath, queryString] = localizedPath.split("?");
+
+  const matchesPath =
+    currentPathname === targetPath ||
+    (itemPath !== "/" && Boolean(targetPath) && currentPathname.startsWith(targetPath));
+
+  const targetParams = new URLSearchParams(queryString ?? "");
+  const currentParams = new URLSearchParams(currentSearch);
+
+  const matchesQuery =
+    targetParams.toString().length === 0 ||
+    Array.from(targetParams.entries()).every(([key, value]) => currentParams.get(key) === value);
+
+  return matchesPath && matchesQuery;
+};
+
+export const useNavItemActiveState = () => {
+  const location = useLocation();
+
+  return useCallback(
+    (itemPath: string, localizedPath: string) =>
+      isNavItemActive({
+        itemPath,
+        localizedPath,
+        currentPathname: location.pathname,
+        currentSearch: location.search,
+      }),
+    [location.pathname, location.search]
+  );
+};
+
+export default useNavItemActiveState;


### PR DESCRIPTION
## Summary
- extract the navigation active-state calculation into a reusable `useNavItemActiveState` helper
- consume the helper for both desktop and mobile navigation link rendering
- add unit coverage to confirm the helper handles localized paths and query parameters

## Testing
- `npm run test` *(fails: existing builder/activity preference suites require unavailable APIs and hit timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68e345af99c88331b9e8ddc797b0a6fb