### PR TITLE
Filter out example class from curriculum boards

### DIFF
--- a/src/pages/TeacherPage.tsx
+++ b/src/pages/TeacherPage.tsx
@@ -416,7 +416,13 @@ export default function TeacherPage() {
   }, [classesQuery.data]);
 
   const curriculumClasses = useMemo(
-    () => classes.filter(cls => !cls.isExample),
+    () =>
+      classes.filter(
+        cls =>
+          !cls.isExample &&
+          cls.id !== DASHBOARD_EXAMPLE_CLASS.id &&
+          cls.title !== DASHBOARD_EXAMPLE_CLASS.title,
+      ),
     [classes],
   );
 


### PR DESCRIPTION
## Summary
- filter out the example fallback class so it no longer appears in the curriculum board list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b42336b48331831df626cd6d93f1