### PR TITLE
Remove My Profile button from navigation menus

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -63,18 +63,12 @@ const Navigation = () => {
 
   const homePath = getLocalizedNavPath("/");
   const authPath = getLocalizedNavPath("/auth");
-  const profilePath = getLocalizedNavPath("/my-profile");
   const authLabel = `${t.nav.signUp} / ${t.nav.signIn}`;
-  const myProfileLabel = t.nav.my_profile ?? t.nav.dashboard;
   const signOutLabel = t.nav.signOut;
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();
     navigate(homePath);
-  };
-
-  const handleNavigateToProfile = () => {
-    navigate(profilePath);
   };
 
   return (
@@ -106,9 +100,7 @@ const Navigation = () => {
                 user={user}
                 authPath={authPath}
                 authLabel={authLabel}
-                myProfileLabel={myProfileLabel}
                 signOutLabel={signOutLabel}
-                onNavigateToProfile={handleNavigateToProfile}
                 onSignOut={handleSignOut}
               />
             </div>
@@ -122,9 +114,7 @@ const Navigation = () => {
               isAuthDialogOpen={isAuthDialogOpen}
               user={user}
               authPath={authPath}
-              profilePath={profilePath}
               authLabel={authLabel}
-              myProfileLabel={myProfileLabel}
               signOutLabel={signOutLabel}
               onSignOut={handleSignOut}
             />

--- a/src/components/navigation/AccountMenu.tsx
+++ b/src/components/navigation/AccountMenu.tsx
@@ -7,20 +7,16 @@ type AccountMenuProps = {
   user: SupabaseUser | null;
   authPath: string;
   authLabel: string;
-  myProfileLabel: string;
   signOutLabel: string;
   onSignOut: () => void | Promise<void>;
-  onNavigateToProfile: () => void;
 };
 
 const AccountMenu = ({
   user,
   authPath,
   authLabel,
-  myProfileLabel,
   signOutLabel,
   onSignOut,
-  onNavigateToProfile,
 }: AccountMenuProps) => {
   if (!user) {
     return (
@@ -31,15 +27,10 @@ const AccountMenu = ({
   }
 
   return (
-    <div className="flex items-center gap-3">
-      <Button variant="secondary" onClick={onNavigateToProfile}>
-        {myProfileLabel}
-      </Button>
-      <Button variant="outline" onClick={onSignOut} className="flex items-center gap-2">
-        <LogOut className="h-4 w-4" />
-        {signOutLabel}
-      </Button>
-    </div>
+    <Button variant="outline" onClick={onSignOut} className="flex items-center gap-2">
+      <LogOut className="h-4 w-4" />
+      {signOutLabel}
+    </Button>
   );
 };
 

--- a/src/components/navigation/MobileNavSheet.tsx
+++ b/src/components/navigation/MobileNavSheet.tsx
@@ -16,9 +16,7 @@ export type MobileNavSheetProps = {
   isAuthDialogOpen: boolean;
   user: SupabaseUser | null;
   authPath: string;
-  profilePath: string;
   authLabel: string;
-  myProfileLabel: string;
   signOutLabel: string;
   onSignOut: () => Promise<void> | void;
 };
@@ -32,9 +30,7 @@ const MobileNavSheet = ({
   isAuthDialogOpen,
   user,
   authPath,
-  profilePath,
   authLabel,
-  myProfileLabel,
   signOutLabel,
   onSignOut,
 }: MobileNavSheetProps) => {
@@ -95,11 +91,6 @@ const MobileNavSheet = ({
           {user ? (
             <div className="border-t pt-4 space-y-3">
               <p className="px-2 text-sm text-muted-foreground">{user.email}</p>
-              <Link to={profilePath} onClick={handleClose}>
-                <Button className="w-full" variant="secondary">
-                  {myProfileLabel}
-                </Button>
-              </Link>
               <Button onClick={handleSignOut} className="w-full" variant="outline">
                 <LogOut className="mr-2 h-4 w-4" />
                 {signOutLabel}


### PR DESCRIPTION
## Summary
- remove the My Profile button from the desktop account menu and mobile drawer so only the sign-out action remains for authenticated users
- clean up navigation props to reflect the simplified menu options

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3687289748331b850e196167f0f9a