### PR TITLE
Add class editing dialog and expand example students

### DIFF
--- a/src/features/dashboard/api.ts
+++ b/src/features/dashboard/api.ts
@@ -49,6 +49,37 @@ export async function createClass(input: {
   return data;
 }
 
+export async function updateClassDetails(input: {
+  id: string;
+  ownerId: string;
+  title: string;
+  stage?: string;
+  subject?: string;
+  start_date?: string;
+  end_date?: string;
+}): Promise<Class> {
+  const { data, error } = await supabase
+    .from("classes")
+    .update({
+      title: input.title,
+      stage: input.stage ?? null,
+      subject: input.subject ?? null,
+      start_date: input.start_date ?? null,
+      end_date: input.end_date ?? null,
+    })
+    .eq("id", input.id)
+    .eq("owner_id", input.ownerId)
+    .select("id,title,stage,subject,start_date,end_date")
+    .single();
+
+  if (error) {
+    console.error("Failed to update class", error);
+    throw error;
+  }
+
+  return data;
+}
+
 export async function fetchLessonPlan(id: string): Promise<LessonPlanWithRelations | null> {
   const { data, error } = await supabase
     .from("lesson_plans")

--- a/src/features/students/api.ts
+++ b/src/features/students/api.ts
@@ -273,7 +273,7 @@ export async function fetchClassSkills(input: { ownerId?: string | null; classId
 
   try {
     const { data, error } = await supabase
-      .from<SupabaseClassSkillRow>("class_skills" as "class_skills")
+      .from<SupabaseClassSkillRow>("class_skills")
       .select("class_id,skill_id,skills(id,title,description)")
       .in("class_id", classIds);
 
@@ -319,7 +319,7 @@ export async function fetchStudents(input: {
 
   try {
     const { data: classStudents, error: classStudentsError } = await supabase
-      .from<SupabaseClassStudentRow>("class_students" as "class_students")
+      .from<SupabaseClassStudentRow>("class_students")
       .select(
         "class_id,student_id,students(id,first_name,last_name,full_name,preferred_name,guardian_name,guardian_contact,behavior_comment,academic_comment,avatar_url)"
       )
@@ -342,7 +342,7 @@ export async function fetchStudents(input: {
 
     const studentIds = Array.from(uniqueStudents.keys());
     const { data: scoreRows, error: scoresError } = await supabase
-      .from<SupabaseStudentSkillScoreRow>("student_skill_scores" as "student_skill_scores")
+      .from<SupabaseStudentSkillScoreRow>("student_skill_scores")
       .select("id,student_id,skill_id,month,score")
       .in("student_id", studentIds);
 
@@ -439,7 +439,7 @@ export async function bulkAddStudents(input: {
     });
 
     const { data: insertedStudents, error: insertError } = await supabase
-      .from<Omit<SupabaseStudentRow, "id"> & { id: string }>("students" as "students")
+      .from<Omit<SupabaseStudentRow, "id"> & { id: string }>("students")
       .insert(studentPayload)
       .select("id");
 
@@ -454,7 +454,7 @@ export async function bulkAddStudents(input: {
 
     if (enrollmentPayload.length > 0) {
       const { error: enrollmentError } = await supabase
-        .from<SupabaseClassStudentRow>("class_students" as "class_students")
+        .from<SupabaseClassStudentRow>("class_students")
         .insert(enrollmentPayload);
 
       if (enrollmentError) {
@@ -496,7 +496,7 @@ export async function createSkillForClass(input: {
 
   try {
     const { data: skillRow, error: skillError } = await supabase
-      .from<SupabaseSkillRow>("skills" as "skills")
+      .from<SupabaseSkillRow>("skills")
       .insert({
         owner_id: ownerId,
         title: title.trim(),
@@ -510,7 +510,7 @@ export async function createSkillForClass(input: {
     }
 
     const { error: linkError } = await supabase
-      .from<SupabaseClassSkillRow>("class_skills" as "class_skills")
+      .from<SupabaseClassSkillRow>("class_skills")
       .insert({ class_id: classId, skill_id: skillRow.id });
 
     if (linkError) {
@@ -567,7 +567,7 @@ export async function updateStudentComments(input: {
     }
 
     const { error } = await supabase
-      .from("students" as "students")
+      .from("students")
       .update(updates)
       .eq("id", studentId);
 
@@ -603,7 +603,7 @@ export async function upsertStudentSkillScore(input: {
     };
 
     const { error } = await supabase
-      .from("student_skill_scores" as "student_skill_scores")
+      .from("student_skill_scores")
       .upsert(payload, { onConflict: "student_id,skill_id,month" });
 
     if (error) {

--- a/src/features/students/examples.ts
+++ b/src/features/students/examples.ts
@@ -168,6 +168,137 @@ export const DASHBOARD_EXAMPLE_STUDENTS: StudentRecord[] = [
     ],
     isExample: true,
   },
+  {
+    id: "example-student-ravi",
+    classId: DASHBOARD_EXAMPLE_CLASS_ID,
+    fullName: "Ravi Singh",
+    preferredName: "Ravi",
+    email: "ravi.singh@example.com",
+    guardianName: "Priya Singh",
+    guardianContact: "priya.singh@example.com",
+    behaviorComment: "Builds community by pairing classmates for peer review and checking in on new arrivals.",
+    academicComment: "Experimenting with stronger evidence in persuasive writing and reflecting confidently on feedback.",
+    skills: [
+      {
+        skillId: DASHBOARD_EXAMPLE_SKILLS[0]!.id,
+        skillName: DASHBOARD_EXAMPLE_SKILLS[0]!.title,
+        scores: createScoreSeries([
+          { month: "2024-09", score: 58 },
+          { month: "2024-10", score: 63 },
+          { month: "2024-11", score: 68 },
+          { month: "2024-12", score: 73 },
+        ]),
+      },
+      {
+        skillId: DASHBOARD_EXAMPLE_SKILLS[1]!.id,
+        skillName: DASHBOARD_EXAMPLE_SKILLS[1]!.title,
+        scores: createScoreSeries([
+          { month: "2024-09", score: 56 },
+          { month: "2024-10", score: 61 },
+          { month: "2024-11", score: 66 },
+          { month: "2024-12", score: 71 },
+        ]),
+      },
+      {
+        skillId: DASHBOARD_EXAMPLE_SKILLS[2]!.id,
+        skillName: DASHBOARD_EXAMPLE_SKILLS[2]!.title,
+        scores: createScoreSeries([
+          { month: "2024-09", score: 60 },
+          { month: "2024-10", score: 65 },
+          { month: "2024-11", score: 70 },
+          { month: "2024-12", score: 75 },
+        ]),
+      },
+    ],
+    isExample: true,
+  },
+  {
+    id: "example-student-maya",
+    classId: DASHBOARD_EXAMPLE_CLASS_ID,
+    fullName: "Maya Lopez",
+    preferredName: "Maya",
+    email: "maya.lopez@example.com",
+    guardianName: "Elena Lopez",
+    guardianContact: "elena.lopez@example.com",
+    behaviorComment: "Keeps group projects organized with shared checklists and celebrates teammates' wins on the class board.",
+    academicComment: "Applying new vocabulary intentionally in daily writing warm-ups and reading discussions.",
+    skills: [
+      {
+        skillId: DASHBOARD_EXAMPLE_SKILLS[0]!.id,
+        skillName: DASHBOARD_EXAMPLE_SKILLS[0]!.title,
+        scores: createScoreSeries([
+          { month: "2024-09", score: 61 },
+          { month: "2024-10", score: 66 },
+          { month: "2024-11", score: 71 },
+          { month: "2024-12", score: 75 },
+        ]),
+      },
+      {
+        skillId: DASHBOARD_EXAMPLE_SKILLS[1]!.id,
+        skillName: DASHBOARD_EXAMPLE_SKILLS[1]!.title,
+        scores: createScoreSeries([
+          { month: "2024-09", score: 59 },
+          { month: "2024-10", score: 64 },
+          { month: "2024-11", score: 69 },
+          { month: "2024-12", score: 73 },
+        ]),
+      },
+      {
+        skillId: DASHBOARD_EXAMPLE_SKILLS[2]!.id,
+        skillName: DASHBOARD_EXAMPLE_SKILLS[2]!.title,
+        scores: createScoreSeries([
+          { month: "2024-09", score: 63 },
+          { month: "2024-10", score: 68 },
+          { month: "2024-11", score: 72 },
+          { month: "2024-12", score: 77 },
+        ]),
+      },
+    ],
+    isExample: true,
+  },
+  {
+    id: "example-student-harper",
+    classId: DASHBOARD_EXAMPLE_CLASS_ID,
+    fullName: "Harper Lee",
+    email: "harper.lee@example.com",
+    guardianName: "Jordan Lee",
+    guardianContact: "jordan.lee@example.com",
+    behaviorComment: "Leads tech setup for storytelling stations and offers encouraging peer feedback during share-outs.",
+    academicComment: "Growing confidence with inferencing and experimenting with multimodal storytelling drafts.",
+    skills: [
+      {
+        skillId: DASHBOARD_EXAMPLE_SKILLS[0]!.id,
+        skillName: DASHBOARD_EXAMPLE_SKILLS[0]!.title,
+        scores: createScoreSeries([
+          { month: "2024-09", score: 54 },
+          { month: "2024-10", score: 59 },
+          { month: "2024-11", score: 64 },
+          { month: "2024-12", score: 69 },
+        ]),
+      },
+      {
+        skillId: DASHBOARD_EXAMPLE_SKILLS[1]!.id,
+        skillName: DASHBOARD_EXAMPLE_SKILLS[1]!.title,
+        scores: createScoreSeries([
+          { month: "2024-09", score: 55 },
+          { month: "2024-10", score: 60 },
+          { month: "2024-11", score: 65 },
+          { month: "2024-12", score: 70 },
+        ]),
+      },
+      {
+        skillId: DASHBOARD_EXAMPLE_SKILLS[2]!.id,
+        skillName: DASHBOARD_EXAMPLE_SKILLS[2]!.title,
+        scores: createScoreSeries([
+          { month: "2024-09", score: 57 },
+          { month: "2024-10", score: 62 },
+          { month: "2024-11", score: 66 },
+          { month: "2024-12", score: 71 },
+        ]),
+      },
+    ],
+    isExample: true,
+  },
 ];
 
 export const DASHBOARD_EXAMPLE_STUDENT_CLASSES = [DASHBOARD_EXAMPLE_CLASS];

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -93,6 +93,8 @@ export const en = {
       classCreated: "Class created",
       classCreatedWithStudents: "“{title}” was created and {count} students were added.",
       classCreatedNoStudents: "“{title}” was created. Add students anytime from the Students tab.",
+      classUpdated: "Class updated",
+      classUpdatedDescription: "“{title}” has been updated.",
       curriculumCreated: "Curriculum created",
       lessonPlanCreated: "Lesson plan created",
       exportUnavailable: "CSV export will be available soon.",
@@ -365,6 +367,12 @@ export const en = {
           helper: "We'll add these students to the class as soon as it's created.",
         },
         submit: "Create class",
+      },
+      editClass: {
+        title: "Edit class",
+        description: "Update the details for “{title}”.",
+        loading: "Loading class details…",
+        submit: "Save changes",
       },
       newCurriculum: {
         title: "New Curriculum",


### PR DESCRIPTION
## Summary
- add a Supabase helper for updating class records
- enable editing from the teacher dashboard classes tab with a dedicated dialog and state handling
- expand the example student roster for Ms. Rivera's class and refine the mock client update flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3ad43e218833195a83ae87e3aa5ea