### PR TITLE
Replace account dropdown with sign-out button

### DIFF
--- a/src/components/navigation/AccountMenu.tsx
+++ b/src/components/navigation/AccountMenu.tsx
@@ -1,7 +1,6 @@
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { IdCard, LogOut, User } from "lucide-react";
+import { LogOut } from "lucide-react";
 import type { SupabaseUser } from "@supabase/supabase-js";
 
 type AccountMenuProps = {
@@ -32,27 +31,15 @@ const AccountMenu = ({
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="flex items-center gap-2">
-          <User className="h-5 w-5" />
-          <span className="text-sm font-medium">My account</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
-        <DropdownMenuItem className="text-sm text-muted-foreground">{user.email}</DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={onNavigateToProfile}>
-          <IdCard className="mr-2 h-4 w-4" />
-          {myProfileLabel}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={onSignOut}>
-          <LogOut className="mr-2 h-4 w-4" />
-          {signOutLabel}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <div className="flex items-center gap-3">
+      <Button variant="secondary" onClick={onNavigateToProfile}>
+        {myProfileLabel}
+      </Button>
+      <Button variant="outline" onClick={onSignOut} className="flex items-center gap-2">
+        <LogOut className="h-4 w-4" />
+        {signOutLabel}
+      </Button>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- replace the My Account dropdown in the desktop navigation with dedicated profile and sign out buttons so the navigation shows a Sign Out action

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e365b5e91c83318afb46bf6047cd61