### PR TITLE
Rename teacher dashboard page component to TeacherPage

### DIFF
--- a/src/components/LocalizedRoutes.tsx
+++ b/src/components/LocalizedRoutes.tsx
@@ -20,7 +20,7 @@ import Footer from '@/components/Footer';
 import AdminLayout from '@/pages/admin/AdminLayout';
 import AdminPage from '@/pages/admin/AdminPage';
 import AdminLoginPrototype from '@/pages/admin/AdminLoginPrototype';
-import DashboardPage from '@/pages/Dashboard';
+import TeacherPage from '@/pages/TeacherPage';
 import StudentPage from '@/pages/Student';
 import StudentDashboardPage from '@/pages/StudentDashboard';
 import TeacherCurriculumDetailPage from '@/pages/TeacherCurriculumDetail';
@@ -103,7 +103,7 @@ export const LocalizedRoutes = () => {
       <Route path="/faq" element={<RouteWrapper><FAQ /></RouteWrapper>} />
       <Route path="/auth" element={<RouteWrapper><Auth /></RouteWrapper>} />
       <Route path="/account" element={<LegacyAccountRedirect />} />
-      <Route path="/teacher" element={<RouteWrapper><DashboardPage /></RouteWrapper>} />
+      <Route path="/teacher" element={<RouteWrapper><TeacherPage /></RouteWrapper>} />
       <Route path="/teacher/curriculum/:id" element={<RouteWrapper><TeacherCurriculumDetailPage /></RouteWrapper>} />
       <Route path="/teacher/classes/:id" element={<LegacyClassDashboardRedirect />} />
       <Route path="/dashboard" element={<Navigate to="/teacher" replace />} />

--- a/src/pages/TeacherPage.tsx
+++ b/src/pages/TeacherPage.tsx
@@ -138,7 +138,7 @@ const GLASS_PANEL_CLASS =
 const GLASS_TAB_TRIGGER_CLASS =
   "w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white/70 transition backdrop-blur-xl hover:border-white/40 hover:bg-white/15 hover:text-white data-[state=active]:border-white/60 data-[state=active]:bg-white/25 data-[state=active]:text-white data-[state=active]:shadow-[0_15px_45px_-25px_rgba(15,23,42,0.85)]";
 
-export default function DashboardPage() {
+export default function TeacherPage() {
   const { t } = useLanguage();
   const navigate = useNavigate();
   const queryClient = useQueryClient();


### PR DESCRIPTION
## Summary
- rename the teacher dashboard page file to `TeacherPage.tsx` and update the component export
- adjust localized routes to import and render the new `TeacherPage` component for the `/teacher` path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3487a3884833180d65c45cca13b53