### PR TITLE
Add draggable lesson workspace board

### DIFF
--- a/src/pages/lesson-builder/components/LessonResourceSidebar.tsx
+++ b/src/pages/lesson-builder/components/LessonResourceSidebar.tsx
@@ -2,7 +2,7 @@ import { type FormEvent, useCallback, useMemo, useState } from "react";
 import { CSS } from "@dnd-kit/utilities";
 import { useDraggable } from "@dnd-kit/core";
 import { useQuery } from "@tanstack/react-query";
-import { Loader2, Search } from "lucide-react";
+import { GripVertical, Loader2, Search } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,6 +13,10 @@ import type { Resource, ResourceDetail } from "@/types/resources";
 import { Badge } from "@/components/ui/badge";
 import { ResourceCard } from "@/components/lesson-draft/ResourceCard";
 import { cn } from "@/lib/utils";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import type { LessonWorkspaceTextCard } from "../types";
 
 const SEARCH_INPUT_ID = "lesson-resource-search-input";
 
@@ -20,6 +24,12 @@ type DraggableResourceData = {
   type: "library-resource";
   resource: Resource;
   resourceId: string;
+  source: "sidebar";
+};
+
+type SidebarTextCardDragData = {
+  type: "text-card";
+  textCardId: string;
   source: "sidebar";
 };
 
@@ -87,13 +97,96 @@ const SidebarResourceCard = ({ resource, onInsert, disabled, isPending }: Sideba
   );
 };
 
+interface SidebarTextCardProps {
+  card: LessonWorkspaceTextCard;
+  onTitleChange: (value: string) => void;
+  onContentChange: (value: string) => void;
+}
+
+const SidebarTextCard = ({ card, onTitleChange, onContentChange }: SidebarTextCardProps) => {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable<SidebarTextCardDragData>({
+    id: `lesson-text-card-${card.id}`,
+    data: {
+      type: "text-card",
+      textCardId: card.id,
+      source: "sidebar",
+    },
+  });
+
+  const style = transform ? { transform: CSS.Translate.toString(transform) } : undefined;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "space-y-3 rounded-2xl border border-white/20 bg-white/10 p-4 shadow-[0_18px_40px_-28px_rgba(15,23,42,0.85)] backdrop-blur",
+        isDragging && "opacity-80",
+      )}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-foreground">Text card</p>
+          <p className="text-xs text-muted-foreground">Drag to your lesson wall or keep editing here.</p>
+        </div>
+        <button
+          type="button"
+          className="rounded-full border border-white/20 bg-white/10 p-2 text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+          aria-label="Drag text card"
+          {...listeners}
+          {...attributes}
+        >
+          <GripVertical className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`lesson-text-card-${card.id}-title`} className="text-xs uppercase tracking-wide text-slate-200/80">
+          Title
+        </Label>
+        <Input
+          id={`lesson-text-card-${card.id}-title`}
+          value={card.title}
+          onChange={event => onTitleChange(event.target.value)}
+          placeholder="Add a heading"
+          className="border-white/20 bg-white/10 text-foreground placeholder:text-slate-200/60 backdrop-blur"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`lesson-text-card-${card.id}-content`} className="text-xs uppercase tracking-wide text-slate-200/80">
+          Notes
+        </Label>
+        <Textarea
+          id={`lesson-text-card-${card.id}-content`}
+          value={card.content}
+          onChange={event => onContentChange(event.target.value)}
+          placeholder="Capture talking points, reminders, or differentiation ideas."
+          rows={4}
+          className="min-h-[120px] border-white/20 bg-white/10 text-foreground placeholder:text-slate-200/60 backdrop-blur"
+        />
+      </div>
+    </div>
+  );
+};
+
 interface LessonResourceSidebarProps {
   subject: Subject | null;
   onInsertResource: (resource: ResourceDetail) => void;
   isAuthenticated: boolean;
+  textCards: LessonWorkspaceTextCard[];
+  onAddTextCard: () => void;
+  onUpdateTextCard: (id: string, updates: { title?: string; content?: string }) => void;
 }
 
