### PR TITLE
Revamp lesson workspace layout and resource search

### DIFF
--- a/src/pages/lesson-builder/LessonBuilderPage.tsx
+++ b/src/pages/lesson-builder/LessonBuilderPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { format, isValid, parseISO } from "date-fns";
+import { format } from "date-fns";
 import { Loader2 } from "lucide-react";
 import { DndContext, DragOverlay, type DragCancelEvent, type DragEndEvent, type DragStartEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
@@ -22,9 +22,8 @@ import { useMyClasses } from "@/hooks/useMyClasses";
 import { linkPlanToClass, listClassLessons, type ClassLessonSummary } from "@/lib/classes";
 import { LessonMetaForm, type LessonMetaFormValue } from "./components/LessonMetaForm";
 import { LessonPreviewPane } from "./components/LessonPreviewPane";
-import { LessonDocEditor } from "@/pages/account/LessonDocEditor";
 import type { LessonPlanMetaDraft } from "./types";
-import type { Resource, ResourceDetail } from "@/types/resources";
+import type { Resource } from "@/types/resources";
 import { createLessonPlan, getLessonPlan, updateLessonPlan } from "./api";
 import { LessonResourceSidebar } from "./components/LessonResourceSidebar";
 import { ResourceCard } from "@/components/lesson-draft/ResourceCard";
@@ -45,135 +44,6 @@ const createInitialMeta = (): LessonPlanMetaDraft => ({
   sequence: null,
   stage: null,
 });
-
-const escapeHtml = (value: string): string =>
-  value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-
-const formatMultiline = (value: string): string => escapeHtml(value).replace(/\n/g, "<br />");
-
-const formatDocumentDate = (value: string | null): string => {
-  if (!value) {
-    return "Not set";
-  }
-
-  const parsed = parseISO(value);
-  if (!isValid(parsed)) {
-    return escapeHtml(value);
-  }
-
-  try {
-    return escapeHtml(format(parsed, "PPP"));
-  } catch {
-    return escapeHtml(value);
-  }
-};
-
-const createLessonDocTemplate = (meta: LessonPlanMetaDraft, fallbackTeacher: string | null): string => {
-  const teacherName = meta.teacher?.trim() || fallbackTeacher?.trim() || "";
-  const rows = [
-    { label: "Lesson title", value: meta.title.trim() || "Untitled lesson" },
-    { label: "Teacher", value: teacherName || "Not assigned" },
-    { label: "Subject", value: meta.subject ?? "Not set" },
-    { label: "Lesson date", value: formatDocumentDate(meta.date) },
-  ];
-
-  const renderRows = rows
-    .map(row => {
-      const value = typeof row.value === "string" ? escapeHtml(row.value) : "";
-      return `
-        <tr>
-          <th style="text-align:left;padding:0.5rem;border:1px solid #d8dee6;background:#f1f5f9;font-weight:600;">${escapeHtml(
-            row.label,
-          )}</th>
-          <td style="padding:0.5rem;border:1px solid #d8dee6;background:#f1f5f9;">${value}</td>
-        </tr>
-      `;
-    })
-    .join("");
-
-  const objectiveContent = meta.objective.trim()
-    ? formatMultiline(meta.objective)
-    : "<em>Add your learning objectives here.</em>";
-  const successCriteriaContent = meta.successCriteria.trim()
-    ? formatMultiline(meta.successCriteria)
-    : "<em>Describe how students will demonstrate success.</em>";
-
-  return `
-    <table style="width:100%;border-collapse:collapse;margin-bottom:1.5rem;">
-      <tbody>
-        ${renderRows}
-      </tbody>
-    </table>
-    <section style="margin-bottom:1.5rem;">
-      <h3 style="font-size:1rem;font-weight:600;margin-bottom:0.5rem;">Learning objectives</h3>
-      <p>${objectiveContent}</p>
-    </section>
-    <section style="margin-bottom:1.5rem;">
-      <h3 style="font-size:1rem;font-weight:600;margin-bottom:0.5rem;">Success criteria</h3>
-      <p>${successCriteriaContent}</p>
-    </section>
-    <section style="margin-bottom:1.5rem;">
-      <h3 style="font-size:1rem;font-weight:600;margin-bottom:0.5rem;">Lesson narrative</h3>
-      <p><em>Use this space to outline your teaching sequence, key questions, and differentiation strategies.</em></p>
-    </section>
-  `;
-};
-
-const createResourceTableMarkup = (resource: ResourceDetail): string => {
-  const instructions = resource.instructionalNotes?.trim()
-    ? formatMultiline(resource.instructionalNotes)
-    : "<em>No specific instructions provided.</em>";
-  const description = resource.description?.trim()
-    ? formatMultiline(resource.description)
-    : "<em>No description available.</em>";
-  const details: Array<{ label: string; value: string | null }> = [
-    { label: "Format", value: resource.format },
-    { label: "Stage", value: resource.stage },
-    { label: "Subject", value: resource.subject },
-    { label: "Type", value: resource.type },
-  ];
-
-  const detailRows = details
-    .filter(detail => detail.value && detail.value.trim().length > 0)
-    .map(detail => `
-      <tr>
-        <th style="text-align:left;padding:0.5rem;border:1px solid #d8dee6;background:#f8fafc;">${escapeHtml(detail.label)}</th>
-        <td style="padding:0.5rem;border:1px solid #d8dee6;">${escapeHtml(detail.value ?? "")}</td>
-      </tr>
-    `)
-    .join("");
-
-  const link = resource.url
-    ? `<a href="${escapeHtml(resource.url)}" target="_blank" rel="noopener noreferrer">Open resource</a>`
-    : "<em>Link not available</em>";
-
-  const resourceHeader = escapeHtml(resource.title || "Resource");
-
-  return `
-    <table style="width:100%;border-collapse:collapse;margin:1.5rem 0;">
-      <caption style="caption-side:top;text-align:left;font-weight:600;margin-bottom:0.5rem;">${resourceHeader}</caption>
-      <tbody>
-        <tr>
-          <th style="text-align:left;padding:0.5rem;border:1px solid #d8dee6;background:#f8fafc;">Instructions</th>
-          <td style="padding:0.5rem;border:1px solid #d8dee6;">${instructions}</td>
-        </tr>
-        <tr>
-          <th style="text-align:left;padding:0.5rem;border:1px solid #d8dee6;background:#f8fafc;">Resource</th>
-          <td style="padding:0.5rem;border:1px solid #d8dee6;">${link}</td>
-        </tr>
-        <tr>
-          <th style="text-align:left;padding:0.5rem;border:1px solid #d8dee6;background:#f8fafc;">Summary</th>
-          <td style="padding:0.5rem;border:1px solid #d8dee6;">${description}</td>
-        </tr>
-        ${detailRows}
-      </tbody>
-    </table>
-  `;
-};
 
 const createWorkspaceTextCard = (): LessonWorkspaceTextCard => ({
   id: nanoid(),
@@ -275,17 +145,10 @@ const LessonBuilderPage = ({
   const classLinkingCopy = t.lessonBuilder.classLinking;
   const { fullName, schoolName, schoolLogoUrl } = useMyProfile();
   const { toast } = useToast();
-  const docTemplateRef = useRef<string>("");
-  if (docTemplateRef.current === "") {
-    docTemplateRef.current = createLessonDocTemplate(meta, fullName ?? null);
-  }
-  const [lessonDocHtml, setLessonDocHtml] = useState<string>(docTemplateRef.current);
-  const [lessonDocBackground, setLessonDocBackground] = useState<string>("default");
   const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestMeta = useRef(meta);
   const skipNextAutosave = useRef(false);
   const isMounted = useRef(true);
-  const isDocDirty = useRef(false);
   const [activeExport, setActiveExport] = useState<"pdf" | "docx" | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [textCards, setTextCards] = useState<LessonWorkspaceTextCard[]>(() => [createWorkspaceTextCard()]);
@@ -362,23 +225,6 @@ const LessonBuilderPage = ({
       });
     }
   }, [fullName, meta.teacher]);
-
-  useEffect(() => {
-    const template = createLessonDocTemplate(meta, fullName ?? null);
-    const currentHtml = lessonDocHtml;
-    const previousTemplate = docTemplateRef.current;
-    const isMatch = currentHtml.trim() === previousTemplate.trim();
-
-    if (!isDocDirty.current || isMatch || currentHtml.trim().length === 0) {
-      docTemplateRef.current = template;
-      if (currentHtml !== template) {
-        setLessonDocHtml(template);
-      }
-      isDocDirty.current = false;
-    } else {
-      docTemplateRef.current = template;
-    }
-  }, [fullName, lessonDocHtml, meta]);
 
   useEffect(() => {
     let active = true;
@@ -659,30 +505,6 @@ const LessonBuilderPage = ({
   const handleSuccessCriteriaChange = (value: string) => {
     setMeta(prev => ({ ...prev, successCriteria: value }));
   };
-
-  const handleLessonDocChange = useCallback((value: string) => {
-    isDocDirty.current = true;
-    setLessonDocHtml(value);
-  }, []);
-
-  const handleResourceInsert = useCallback(
-    (resource: ResourceDetail) => {
-      isDocDirty.current = true;
-      const markup = createResourceTableMarkup(resource);
-      setLessonDocHtml(current => {
-        const trimmed = current.trim();
-        if (!trimmed) {
-          return markup;
-        }
-        return `${current.trimEnd()}\n${markup}`;
-      });
-      toast({
-        title: "Resource added",
-        description: `${resource.title} was inserted into your lesson plan document.`,
-      });
-    },
-    [toast],
-  );
 
   const normalizedTitle = useMemo(() => {
     const trimmed = meta.title.trim();
@@ -1282,44 +1104,32 @@ const LessonBuilderPage = ({
               <div className="space-y-2">
                 <h2 className="text-xl font-semibold text-foreground">Lesson workspace</h2>
                 <p className="text-sm text-muted-foreground">
-                  Arrange text notes and resource cards on the left. Drag items from the shelf to build your lesson wall, then refine the narrative in the document below.
+                  Arrange text notes and resource cards on the left. Drag items from the shelf to shape your lesson wall.
                 </p>
               </div>
 
               <div className="grid gap-6 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)] lg:items-start">
-                <div className="space-y-6">
-                  <LessonWorkspaceBoard
-                    meta={meta}
-                    items={workspaceItems}
-                    textCards={textCards}
-                    onRemoveItem={handleRemoveWorkspaceItem}
-                    onUpdateTextCard={handleUpdateTextCard}
-                  />
-
-                  <div className="space-y-3 rounded-3xl border border-white/15 bg-white/10 p-4 shadow-[0_20px_60px_-40px_rgba(15,23,42,0.85)] backdrop-blur">
-                    <div className="space-y-1">
-                      <h3 className="text-lg font-semibold text-foreground">Lesson document</h3>
-                      <p className="text-sm text-muted-foreground">
-                        Capture the full story of your lesson once your wall looks right. Changes stay in sync with the rest of your plan.
-                      </p>
-                    </div>
-                    <LessonDocEditor
-                      value={lessonDocHtml}
-                      onChange={handleLessonDocChange}
-                      background={lessonDocBackground}
-                      onBackgroundChange={setLessonDocBackground}
+                <div className="lg:min-h-[420px] lg:max-h-[calc(100vh-18rem)] lg:overflow-y-auto lg:overscroll-contain lg:pr-3 lg:pt-1">
+                  <div className="space-y-6">
+                    <LessonWorkspaceBoard
+                      meta={meta}
+                      items={workspaceItems}
+                      textCards={textCards}
+                      onRemoveItem={handleRemoveWorkspaceItem}
+                      onUpdateTextCard={handleUpdateTextCard}
                     />
                   </div>
                 </div>
 
-                <LessonResourceSidebar
-                  subject={meta.subject}
-                  onInsertResource={handleResourceInsert}
-                  isAuthenticated={isAuthenticated}
-                  textCards={textCards}
-                  onAddTextCard={handleAddTextCard}
-                  onUpdateTextCard={handleUpdateTextCard}
-                />
+                <div className="lg:min-h-[420px] lg:max-h-[calc(100vh-18rem)] lg:overflow-y-auto lg:overscroll-contain lg:pr-2 lg:pt-1">
+                  <LessonResourceSidebar
+                    subject={meta.subject}
+                    isAuthenticated={isAuthenticated}
+                    textCards={textCards}
+                    onAddTextCard={handleAddTextCard}
+                    onUpdateTextCard={handleUpdateTextCard}
+                  />
+                </div>
               </div>
             </section>
 

--- a/src/pages/lesson-builder/components/LessonResourceSidebar.tsx
+++ b/src/pages/lesson-builder/components/LessonResourceSidebar.tsx
@@ -1,15 +1,14 @@
 import { type FormEvent, useCallback, useMemo, useState } from "react";
 import { CSS } from "@dnd-kit/utilities";
 import { useDraggable } from "@dnd-kit/core";
-import { useQuery } from "@tanstack/react-query";
 import { GripVertical, Loader2, Search } from "lucide-react";
+import { nanoid } from "nanoid";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { useToast } from "@/hooks/use-toast";
-import { searchResources, fetchResourceById } from "@/lib/resources";
+import { searchResources } from "@/lib/resources";
 import type { Subject } from "@/lib/constants/subjects";
-import type { Resource, ResourceDetail } from "@/types/resources";
+import type { Resource } from "@/types/resources";
 import { Badge } from "@/components/ui/badge";
 import { ResourceCard } from "@/components/lesson-draft/ResourceCard";
 import { cn } from "@/lib/utils";
@@ -35,12 +34,9 @@ type SidebarTextCardDragData = {
 
 interface SidebarResourceCardProps {
   resource: Resource;
-  onInsert: (resourceId: string) => void;
-  disabled: boolean;
-  isPending: boolean;
 }
 
-const SidebarResourceCard = ({ resource, onInsert, disabled, isPending }: SidebarResourceCardProps) => {
+const SidebarResourceCard = ({ resource }: SidebarResourceCardProps) => {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable<DraggableResourceData>({
     id: `lesson-resource-${resource.id}`,
     data: {
@@ -59,39 +55,26 @@ const SidebarResourceCard = ({ resource, onInsert, disabled, isPending }: Sideba
         ref={setNodeRef}
         style={style}
         className={cn(
-          "group focus-within:ring-2 focus-within:ring-sky-300/80 focus-within:ring-offset-4 focus-within:ring-offset-[rgba(255,255,255,0.08)]",
-          "cursor-grab rounded-2xl border border-white/20 bg-white/10 p-3 shadow-[0_18px_50px_-30px_rgba(15,23,42,0.9)] backdrop-blur transition",
+          "group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/80 focus-visible:ring-offset-4 focus-visible:ring-offset-[rgba(255,255,255,0.08)]",
+          "cursor-grab space-y-3 rounded-2xl border border-white/20 bg-white/10 p-4 shadow-[0_18px_50px_-30px_rgba(15,23,42,0.9)] backdrop-blur transition",
           isDragging && "opacity-70",
         )}
         {...listeners}
         {...attributes}
       >
-        <div className="flex flex-col gap-3">
-          <ResourceCard resource={resource} layout="horizontal" />
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              size="sm"
-              onClick={() => onInsert(resource.id)}
-              disabled={disabled || isPending}
-              aria-label={`Insert ${resource.title} into document`}
-              className="border-white/20 bg-white/10 text-foreground shadow-[0_10px_30px_-18px_rgba(15,23,42,0.85)] backdrop-blur"
-            >
-              {isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Add resource card
-            </Button>
-            {resource.url ? (
-              <a
-                href={resource.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm font-medium text-sky-200 underline-offset-2 hover:underline"
-              >
-                Preview
-              </a>
-            ) : null}
-          </div>
-        </div>
+        <ResourceCard resource={resource} layout="horizontal" />
+        {resource.url ? (
+          <a
+            href={resource.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center text-xs font-medium text-sky-200 underline-offset-2 hover:underline"
+          >
+            Preview resource
+          </a>
+        ) : (
+          <p className="text-xs text-muted-foreground">Drag this card into your lesson wall.</p>
+        )}
       </div>
     </li>
   );
@@ -170,9 +153,19 @@ const SidebarTextCard = ({ card, onTitleChange, onContentChange }: SidebarTextCa
   );
 };
 
+type SearchSectionStatus = "loading" | "success" | "error";
+
+interface SearchSection {
+  id: string;
+  query: string;
+  status: SearchSectionStatus;
+  resources: Resource[];
+  errorMessage?: string;
+  subjectLabel: Subject | null;
+}
+
 interface LessonResourceSidebarProps {
   subject: Subject | null;
-  onInsertResource: (resource: ResourceDetail) => void;
   isAuthenticated: boolean;
   textCards: LessonWorkspaceTextCard[];
   onAddTextCard: () => void;
@@ -181,16 +174,13 @@ interface LessonResourceSidebarProps {
 
 export const LessonResourceSidebar = ({
   subject,
-  onInsertResource,
   isAuthenticated,
   textCards,
   onAddTextCard,
   onUpdateTextCard,
 }: LessonResourceSidebarProps) => {
-  const { toast } = useToast();
   const [query, setQuery] = useState("");
-  const [submittedQuery, setSubmittedQuery] = useState("");
-  const [pendingResourceId, setPendingResourceId] = useState<string | null>(null);
+  const [searchSections, setSearchSections] = useState<SearchSection[]>([]);
 
   const subjectFilters = useMemo(() => {
     if (!subject) {
@@ -199,52 +189,61 @@ export const LessonResourceSidebar = ({
     return [subject];
   }, [subject]);
 
-  const resourceQuery = useQuery({
-    queryKey: ["lesson-builder-resource-search", submittedQuery, subjectFilters?.join("|") ?? "all"],
-    enabled: isAuthenticated,
-    staleTime: 1000 * 60,
-    queryFn: async () => {
-      const result = await searchResources({
-        q: submittedQuery || undefined,
-        subjects: subjectFilters,
-        pageSize: 8,
-      });
-      return result.items as Resource[];
-    },
-  });
-
-  const resources = resourceQuery.data ?? [];
-
   const handleSubmit = useCallback(
-    (event: FormEvent<HTMLFormElement>) => {
+    async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      setSubmittedQuery(query.trim());
-    },
-    [query],
-  );
 
-  const handleInsert = useCallback(
-    async (resourceId: string) => {
       if (!isAuthenticated) {
-        toast({
-          title: "Sign in to add resources",
-          description: "You'll need to be signed in to attach catalog resources to your lesson plan.",
-        });
         return;
       }
 
-      setPendingResourceId(resourceId);
+      const trimmed = query.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      const sectionId = nanoid();
+      const nextSection: SearchSection = {
+        id: sectionId,
+        query: trimmed,
+        status: "loading",
+        resources: [],
+        subjectLabel: subject ?? null,
+      };
+
+      setSearchSections(prev => [nextSection, ...prev]);
+      setQuery("");
+
       try {
-        const detail = await fetchResourceById(resourceId);
-        onInsertResource(detail);
+        const result = await searchResources({
+          q: trimmed || undefined,
+          subjects: subjectFilters,
+          pageSize: 8,
+        });
+
+        const items = Array.isArray(result.items) ? (result.items as Resource[]) : [];
+        setSearchSections(prev =>
+          prev.map(section =>
+            section.id === sectionId
+              ? { ...section, status: "success", resources: items }
+              : section,
+          ),
+        );
       } catch (error) {
-        const description = error instanceof Error ? error.message : "Unable to add this resource.";
-        toast({ title: "Resource not added", description, variant: "destructive" });
-      } finally {
-        setPendingResourceId(current => (current === resourceId ? null : current));
+        const description =
+          error instanceof Error
+            ? error.message
+            : "Unable to load resources right now. Please try searching again shortly.";
+        setSearchSections(prev =>
+          prev.map(section =>
+            section.id === sectionId
+              ? { ...section, status: "error", errorMessage: description }
+              : section,
+          ),
+        );
       }
     },
-    [isAuthenticated, onInsertResource, toast],
+    [isAuthenticated, query, subject, subjectFilters],
   );
 
   return (
@@ -283,13 +282,13 @@ export const LessonResourceSidebar = ({
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">Add a resource</p>
         <p className="text-xs text-slate-200/80">
-          Search presentations, worksheets, and videos. Drag them to your lesson room or insert them into documents.
+          Search presentations, worksheets, and videos. Drag them to your lesson room or keep them handy here.
         </p>
       </div>
 
       {isAuthenticated ? (
         <>
-          <form onSubmit={handleSubmit} className="space-y-3">
+          <form onSubmit={handleSubmit} className="space-y-2">
             <div className="relative">
               <Input
                 id={SEARCH_INPUT_ID}
@@ -301,64 +300,80 @@ export const LessonResourceSidebar = ({
               />
               <Search className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden />
             </div>
-            <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <div className="flex items-center gap-2">
-                {subject ? (
-                  <Badge variant="secondary" className="border-white/20 bg-white/10 backdrop-blur">
-                    {subject}
-                  </Badge>
-                ) : null}
-                <span>{resourceQuery.data ? `${resources.length} results` : "Ready to search"}</span>
-              </div>
-              <Button
-                type="submit"
-                size="sm"
-                variant="outline"
-                disabled={resourceQuery.isFetching}
-                className="border-white/20 bg-white/10 text-foreground shadow-[0_12px_35px_-20px_rgba(15,23,42,0.85)] backdrop-blur"
-              >
-                {resourceQuery.isFetching ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
-                Search
-              </Button>
-            </div>
+            <p className="text-xs text-muted-foreground">
+              Press Enter to pin this search. Each request creates a set of draggable resource cards below.
+            </p>
           </form>
 
-          {resourceQuery.isError ? (
-            <div className="rounded-2xl border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive backdrop-blur">
-              Unable to load resources right now. Please try searching again shortly.
-            </div>
-          ) : null}
-
           <div className="space-y-3">
-            {resourceQuery.isLoading ? (
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                Loading resources…
+            {searchSections.length === 0 ? (
+              <div className="space-y-2 rounded-2xl border border-dashed border-white/20 bg-white/5 p-4 text-xs text-slate-200/80 backdrop-blur">
+                <p>Try searching for “fraction warm up” or “ecosystems video”.</p>
               </div>
             ) : null}
 
-            {!resourceQuery.isLoading && resources.length === 0 ? (
-              <p className="text-sm text-slate-200/80">No matching resources yet. Try another search term.</p>
-            ) : null}
+            {searchSections.map(section => {
+              const resourceCountLabel =
+                section.resources.length === 1
+                  ? "1 resource"
+                  : `${section.resources.length} resources`;
 
-            <ul className="space-y-3">
-              {resources.map(resource => (
-                <SidebarResourceCard
-                  key={resource.id}
-                  resource={resource}
-                  onInsert={resourceId => void handleInsert(resourceId)}
-                  disabled={resourceQuery.isFetching}
-                  isPending={pendingResourceId === resource.id}
-                />
-              ))}
-            </ul>
+              let content: JSX.Element;
+              if (section.status === "loading") {
+                content = (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                    Loading resources…
+                  </div>
+                );
+              } else if (section.status === "error") {
+                content = (
+                  <div className="rounded-2xl border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive backdrop-blur">
+                    {section.errorMessage ?? "Unable to load resources right now. Please try again shortly."}
+                  </div>
+                );
+              } else if (section.resources.length === 0) {
+                content = (
+                  <p className="text-sm text-slate-200/80">No matching resources yet. Try another search term.</p>
+                );
+              } else {
+                content = (
+                  <ul className="space-y-3">
+                    {section.resources.map(resource => (
+                      <SidebarResourceCard key={`${section.id}-${resource.id}`} resource={resource} />
+                    ))}
+                  </ul>
+                );
+              }
+
+              return (
+                <div
+                  key={section.id}
+                  className="space-y-3 rounded-2xl border border-white/15 bg-white/10 p-4 shadow-[0_18px_40px_-30px_rgba(15,23,42,0.85)] backdrop-blur"
+                >
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-foreground">Results for “{section.query}”</p>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      {section.subjectLabel ? (
+                        <Badge variant="secondary" className="border-white/20 bg-white/10 backdrop-blur">
+                          {section.subjectLabel}
+                        </Badge>
+                      ) : null}
+                      {section.status === "success" ? <span>{resourceCountLabel}</span> : null}
+                    </div>
+                  </div>
+
+                  {content}
+                </div>
+              );
+            })}
           </div>
         </>
       ) : (
         <div className="space-y-2 rounded-2xl border border-dashed border-white/20 bg-white/5 p-4 text-sm text-slate-200/80 backdrop-blur">
           <p className="font-medium text-white">Sign in to browse resources</p>
           <p className="text-xs text-slate-200/70">
-            You can still craft and edit text cards. Sign in to search vetted resources and attach them to your lessons.
+            You can still craft and edit text cards. Sign in to search vetted resources and drag them into your lessons.
           </p>
         </div>
       )}


### PR DESCRIPTION
## Summary
- make the lesson workspace board and resource shelf independently scrollable and remove the unused document editor
- redesign the resource sidebar so text cards stay editable, searches run on enter, and each query pins its own draggable results set
- refresh helper copy to reflect the drag-and-drop workflow without the old document surface

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5fec7b23c83318c5e311b93b1646c