### PR TITLE
Swap profile overview and settings column order

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -283,9 +283,13 @@ const Profile = () => {
           </div>
         </section>
 
-        <div className="grid gap-8 lg:grid-cols-[360px,1fr]">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr),360px]">
+          <div id="profile-settings" className="space-y-6">
+            <SettingsPanel user={user} variant="glass" className="space-y-6" />
+          </div>
+
           <div className="space-y-6">
-            <Card className={cn(glassCardClass, "p-6 sm:p-8")}>
+            <Card className={cn(glassCardClass, "p-6 sm:p-8")}> 
               <CardHeader className="space-y-4 border-none p-0">
                 <CardTitle className="text-2xl font-semibold text-white">
                   {t.profilePage.info.title}
@@ -347,10 +351,6 @@ const Profile = () => {
                 </Button>
               </CardContent>
             </Card>
-          </div>
-
-          <div id="profile-settings" className="space-y-6">
-            <SettingsPanel user={user} variant="glass" className="space-y-6" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- reorder the My Profile layout so the settings panel appears before the teacher info column
- adjust the profile grid to keep the editing tools in the wider column after the swap

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e369910e08833195462c6e548a13bf