-export const LessonResourceSidebar = ({ subject, onInsertResource, isAuthenticated }: LessonResourceSidebarProps) => {
+export const LessonResourceSidebar = ({
+  subject,
+  onInsertResource,
+  isAuthenticated,
+  textCards,
+  onAddTextCard,
+  onUpdateTextCard,
+}: LessonResourceSidebarProps) => {
   const { toast } = useToast();
   const [query, setQuery] = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
@@ -154,86 +247,121 @@ export const LessonResourceSidebar = ({ subject, onInsertResource, isAuthenticat
     [isAuthenticated, onInsertResource, toast],
   );
 
-  if (!isAuthenticated) {
-    return (
-      <aside className="space-y-3 rounded-2xl border border-dashed border-white/30 bg-white/5 p-4 text-sm text-slate-100 backdrop-blur">
-        <p className="font-medium text-white">Add resources</p>
-        <p className="text-slate-200/80">
-          Sign in and open a lesson workspace to search approved resources and insert them directly into your document.
-        </p>
-      </aside>
-    );
-  }
-
   return (
     <aside className="space-y-4 rounded-2xl border border-white/20 bg-white/10 p-4 shadow-[0_24px_70px_-40px_rgba(15,23,42,0.9)] backdrop-blur">
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-foreground">Reusable text cards</p>
+          <p className="text-xs text-slate-200/80">
+            Capture quick notes and drag them into your lesson room. Changes stay in sync wherever the card lives.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          {textCards.map(card => (
+            <SidebarTextCard
+              key={card.id}
+              card={card}
+              onTitleChange={value => onUpdateTextCard(card.id, { title: value })}
+              onContentChange={value => onUpdateTextCard(card.id, { content: value })}
+            />
+          ))}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onAddTextCard}
+            className="w-full border-white/20 bg-white/10 text-foreground shadow-[0_12px_35px_-22px_rgba(56,189,248,0.65)] backdrop-blur"
+          >
+            Add another text card
+          </Button>
+        </div>
+      </div>
+
+      <Separator className="border-white/10" />
+
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">Add a resource</p>
         <p className="text-xs text-slate-200/80">
-          Search presentations, worksheets, and videos. Click insert to add the resource to your lesson plan table.
+          Search presentations, worksheets, and videos. Drag them to your lesson room or insert them into documents.
         </p>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-3">
-        <div className="relative">
-          <Input
-            id={SEARCH_INPUT_ID}
-            value={query}
-            onChange={event => setQuery(event.target.value)}
-            placeholder="Search the resource library"
-            className="pr-10 border-white/20 bg-white/10 text-foreground placeholder:text-slate-200/60 backdrop-blur"
-            aria-label="Search lesson resources"
-          />
-          <Search className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden />
-        </div>
-        <div className="flex items-center justify-between text-xs text-muted-foreground">
-          <div className="flex items-center gap-2">
-            {subject ? <Badge variant="secondary" className="border-white/20 bg-white/10 backdrop-blur">{subject}</Badge> : null}
-            <span>{resourceQuery.data ? `${resources.length} results` : "Ready to search"}</span>
+      {isAuthenticated ? (
+        <>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div className="relative">
+              <Input
+                id={SEARCH_INPUT_ID}
+                value={query}
+                onChange={event => setQuery(event.target.value)}
+                placeholder="Search the resource library"
+                className="pr-10 border-white/20 bg-white/10 text-foreground placeholder:text-slate-200/60 backdrop-blur"
+                aria-label="Search lesson resources"
+              />
+              <Search className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden />
+            </div>
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <div className="flex items-center gap-2">
+                {subject ? (
+                  <Badge variant="secondary" className="border-white/20 bg-white/10 backdrop-blur">
+                    {subject}
+                  </Badge>
+                ) : null}
+                <span>{resourceQuery.data ? `${resources.length} results` : "Ready to search"}</span>
+              </div>
+              <Button
+                type="submit"
+                size="sm"
+                variant="outline"
+                disabled={resourceQuery.isFetching}
+                className="border-white/20 bg-white/10 text-foreground shadow-[0_12px_35px_-20px_rgba(15,23,42,0.85)] backdrop-blur"
+              >
+                {resourceQuery.isFetching ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+                Search
+              </Button>
+            </div>
+          </form>
+
+          {resourceQuery.isError ? (
+            <div className="rounded-2xl border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive backdrop-blur">
+              Unable to load resources right now. Please try searching again shortly.
+            </div>
+          ) : null}
+
+          <div className="space-y-3">
+            {resourceQuery.isLoading ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Loading resources…
+              </div>
+            ) : null}
+
+            {!resourceQuery.isLoading && resources.length === 0 ? (
+              <p className="text-sm text-slate-200/80">No matching resources yet. Try another search term.</p>
+            ) : null}
+
+            <ul className="space-y-3">
+              {resources.map(resource => (
+                <SidebarResourceCard
+                  key={resource.id}
+                  resource={resource}
+                  onInsert={resourceId => void handleInsert(resourceId)}
+                  disabled={resourceQuery.isFetching}
+                  isPending={pendingResourceId === resource.id}
+                />
+              ))}
+            </ul>
           </div>
-          <Button
-            type="submit"
-            size="sm"
-            variant="outline"
-            disabled={resourceQuery.isFetching}
-            className="border-white/20 bg-white/10 text-foreground shadow-[0_12px_35px_-20px_rgba(15,23,42,0.85)] backdrop-blur"
-          >
-            {resourceQuery.isFetching ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
-            Search
-          </Button>
+        </>
+      ) : (
+        <div className="space-y-2 rounded-2xl border border-dashed border-white/20 bg-white/5 p-4 text-sm text-slate-200/80 backdrop-blur">
+          <p className="font-medium text-white">Sign in to browse resources</p>
+          <p className="text-xs text-slate-200/70">
+            You can still craft and edit text cards. Sign in to search vetted resources and attach them to your lessons.
+          </p>
         </div>
-      </form>
-
-      {resourceQuery.isError ? (
-        <div className="rounded-2xl border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive backdrop-blur">
-          Unable to load resources right now. Please try searching again shortly.
-        </div>
-      ) : null}
-
-      <div className="space-y-3">
-        {resourceQuery.isLoading ? (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-            Loading resources…
-          </div>
-        ) : null}
-
-        {!resourceQuery.isLoading && resources.length === 0 ? (
-          <p className="text-sm text-slate-200/80">No matching resources yet. Try another search term.</p>
-        ) : null}
-
-        <ul className="space-y-3">
-          {resources.map(resource => (
-            <SidebarResourceCard
-              key={resource.id}
-              resource={resource}
-              onInsert={resourceId => void handleInsert(resourceId)}
-              disabled={resourceQuery.isFetching}
-              isPending={pendingResourceId === resource.id}
-            />
-          ))}
-        </ul>
-      </div>
+      )}
     </aside>
   );
 };

--- a/src/pages/lesson-builder/components/LessonWorkspaceBoard.tsx
+++ b/src/pages/lesson-builder/components/LessonWorkspaceBoard.tsx
@@ -1,0 +1,228 @@
+import { useMemo, type CSSProperties } from "react";
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { ResourceCard } from "@/components/lesson-draft/ResourceCard";
+import type {
+  LessonPlanMetaDraft,
+  LessonWorkspaceItem,
+  LessonWorkspaceTextCard,
+} from "../types";
+
+const formatDate = (value: string | null) => {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(parsed);
+};
+
+interface WorkspaceSummaryProps {
+  meta: LessonPlanMetaDraft;
+}
+
+const WorkspaceSummary = ({ meta }: WorkspaceSummaryProps) => {
+  const rows = useMemo(
+    () => [
+      { label: "Teacher", value: meta.teacher ?? undefined },
+      { label: "Lesson", value: meta.title.trim() ? meta.title : "Untitled lesson" },
+      { label: "Subject", value: meta.subject ?? undefined },
+      { label: "Date", value: formatDate(meta.date) ?? "Date not set" },
+      { label: "Learning objective", value: meta.objective.trim() ? meta.objective : null },
+      {
+        label: "Success criteria",
+        value: meta.successCriteria.trim() ? meta.successCriteria : null,
+      },
+    ],
+    [meta.date, meta.objective, meta.subject, meta.successCriteria, meta.teacher, meta.title],
+  );
+
+  return (
+    <div className="space-y-3 rounded-3xl border border-white/15 bg-white/10 p-4 shadow-[0_18px_60px_-35px_rgba(15,23,42,0.85)] backdrop-blur">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-200/80">
+        Lesson context
+      </h3>
+      <dl className="grid gap-3 text-sm text-slate-100 sm:grid-cols-2">
+        {rows.map(row => (
+          <div key={row.label} className="space-y-1">
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-300/70">
+              {row.label}
+            </dt>
+            <dd className="whitespace-pre-wrap text-sm text-foreground/90">
+              {row.value ? row.value : "Add details"}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+};
+
+interface SortableWorkspaceCardProps {
+  item: LessonWorkspaceItem;
+  textCard: LessonWorkspaceTextCard | null;
+  onRemove: (workspaceId: string) => void;
+  onUpdateTextCard: (textId: string, updates: { title?: string; content?: string }) => void;
+}
+
+const SortableWorkspaceCard = ({
+  item,
+  textCard,
+  onRemove,
+  onUpdateTextCard,
+}: SortableWorkspaceCardProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.id,
+    data:
+      item.type === "resource"
+        ? {
+            type: "workspace-card" as const,
+            workspaceId: item.id,
+            itemType: "resource" as const,
+            resource: item.resource,
+          }
+        : {
+            type: "workspace-card" as const,
+            workspaceId: item.id,
+            itemType: "text" as const,
+            textCardId: item.textId,
+          },
+  });
+
+  const style: CSSProperties = {
+    transform: transform ? CSS.Transform.toString(transform) : undefined,
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "space-y-4 rounded-2xl border border-white/15 bg-white/10 p-4 shadow-[0_18px_60px_-35px_rgba(15,23,42,0.85)] backdrop-blur",
+        isDragging && "ring-2 ring-sky-300/60",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="rounded-full border border-white/20 bg-white/10 p-2 text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+            aria-label="Reorder card"
+            {...listeners}
+            {...attributes}
+          >
+            <GripVertical className="h-4 w-4" aria-hidden />
+          </button>
+          <p className="text-sm font-semibold text-foreground">
+            {item.type === "resource" ? item.resource.title : textCard?.title || "Text card"}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => onRemove(item.id)}
+          aria-label="Remove card from workspace"
+        >
+          <Trash2 className="h-4 w-4" aria-hidden />
+        </Button>
+      </div>
+
+      {item.type === "resource" ? (
+        <ResourceCard resource={item.resource} layout="horizontal" />
+      ) : (
+        <div className="space-y-3">
+          <Input
+            value={textCard?.title ?? ""}
+            onChange={event => onUpdateTextCard(item.textId, { title: event.target.value })}
+            placeholder="Title"
+            className="border-white/20 bg-white/10 text-foreground placeholder:text-slate-200/60 backdrop-blur"
+          />
+          <Textarea
+            value={textCard?.content ?? ""}
+            onChange={event => onUpdateTextCard(item.textId, { content: event.target.value })}
+            placeholder="Add lesson notes or reminders."
+            rows={4}
+            className="min-h-[120px] border-white/20 bg-white/10 text-foreground placeholder:text-slate-200/60 backdrop-blur"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface LessonWorkspaceBoardProps {
+  meta: LessonPlanMetaDraft;
+  items: LessonWorkspaceItem[];
+  textCards: LessonWorkspaceTextCard[];
+  onRemoveItem: (workspaceId: string) => void;
+  onUpdateTextCard: (textId: string, updates: { title?: string; content?: string }) => void;
+}
+
+export const LessonWorkspaceBoard = ({
+  meta,
+  items,
+  textCards,
+  onRemoveItem,
+  onUpdateTextCard,
+}: LessonWorkspaceBoardProps) => {
+  const dropZone = useDroppable({
+    id: "lesson-workspace",
+    data: { type: "workspace-dropzone" as const },
+  });
+
+  const itemIds = useMemo(() => items.map(item => item.id), [items]);
+
+  return (
+    <div className="space-y-6">
+      <WorkspaceSummary meta={meta} />
+      <div
+        ref={dropZone.setNodeRef}
+        className={cn(
+          "space-y-4 rounded-3xl border border-dashed border-white/20 bg-white/5 p-6 text-slate-200/80 backdrop-blur",
+          dropZone.isOver && "border-sky-300/70 bg-sky-500/10",
+        )}
+        aria-label="Lesson room drop zone"
+      >
+        {items.length === 0 ? (
+          <p className="text-sm">
+            Drag resource and text cards here to begin assembling your lesson wall. New cards snap to the top so you can build
+            downward.
+          </p>
+        ) : (
+          <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+            <div className="space-y-4">
+              {items.map(item => (
+                <SortableWorkspaceCard
+                  key={item.id}
+                  item={item}
+                  textCard={item.type === "text" ? textCards.find(card => card.id === item.textId) ?? null : null}
+                  onRemove={onRemoveItem}
+                  onUpdateTextCard={onUpdateTextCard}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default LessonWorkspaceBoard;

--- a/src/pages/lesson-builder/types.ts
+++ b/src/pages/lesson-builder/types.ts
@@ -1,4 +1,5 @@
 import type { Subject } from "@/lib/constants/subjects";
+import type { Resource } from "@/types/resources";
 
 export interface LessonPlanMetaDraft {
   title: string;
@@ -12,3 +13,21 @@ export interface LessonPlanMetaDraft {
   sequence: number | null;
   stage: string | null;
 }
+
+export interface LessonWorkspaceTextCard {
+  id: string;
+  title: string;
+  content: string;
+}
+
+export type LessonWorkspaceItem =
+  | {
+      id: string;
+      type: "resource";
+      resource: Resource;
+    }
+  | {
+      id: string;
+      type: "text";
+      textId: string;
+    };


### PR DESCRIPTION
## Summary
- add editable text cards to the lesson resource sidebar so teachers can draft notes before dragging them into a plan
- introduce a lesson workspace board that stacks text and resource cards while surfacing key lesson details at the top
- update the lesson builder page to manage workspace state, enhanced drag previews, and shared workspace types

## Testing
- `npm run lint` *(fails: existing repository lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f64e8e388331aa6a90e294127952