### PR TITLE
Adjust spacing between hero and stats sections

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -316,7 +316,7 @@ const Index = () => {
       />
       <StructuredData type="Organization" data={structuredData} />
 
-      <section className="relative overflow-hidden pt-3 pb-2.5 md:pt-3">
+      <section className="relative overflow-hidden pt-3 pb-0 md:pt-3">
         <MouseGlowEffect />
         <SparklesBackground />
         <div className="absolute inset-0 overflow-hidden" aria-hidden="true">
@@ -518,7 +518,7 @@ const Index = () => {
         </div>
       </section>
 
-      <section className="relative overflow-hidden pt-2.5 pb-[10px]">
+      <section className="relative overflow-hidden pt-[10px] pb-[10px]">
         <div className="absolute inset-0 -z-20">
           <img
             src={classroomTechnologyBackgrounds.stats}


### PR DESCRIPTION
## Summary
- reduce the hero section's bottom padding so the stat cards sit closer to the preceding card
- set the stats section top padding to an explicit 10px value to keep a consistent gap

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3495e24c88331941ad8208500afb6